### PR TITLE
ADFA-434 | Remove terminal and theme options

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/preferences/generalPrefExts.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/generalPrefExts.kt
@@ -42,7 +42,6 @@ class GeneralPreferencesScreen(
   init {
     addPreference(InterfaceConfig())
     addPreference(ProjectConfig())
-    addPreference(TerminalConfig())
   }
 }
 
@@ -55,7 +54,6 @@ class InterfaceConfig(
 
   init {
     addPreference(UiMode())
-    addPreference(ThemeSelector())
     addPreference(LocaleSelector())
   }
 }
@@ -70,18 +68,6 @@ class ProjectConfig(
   init {
     addPreference(OpenLastProject())
     addPreference(ConfirmProjectOpen())
-  }
-}
-
-@Parcelize
-class TerminalConfig(
-  override val key: String = "idepref_general_terminal",
-  override val title: Int = R.string.title_terminal,
-  override val children: List<IPreference> = mutableListOf(),
-) : IPreferenceGroup() {
-
-  init {
-    addPreference(UseSytemShell())
   }
 }
 
@@ -118,39 +104,6 @@ class UiMode(
     position: Int
   ) {
     GeneralPreferences.uiMode = (entry?.data as? Int?) ?: AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-  }
-}
-
-@Parcelize
-class ThemeSelector(
-  override val key: String = GeneralPreferences.SELECTED_THEME,
-  override val title: Int = R.string.idepref_general_themeSelector_title,
-  override val summary: Int? = R.string.idepref_general_themeSelector_summary,
-  override val icon: Int? = R.drawable.ic_color_scheme
-) : SingleChoicePreference() {
-
-  @IgnoredOnParcel
-  private val themes = IDETheme.entries
-
-  override fun getEntries(preference: Preference): Array<PreferenceChoices.Entry> {
-    val context = preference.context
-    val currentTheme = IThemeManager.getInstance().getCurrentTheme()
-    return Array(themes.size) { index ->
-      val ideTheme = themes[index]
-      PreferenceChoices.Entry(
-        label = ContextCompat.getString(context, ideTheme.title),
-        _isChecked = currentTheme.name == ideTheme.name,
-        data = ideTheme
-      )
-    }
-  }
-
-  override fun onChoiceConfirmed(
-    preference: Preference,
-    entry: PreferenceChoices.Entry?,
-    position: Int
-  ) {
-    GeneralPreferences.selectedTheme = (entry?.data as? IDETheme?)?.name ?: IDETheme.DEFAULT.name
   }
 }
 


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
Update refactors the general preferences by removing terminal and theme options. Key classes such as TerminalConfig, ThemeSelector, and UseSytemShell have been eliminated, and related preference groups like GeneralPrefGroup and InterfacePrefGroup have been updated accordingly

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->
![ADFA-434](https://github.com/user-attachments/assets/84f5e091-6717-4b2f-a19a-467cfd598686)

## Ticket
[ADFA-434](https://appdevforall.atlassian.net/browse/ADFA-434)

## Observation
<!-- Some important about your code --> 

