### PR TITLE
ADFA-367: remove need for LayoutEditor symlink

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,37 +87,6 @@ android {
   }
 }
 
-// Task to create symbolic link on Linux only
-tasks.register("createSymbolicLinkForLayoutEditor") {
-  // Check if the OS is Linux
-  val os: String = System.getProperty("os.name").lowercase(Locale.ENGLISH)
-
-  // Update paths to reflect the correct locations for LayoutEditor
-  val sourcePath: java.nio.file.Path = Paths.get(rootDir.absolutePath, "LayoutEditor")
-  val destinationPath: java.nio.file.Path = Paths.get(rootDir.absolutePath, "layouteditor")
-  val destinationFile = destinationPath.toFile()
-
-  if (os.contains("linux") || os.contains("nix") || os.contains("nux")) {
-    // Check if the symbolic link already exists
-    if (destinationFile.exists() && Files.isSymbolicLink(destinationPath)) {
-      doLast {
-        println("Symbolic link already exists: $destinationPath -> $sourcePath")
-      }
-    } else {
-      Files.createSymbolicLink(destinationPath, sourcePath)
-    }
-  } else {
-    doLast {
-      println("Skipping symbolic link creation: Not running on Linux.")
-    }
-  }
-}
-
-// Ensure the symbolic link task runs before preBuild
-tasks.named("preBuild").configure {
-  dependsOn("createSymbolicLinkForLayoutEditor")
-}
-
 kapt { arguments { arg("eventBusIndex", "${BuildConfig.packageName}.events.AppEventsIndex") } }
 
 desugaring {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -157,13 +157,14 @@ include(
   ":testing:lsp",
   ":testing:tooling",
   ":testing:unit",
-  ":layouteditor:app",
+  ":layouteditor:layouteditor-app",
   ":layouteditor:vectormaster",
   ":constants"
 )
 
-project(":layouteditor:app").name = "layouteditor-app"
-project(":layouteditor:vectormaster").name = "vectormaster"
+val layoutEditorDir = rootDir.resolve("LayoutEditor")
+project(":layouteditor:layouteditor-app").projectDir = layoutEditorDir.resolve("app")
+project(":layouteditor:vectormaster").projectDir = layoutEditorDir.resolve("vectormaster")
 
 object FDroidConfig {
 


### PR DESCRIPTION
Building on Linux doesn't require symbolic link for `LayoutEditor` anymore.