### PR TITLE
ADFA-341 | Adding help button in file tree actions

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/filetree/HelpAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/filetree/HelpAction.kt
@@ -1,0 +1,28 @@
+package com.itsaky.androidide.actions.filetree
+
+import android.content.Context
+import com.itsaky.androidide.actions.ActionData
+import com.itsaky.androidide.R
+import com.itsaky.androidide.actions.requireContext
+import com.itsaky.androidide.utils.UrlManager
+
+class HelpAction(context: Context, override val order: Int) :
+    BaseFileTreeAction(
+        context = context,
+        labelRes = R.string.help,
+        iconRes = R.drawable.ic_action_help
+    ) {
+    override val id: String = "ide.editor.fileTree.help"
+
+    override suspend fun execAction(data: ActionData) {
+        val context = data.requireContext()
+        UrlManager.openUrl(
+            url = HELP_URL,
+            context = context
+        )
+    }
+
+    companion object {
+        private const val HELP_URL = "https://code-on-the-go.com/help"
+    }
+}

--- a/app/src/main/java/com/itsaky/androidide/utils/EditorActivityActions.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/EditorActivityActions.kt
@@ -43,6 +43,7 @@ import com.itsaky.androidide.actions.file.SaveFileAction
 import com.itsaky.androidide.actions.file.ShowTooltipAction
 import com.itsaky.androidide.actions.filetree.CopyPathAction
 import com.itsaky.androidide.actions.filetree.DeleteAction
+import com.itsaky.androidide.actions.filetree.HelpAction
 import com.itsaky.androidide.actions.filetree.NewFileAction
 import com.itsaky.androidide.actions.filetree.NewFolderAction
 import com.itsaky.androidide.actions.filetree.OpenWithAction
@@ -62,6 +63,14 @@ import com.itsaky.androidide.actions.text.UndoAction
 class EditorActivityActions {
 
   companion object {
+
+    private const val ORDER_COPY_PATH = 100
+    private const val ORDER_DELETE = 200
+    private const val ORDER_NEW_FILE = 300
+    private const val ORDER_NEW_FOLDER = 400
+    private const val ORDER_OPEN_WITH = 500
+    private const val ORDER_RENAME = 600
+    private const val ORDER_HELP = 1000
 
     @JvmStatic
     fun register(context: Context) {
@@ -102,12 +111,13 @@ class EditorActivityActions {
       registry.registerAction(CloseAllFilesAction(context, order++))
 
       // file tree actions
-      registry.registerAction(CopyPathAction(context, order++))
-      registry.registerAction(DeleteAction(context, order++))
-      registry.registerAction(NewFileAction(context, order++))
-      registry.registerAction(NewFolderAction(context, order++))
-      registry.registerAction(OpenWithAction(context, order++))
-      registry.registerAction(RenameAction(context, order++))
+      registry.registerAction(CopyPathAction(context, ORDER_COPY_PATH))
+      registry.registerAction(DeleteAction(context, ORDER_DELETE))
+      registry.registerAction(NewFileAction(context, ORDER_NEW_FILE))
+      registry.registerAction(NewFolderAction(context, ORDER_NEW_FOLDER))
+      registry.registerAction(OpenWithAction(context, ORDER_OPEN_WITH))
+      registry.registerAction(RenameAction(context, ORDER_RENAME))
+      registry.registerAction(HelpAction(context, ORDER_HELP))
     }
 
     @JvmStatic

--- a/common/src/main/java/com/itsaky/androidide/utils/urlManager.kt
+++ b/common/src/main/java/com/itsaky/androidide/utils/urlManager.kt
@@ -1,0 +1,37 @@
+package com.itsaky.androidide.utils
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import com.blankj.utilcode.util.Utils
+import com.itsaky.androidide.common.R
+
+object UrlManager {
+    /**
+     * Opens a URL with optional package restriction
+     * @param url The URL to open
+     * @param pkg Optional package name to restrict the intent to
+     * @param context Context used to start activities (falls back to app context if null)
+     */
+
+    fun openUrl(url: String, pkg: String? = null, context: Context? = null) {
+        try {
+            val ctx = context ?: Utils.getApp().applicationContext
+
+            Intent().apply {
+                action = Intent.ACTION_VIEW
+                data = Uri.parse(url)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                pkg?.let { setPackage(it) }
+                ctx.startActivity(this)
+            }
+        } catch (th: Throwable) {
+            when {
+                pkg != null -> openUrl(url, context = context)
+                th is ActivityNotFoundException -> flashError(R.string.msg_app_unavailable_for_intent)
+                else -> flashError(th.message)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
This implementation adds a Help action to the file tree's context menu that appears when users long-press files or folders, which when clicked opens the Code on the Go documentation URL in the device's default browser.

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->
![Screenshot_20250325_113834](https://github.com/user-attachments/assets/fb25be9c-e4e2-43da-8bed-427420e2eee8)
![Screenshot_20250325_113812](https://github.com/user-attachments/assets/77111ae5-e657-4aa1-a827-c80ed6695bad)

## Ticket
[ADFA-341](https://appdevforall.atlassian.net/browse/ADFA-341)

## Observation
<!-- Some important about your code --> 

