### PR TITLE
ADFA-695: update deployment workflow to use self-hosted runner and improve android build setup

### DIFF
--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'fastlane/**'
-      - '.github/workflows/crowdin_contributors.yml'
+
   workflow_dispatch: { }
 
 env:
@@ -34,7 +34,7 @@ env:
 jobs:
   build_apk:
     name: Build Universal APK
-    runs-on: macos-13
+    runs-on: self-hosted
     timeout-minutes: 60
     steps:
       - name: Cancel previous runs
@@ -47,8 +47,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git LFS - Selective pull
+      - name: Install and Configure Git LFS - Selective pull
         run: |
+          sudo apt-get update
+          sudo apt-get install -y git-lfs
           git lfs install
           git lfs pull
 
@@ -57,12 +59,34 @@ jobs:
           git submodule init
           git submodule update --remote
 
+      - name: Create symbolic link for layouteditor on Linux
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            echo "Creating symbolic link from LayoutEditor to layouteditor..."
+            ln -sfn "$GITHUB_WORKSPACE/LayoutEditor" "$GITHUB_WORKSPACE/layouteditor"
+            ls -l "$GITHUB_WORKSPACE"
+          else
+            echo "Skipping symbolic link creation: Not running on Linux."
+          fi
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.BUILD_JAVA_VERSION }}
           distribution: ${{ env.BUILD_JAVA_DIST }}
           cache: 'gradle' # Built-in Gradle caching
+
+      - name: Install unzip
+        run: sudo apt-get update && sudo apt-get install -y unzip
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK Platform 35
+        run: yes | sdkmanager "platforms;android-35" "build-tools;35.0.0"
+
+      - name: Generate local.properties
+        run: echo "sdk.dir=$ANDROID_SDK_ROOT" > ./app/local.properties
 
       - name: Cache Dependencies
         uses: actions/cache@v4
@@ -81,6 +105,7 @@ jobs:
         run: ./gradlew :app:assembleDebug --parallel --configure-on-demand
 
       - name: Find APK file
+        # We need to find the APK since the name is dynamically generated and it does not have a definite location
         id: find_apk
         run: |
           apk_path=$(find app/build/outputs/apk/ -type f -name "*.apk" | head -n 1)
@@ -232,3 +257,8 @@ jobs:
           
           # Send notification
           curl -X POST -H "Content-type: application/json" --data @payload.json "$SLACK_WEBHOOK"
+
+      # Cleanup stale workspace and Android build cache
+      - name: Cleanup runner disk
+        if: always()
+        run: sudo -E /usr/local/bin/runner-cleanup.sh


### PR DESCRIPTION
Ticket: https://appdevforall.atlassian.net/browse/ADFA-695

Migrate GitHub Actions runner to a self-hosted machine.