### PR TITLE
ADFA-387 Remove gradle's attempts to connect on the network

### DIFF
--- a/gradle-plugin/src/test/resources/sample-project/build-logic/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugin/src/test/resources/sample-project/build-logic/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+# distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle-plugin/src/test/resources/sample-project/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugin/src/test/resources/sample-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+# distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=gradle-8.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Modified gradle wrapper references to external gradle-bin-8.0.zip in tests for  CoGo app plugin to instead use the local one