### PR TITLE
ADFA-590 remove redundant libs_source/termux/armeabi

### DIFF
--- a/libs_source/termux/armeabi/ca-certificates-java_1%3a2023.08.22_all.deb
+++ b/libs_source/termux/armeabi/ca-certificates-java_1%3a2023.08.22_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad403247df0bd641388ee953e2edf21228d83937768c9f58299592821487120c
-size 110204

--- a/libs_source/termux/armeabi/fontconfig_2.14.2-2_arm.deb
+++ b/libs_source/termux/armeabi/fontconfig_2.14.2-2_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86d7b07b9fa623d516cc94bf10e5175b7e4ff55eb9992c926b634c046ca8b083
-size 109580

--- a/libs_source/termux/armeabi/freetype_2.13.2_arm.deb
+++ b/libs_source/termux/armeabi/freetype_2.13.2_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:548d74e161192bc885e6ef859aa8e8e6b3ffb6818974bde5d94e1e83320e58b8
-size 384248

--- a/libs_source/termux/armeabi/giflib_5.2.1-2_arm.deb
+++ b/libs_source/termux/armeabi/giflib_5.2.1-2_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:256c5d5a73e8c4eca61a30ed9d01232dbb70db4c2abc72a41b1409761111f7a0
-size 16476

--- a/libs_source/termux/armeabi/git_2.43.0_arm.deb
+++ b/libs_source/termux/armeabi/git_2.43.0_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7dc6109caf54fbf70fc22df4bc229fa15d346b880b998b6e8e829402eb0fd53e
-size 3214984

--- a/libs_source/termux/armeabi/krb5_1.21.2_arm.deb
+++ b/libs_source/termux/armeabi/krb5_1.21.2_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0cf46ba34b75833e75a137243691e016b799cb4943ddea0cac6648c43f865e12
-size 839044

--- a/libs_source/termux/armeabi/ldns_1.8.3-2_arm.deb
+++ b/libs_source/termux/armeabi/ldns_1.8.3-2_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e728dba12be8d7f894de0f8b977ec9e5b3e0342eb2aeb2d93b9388d897b97699
-size 291552

--- a/libs_source/termux/armeabi/libandroid-shmem_0.4_arm.deb
+++ b/libs_source/termux/armeabi/libandroid-shmem_0.4_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65d86e4ae9e68ac0a39230fdc4f0130a0943e037443a4c03373b98338a9d9ae6
-size 6540

--- a/libs_source/termux/armeabi/libdb_18.1.40-4_arm.deb
+++ b/libs_source/termux/armeabi/libdb_18.1.40-4_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23ae8aaee7da6eeb519f2b7a5f6e7cc4c9e74d24d62b85cfaff3a10468011d7b
-size 462028

--- a/libs_source/termux/armeabi/libedit_20221030-3.1-0_arm.deb
+++ b/libs_source/termux/armeabi/libedit_20221030-3.1-0_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41e538d511061f0317aafb56d60ab8518e48f288c6e4de8a7f74c3049c28dfcd
-size 68792

--- a/libs_source/termux/armeabi/libexpat_2.5.0-1_arm.deb
+++ b/libs_source/termux/armeabi/libexpat_2.5.0-1_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:85c5b0d0dba20702c9421cf95ccbb873cb40cff6552ef9d599e048e4f313267b
-size 76364

--- a/libs_source/termux/armeabi/libice_1.1.1_arm.deb
+++ b/libs_source/termux/armeabi/libice_1.1.1_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c40ebcc3502fb4a116542187ef89cabd8acd022565483d478ffd6998f3695a5
-size 64068

--- a/libs_source/termux/armeabi/libjpeg-turbo_3.0.1_arm.deb
+++ b/libs_source/termux/armeabi/libjpeg-turbo_3.0.1_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03c570a593ee8f5cfa0c38109562f0fb73b067570438c35ad9f53ecb1c01c966
-size 343976

--- a/libs_source/termux/armeabi/libpng_1.6.40_arm.deb
+++ b/libs_source/termux/armeabi/libpng_1.6.40_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7cfe12940dc3514c57f1da79a4e6a3255b6ea3312626c6bfdc96c6ca938392be
-size 188412

--- a/libs_source/termux/armeabi/libresolv-wrapper_1.1.7-4_arm.deb
+++ b/libs_source/termux/armeabi/libresolv-wrapper_1.1.7-4_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4bf5eb639fa640101def76b4585237ae92844d5fd0cce0ba5881fc16b484ee1a
-size 11164

--- a/libs_source/termux/armeabi/libsm_1.2.4-1_arm.deb
+++ b/libs_source/termux/armeabi/libsm_1.2.4-1_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3438f6594b3113008ed1b6c129b224f58b55eb1c6a9f2dbda826a4b2d45d5bf
-size 39752

