### PR TITLE
ADFA-441 | JavaDiagnosticsEnabled preference

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/preferences/javaPrefExts.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/javaPrefExts.kt
@@ -32,7 +32,6 @@ internal class JavaCodeConfigurations(
 
   init {
     addPreference(GoogleCodeStyle())
-    addPreference(JavaDiagnosticsEnabled())
   }
 }
 

--- a/app/src/main/java/com/itsaky/androidide/preferences/javaPrefExts.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/javaPrefExts.kt
@@ -44,15 +44,3 @@ private class GoogleCodeStyle(
   override val icon: Int? = drawable.ic_format_code,
 ) : SwitchPreference(getValue = JavaPreferences::googleCodeStyle::get,
   setValue = JavaPreferences::googleCodeStyle::set)
-
-@Parcelize
-private class JavaDiagnosticsEnabled(
-  override val key: String = JavaPreferences.JAVA_DIAGNOSTICS_ENABLED,
-  override val title: Int = R.string.idepref_java_diagnosticEnabled_title,
-  override val summary: Int? = R.string.idepref_java_diagnosticsEnabled_summary,
-  override val icon: Int? = drawable.ic_compilation_error
-) :
-  SwitchPreference(
-    getValue = JavaPreferences::isJavaDiagnosticsEnabled::get,
-    setValue = JavaPreferences::isJavaDiagnosticsEnabled::set
-  )

--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/JavaLanguageServer.kt
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/JavaLanguageServer.kt
@@ -209,7 +209,7 @@ class JavaLanguageServer : ILanguageServer {
   }
 
   override suspend fun analyze(file: Path): DiagnosticResult {
-    if (!settings.diagnosticsEnabled() || !DocumentUtils.isJavaFile(file)) {
+    if (!DocumentUtils.isJavaFile(file)) {
       return DiagnosticResult.NO_UPDATE
     }
 

--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/JavaLanguageServer.kt
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/JavaLanguageServer.kt
@@ -209,7 +209,7 @@ class JavaLanguageServer : ILanguageServer {
   }
 
   override suspend fun analyze(file: Path): DiagnosticResult {
-    if (!DocumentUtils.isJavaFile(file)) {
+    if (!settings.diagnosticsEnabled() || !DocumentUtils.isJavaFile(file)) {
       return DiagnosticResult.NO_UPDATE
     }
 

--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/models/JavaServerSettings.java
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/models/JavaServerSettings.java
@@ -46,7 +46,7 @@ public class JavaServerSettings extends PrefBasedServerSettings {
 
   @Override
   public boolean diagnosticsEnabled() {
-    return !VMUtils.isJvm();
+    return true;
   }
 
   public JavaFormatterOptions getFormatterOptions() {

--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/models/JavaServerSettings.java
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/models/JavaServerSettings.java
@@ -46,7 +46,7 @@ public class JavaServerSettings extends PrefBasedServerSettings {
 
   @Override
   public boolean diagnosticsEnabled() {
-    return VMUtils.isJvm() || JavaPreferences.INSTANCE.isJavaDiagnosticsEnabled();
+    return !VMUtils.isJvm();
   }
 
   public JavaFormatterOptions getFormatterOptions() {

--- a/preferences/src/main/java/com/itsaky/androidide/preferences/internal/JavaPreferences.kt
+++ b/preferences/src/main/java/com/itsaky/androidide/preferences/internal/JavaPreferences.kt
@@ -24,10 +24,19 @@ package com.itsaky.androidide.preferences.internal
 object JavaPreferences {
 
   const val GOOGLE_CODE_STYLE = "idepref_editor_java_googleCodeStyle"
+  const val JAVA_DIAGNOSTICS_ENABLED = "idepref_editor_java_diagnosticsEnabled"
 
   var googleCodeStyle: Boolean
     get() = prefManager.getBoolean(GOOGLE_CODE_STYLE, false)
     set(value) {
       prefManager.putBoolean(GOOGLE_CODE_STYLE, value)
     }
+
+  /** Whether diagnostics are enabled for the Java source files. */
+  var isJavaDiagnosticsEnabled: Boolean
+    get() = prefManager.getBoolean(JAVA_DIAGNOSTICS_ENABLED, true)
+    set(value) {
+      prefManager.putBoolean(JAVA_DIAGNOSTICS_ENABLED, value)
+    }
+
 }

--- a/preferences/src/main/java/com/itsaky/androidide/preferences/internal/JavaPreferences.kt
+++ b/preferences/src/main/java/com/itsaky/androidide/preferences/internal/JavaPreferences.kt
@@ -24,19 +24,10 @@ package com.itsaky.androidide.preferences.internal
 object JavaPreferences {
 
   const val GOOGLE_CODE_STYLE = "idepref_editor_java_googleCodeStyle"
-  const val JAVA_DIAGNOSTICS_ENABLED = "idepref_editor_java_diagnosticsEnabled"
 
   var googleCodeStyle: Boolean
     get() = prefManager.getBoolean(GOOGLE_CODE_STYLE, false)
     set(value) {
       prefManager.putBoolean(GOOGLE_CODE_STYLE, value)
     }
-
-  /** Whether diagnostics are enabled for the Java source files. */
-  var isJavaDiagnosticsEnabled: Boolean
-    get() = prefManager.getBoolean(JAVA_DIAGNOSTICS_ENABLED, true)
-    set(value) {
-      prefManager.putBoolean(JAVA_DIAGNOSTICS_ENABLED, value)
-    }
-
 }


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
The change removes the `JavaDiagnosticsEnabled` preference from the list of preferences.

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->

![ADFA-441](https://github.com/user-attachments/assets/a8d5e04f-b283-4569-890c-b8d9092a5a53)

## Ticket
[ADFA-441](https://appdevforall.atlassian.net/browse/ADFA-441)

## Observation
<!-- Some important about your code --> 


[ADFA-441]: https://appdevforall.atlassian.net/browse/ADFA-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ADFA-441]: https://appdevforall.atlassian.net/browse/ADFA-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