### PR TITLE
Removed DS_Store from android-sdk.zip

### DIFF
--- a/libs_source/androidsdk/android-sdk.zip
+++ b/libs_source/androidsdk/android-sdk.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12d13c4591f91339e21384456de347d4210e0d6c1508894446ffafd6806aadee
-size 221548952
+oid sha256:83ad841ecf44fecce18b6976a386f776ea0e822a2c6f21b2b5bbbaf774e79fc1
+size 221535448


### PR DESCRIPTION
reduced the size of the apk by 2M by removing .DS_Store files from android-sdk.zip. these files are used by MacOS and are therefore unused by CoGo. gitignore can not be used here because it only filters files and directories, it does not inspect the contents of jars, zip files, etc.