--- a/libs_source/termux/armeabi/libx11_1.8.7_arm.deb
+++ b/libs_source/termux/armeabi/libx11_1.8.7_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc2870c6816a983b224331350441cfc901680213b2971bf4fda384989b378b1a
-size 1886932

--- a/libs_source/termux/armeabi/libxau_1.0.11_arm.deb
+++ b/libs_source/termux/armeabi/libxau_1.0.11_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9e259dc16433eacdfe93f4ccf6312933de5c1acca73e3c148fef53f2250a7cb
-size 7932

--- a/libs_source/termux/armeabi/libxcb_1.16_arm.deb
+++ b/libs_source/termux/armeabi/libxcb_1.16_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:423329c0e6404faf6558df851400c0c94d8b5111f00555df56c55b8c86637c0c
-size 898492

--- a/libs_source/termux/armeabi/libxdmcp_1.1.4_arm.deb
+++ b/libs_source/termux/armeabi/libxdmcp_1.1.4_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d46a63a0295449628214b2094bd97043cd9cb5cbff506869de7867a45ef11fb9
-size 23080

--- a/libs_source/termux/armeabi/libxext_1.3.5_arm.deb
+++ b/libs_source/termux/armeabi/libxext_1.3.5_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3929785a24c607427389684774c350c975e96d977264c580cd1e3553036c56e
-size 93460

--- a/libs_source/termux/armeabi/libxi_1.8.1_arm.deb
+++ b/libs_source/termux/armeabi/libxi_1.8.1_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a524d421855f61bf9c9ae3ee31d1024018c00e5a34027a17ce9533511d92937f
-size 139072

--- a/libs_source/termux/armeabi/libxrandr_1.5.4_arm.deb
+++ b/libs_source/termux/armeabi/libxrandr_1.5.4_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e99107d72737abfe1813cf49e78926df2c76992d8d3fab82e47cf6a32ce6441e
-size 20112

--- a/libs_source/termux/armeabi/libxrender_0.9.11_arm.deb
+++ b/libs_source/termux/armeabi/libxrender_0.9.11_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a2264ccb0ff15534e7a1d51204f5bbe8db90f2c6d1904a4b96d95672e203214d
-size 22128

--- a/libs_source/termux/armeabi/libxt_1.3.0_arm.deb
+++ b/libs_source/termux/armeabi/libxt_1.3.0_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e160be6c35790b05d794950dc8ef2155783aa4f56c1a32f8f240dcef13ea8ec
-size 470792

--- a/libs_source/termux/armeabi/libxtst_1.2.4_arm.deb
+++ b/libs_source/termux/armeabi/libxtst_1.2.4_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7495992fe746293f3d0965dd72ed3d68d277df47994e0d2ae27f709aef61d0b2
-size 24660

--- a/libs_source/termux/armeabi/openjdk-17-x_17.0-30_arm.deb
+++ b/libs_source/termux/armeabi/openjdk-17-x_17.0-30_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:922fd1bf54384a4fe9663a608733c50c7579725e1dad59aaccad33e81452ae2b
-size 12633808

--- a/libs_source/termux/armeabi/openjdk-17_17.0-30_arm.deb
+++ b/libs_source/termux/armeabi/openjdk-17_17.0-30_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5dcfdf0c69da5bd4bce35c3c2cb4736d86d57e755cd43c76f7addc4866937d14
-size 94581788

--- a/libs_source/termux/armeabi/openssh-sftp-server_9.5p1-2_arm.deb
+++ b/libs_source/termux/armeabi/openssh-sftp-server_9.5p1-2_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef92420638ebffa5277730a870eebdd99a1a47cdefac067b77486f4ff9529c19
-size 44452

--- a/libs_source/termux/armeabi/openssh_9.5p1-2_arm.deb
+++ b/libs_source/termux/armeabi/openssh_9.5p1-2_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46e674dd1da545df94a1bbf8be62c24645657d709c40342a45929f3aa4e8a766
-size 755704

--- a/libs_source/termux/armeabi/termux-auth_1.4-2_arm.deb
+++ b/libs_source/termux/armeabi/termux-auth_1.4-2_arm.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70604ec4859278ff87ed086d55b47eabd72162e2ef5d19f763163976eeda1f3a
-size 5840

--- a/libs_source/termux/armeabi/ttf-dejavu_2.37-8_all.deb
+++ b/libs_source/termux/armeabi/ttf-dejavu_2.37-8_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3221852470efa06950c01a584de7bd67926a3ca4956e4fff8a471283c8d6f00d
-size 2502908


### PR DESCRIPTION
It appears that armeabi and v7 are the same and we don't need two copies. 