### PR TITLE
Upgrade Kotlin to 2.0.21 and update stdlib dependencies

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
@@ -696,7 +696,7 @@ open class EditorHandlerActivity : ProjectHandlerActivity(), IEditorHandler {
     editorActivityScope.launch {
       val files = editorViewModel.getOpenedFiles()
       val dupliCount = mutableMapOf<String, Int>()
-      val names = MutableIntObjectMap<Pair<String, @DrawableRes Int>>()
+      val names = MutableIntObjectMap<Pair<String, Int>>()
       val nameBuilder = UniqueNameBuilder<File>("", File.separator)
 
       files.forEach {

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/EditorViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/EditorViewModel.kt
@@ -43,7 +43,7 @@ class EditorViewModel : ViewModel() {
 
   internal val _isBuildInProgress = MutableLiveData(false)
   internal val _isInitializing = MutableLiveData(false)
-  internal val _statusText = MutableLiveData<Pair<CharSequence, @GravityInt Int>>("" to CENTER)
+  internal val _statusText = MutableLiveData<Pair<CharSequence, Int>>("" to CENTER)
   internal val _displayedFile = MutableLiveData(-1)
   internal val _startDrawerOpened = MutableLiveData(false)
   internal val _isSyncNeeded = MutableLiveData(false)

--- a/composite-builds/build-logic/build.gradle.kts
+++ b/composite-builds/build-logic/build.gradle.kts
@@ -17,7 +17,7 @@
 
 plugins {
     id("java")
-    kotlin("jvm") version "1.9.22"
+    kotlin("jvm") version "2.0.21"
 }
 subprojects {
     plugins.withId("java-library") {

--- a/constants/build.gradle.kts
+++ b/constants/build.gradle.kts
@@ -2,7 +2,7 @@ import com.itsaky.androidide.build.config.BuildConfig
 
 plugins {
     id("java")
-    kotlin("jvm") version "1.9.22"
+    kotlin("jvm") version "2.0.21"
 }
 
 /**

--- a/constants/src/main/java/com/adfa/constants/constants.kt
+++ b/constants/src/main/java/com/adfa/constants/constants.kt
@@ -29,7 +29,7 @@ import java.io.File
 
 const val ANDROID_GRADLE_PLUGIN_VERSION = "8.5.0"
 const val GRADLE_DISTRIBUTION_VERSION = "8.0.0"
-const val KOTLIN_VERSION = "1.9.22"
+const val KOTLIN_VERSION = "2.0.21"
 
 val TARGET_SDK_VERSION = Sdk.Tiramisu
 val COMPILE_SDK_VERSION = Sdk.Tiramisu

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ gradle-tooling = "8.6"
 gson = "2.10.1"
 junit-jupiter = "5.10.2"
 anroidx-test-core = "2.2.0"
-kotlin = "1.9.22"
+kotlin = "2.0.21"
 kotlin-coroutines = "1.9.0"
 lifecycleViewmodelKtx = "2.7.0"
 paletteKtx = "1.0.0"
@@ -23,7 +23,7 @@ editor = "0.23.5"
 glide = "4.16.0"
 androidx-vectordrawable = "1.2.0"
 androidx-navigation = "2.7.7"
-ksp = "1.9.22-1.0.17"
+ksp = "2.0.21-1.0.25"
 antlr4 = "4.13.1"
 androidx-work = "2.10.0"
 androidx-espresso = "3.5.1"
@@ -123,7 +123,7 @@ androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version
 androidx-vectors = { module = "androidx.vectordrawable:vectordrawable", version.ref = "androidx-vectordrawable" }
 androidx-animated_vectors = { module = "androidx.vectordrawable:vectordrawable-animated", version.ref = "androidx-vectordrawable" }
 androidx-core = { module = "androidx.core:core", version = "1.13.1" }
-androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.13.1" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.15.0" }
 androidx-fragment_ktx = { module = "androidx.fragment:fragment-ktx", version = "1.6.2" }
 androidx-libDesugaring = { module = "com.android.tools:desugar_jdk_libs", version = "2.0.4" }
 androidx-splashscreen = { module = "androidx.core:core-splashscreen", version = "1.0.1" }

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/models/Dependency.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/models/Dependency.kt
@@ -158,7 +158,7 @@ data class Dependency(val configuration: DependencyConfiguration,
     // Exclude older conflicting version from transitive dependencies
     // Again this arises only when using a local maven repo. Most probably because it lacks flexibility of online one.
     // We can run some gradle:app dependency commands to compare the results for online and offline maven repo later.
-    // Use Kotlin stdlib 1.9.22, and exclude old jdk7 and jdk8 versions
+    // Use Kotlin stdlib 2.0.21, and exclude old jdk7 and jdk8 versions
     implementation(libs.kotlin.stdlib) {
       exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
       exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
@@ -187,10 +187,10 @@ fun composeConfigGroovy(): String = """
     
     configurations.all {
         resolutionStrategy {
-            // Force the use of Kotlin stdlib 1.9.22 for all modules
-            force("org.jetbrains.kotlin:kotlin-stdlib:1.9.22")
-            force("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.22")
-            force("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.22")
+            // Force the use of Kotlin stdlib 2.0.21 for all modules
+            force("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
+            force("org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.0.21")
+            force("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.0.21")
     
             // Force specific AndroidX versions to avoid conflicts
             force("androidx.collection:collection:1.4.2")
@@ -242,10 +242,10 @@ fun composeConfigKts(): String = """
     
     configurations.all {
         resolutionStrategy {
-            // Force the use of Kotlin stdlib 1.9.22 for all modules
-            force("org.jetbrains.kotlin:kotlin-stdlib:1.9.22")
-            force("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.22")
-            force("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.22")
+            // Force the use of Kotlin stdlib 2.0.21 for all modules
+            force("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
+            force("org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.0.21")
+            force("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.0.21")
     
             // Force specific AndroidX versions to avoid conflicts
             force("androidx.collection:collection:1.4.2")
@@ -304,9 +304,9 @@ private fun androidPluginGroovy(): String {
 }
 
 private fun ktPluginKts(isToml: Boolean): String {
-    return if (isToml) """alias(libs.plugins.jetbrains.kotlin.android)""" else """kotlin("android") version "1.9.22" """
+    return if (isToml) """alias(libs.plugins.jetbrains.kotlin.android)""" else """kotlin("android") version "2.0.21" """
 }
 
 private fun ktPluginGroovy(): String {
-    return "id 'org.jetbrains.kotlin.android' version '1.9.22'"
+    return "id 'org.jetbrains.kotlin.android' version '2.0.21'"
 }

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/root/tomlSrc.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/root/tomlSrc.kt
@@ -22,7 +22,7 @@ import com.itsaky.androidide.templates.base.ProjectTemplateBuilder
 fun ProjectTemplateBuilder.composeTomlFileSrc() = """
 [versions]
 agp = "8.0.0"
-kotlin = "1.9.22"
+kotlin = "2.0.21"
 coreKtx = "1.8.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"

--- a/xml-inflater/src/main/java/com/itsaky/androidide/inflater/internal/adapters/AdapterViewAdapter.kt
+++ b/xml-inflater/src/main/java/com/itsaky/androidide/inflater/internal/adapters/AdapterViewAdapter.kt
@@ -30,27 +30,36 @@ import com.itsaky.androidide.inflater.internal.ViewGroupImpl
  */
 abstract class AdapterViewAdapter<T : AdapterView<*>> : ViewGroupAdapter<T>() {
 
-  companion object {
-    const val ADAPTER_DEFAULT_ITEM_COUNT = 3
-  }
-
-  override fun applyBasic(view: IView) {
-    super.applyBasic(view)
-    (view.view as AdapterView<*>).adapter = newSimpleAdapter(view.view.context)
-    if (view is ViewGroupImpl) {
-      view.childrenModifiable = false
+    companion object {
+        const val ADAPTER_DEFAULT_ITEM_COUNT = 3
     }
-  }
 
-  protected open fun newSimpleAdapter(ctx: Context): ArrayAdapter<String> {
-    return newSimpleAdapter(ctx, newAdapterItems(ADAPTER_DEFAULT_ITEM_COUNT))
-  }
+    override fun applyBasic(view: IView) {
+        super.applyBasic(view)
 
-  protected open fun newSimpleAdapter(ctx: Context, items: Array<String>): ArrayAdapter<String> {
-    return ArrayAdapter<String>(ctx, layout.simple_list_item_1, items)
-  }
+        val adapter = newSimpleAdapter(view.view.context)
 
-  protected open fun newAdapterItems(size: Int): Array<String> {
-    return Array(size) { "Item $it" }
-  }
+        when(view.view) {
+            is AdapterView<*> -> {
+                @Suppress("UNCHECKED_CAST")
+                (view.view as AdapterView<android.widget.Adapter>).adapter = adapter
+            }
+        }
+
+        if(view is ViewGroupImpl) {
+            view.childrenModifiable = false
+        }
+    }
+
+    protected open fun newSimpleAdapter(ctx: Context): ArrayAdapter<String> {
+        return newSimpleAdapter(ctx, newAdapterItems(ADAPTER_DEFAULT_ITEM_COUNT))
+    }
+
+    protected open fun newSimpleAdapter(ctx: Context, items: Array<String>): ArrayAdapter<String> {
+        return ArrayAdapter(ctx, layout.simple_list_item_1, items)
+    }
+
+    protected open fun newAdapterItems(size: Int): Array<String> {
+        return Array(size) { "Item $it" }
+    }
 }


### PR DESCRIPTION
This commit updates the Kotlin version to 2.0.21 across the project.
- Updated Kotlin version to 2.0.21 in `build-logic/build.gradle.kts`, `constants/build.gradle.kts`, template build scripts, and root toml file.
- Forced the use of Kotlin stdlib 2.0.21 in `buildGradle.kt` within `templates-api` and updated version in constants.
- updated `ktPluginKts` and `ktPluginGroovy` to version 2.0.21 in templates-api.
- Updated the forced versions for kotlin-stdlib, kotlin-stdlib-jdk7, and kotlin-stdlib-jdk8 in templates-api to 2.0.21.
- fixed a type issue in `AdapterViewAdapter`.