### PR TITLE
fix/ADFA-341 | add tooltips to sidebar actions

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -60,7 +60,6 @@ import com.github.mikephil.charting.data.LineDataSet
 import com.github.mikephil.charting.formatter.IAxisValueFormatter
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
-import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayout.Tab
 import com.itsaky.androidide.R
@@ -91,7 +90,6 @@ import com.itsaky.androidide.projects.ProjectManagerImpl
 import com.itsaky.androidide.tasks.cancelIfActive
 import com.itsaky.androidide.ui.CodeEditorView
 import com.itsaky.androidide.ui.ContentTranslatingDrawerLayout
-import com.itsaky.androidide.ui.CustomSnackbar
 import com.itsaky.androidide.ui.SwipeRevealLayout
 import com.itsaky.androidide.uidesigner.UIDesignerActivity
 import com.itsaky.androidide.utils.ActionMenuUtils.createMenu
@@ -319,19 +317,16 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
             return
         }
 
-    val snackbar = CustomSnackbar(this, findViewById(android.R.id.content))
-    snackbar.show(
-      message = getString(R.string.msg_action_open_application),
-      textFirstAction = getString(R.string.yes),
-      textSecondaryAction = getString(R.string.no),
-      actionFirst = {
-        IntentUtils.launchApp(this, packageName)
-      },
-      actionSecondary = {
-        snackbar.dismiss()
-      }
-    )
-  }
+        val builder = newMaterialDialogBuilder(this)
+        builder.setTitle(string.msg_action_open_title_application)
+        builder.setMessage(string.msg_action_open_application)
+        builder.setPositiveButton(string.yes) { dialog, _ ->
+            dialog.dismiss()
+            IntentUtils.launchApp(this, packageName)
+        }
+        builder.setNegativeButton(string.no, null)
+        builder.show()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -338,7 +338,8 @@
   <string name="idepref_customFont_title">Use custom font</string>
   <string name="idepref_customFont_summary">If enabled, the file at \"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" will be used as Editor font.</string>
   <string name="msg_installing_apk">Installing APK...</string>
-  <string name="msg_action_open_application">Do you want to open the application?</string>
+  <string name="msg_action_open_application">Your app is installed. Do you want to launch the app?</string>
+  <string name="msg_action_open_title_application">App installed</string>
 
     <string name="title_gradle_service_notification_channel">Code on the Go Gradle build service</string>
     <string name="msg_hex_color_code">Hex color code</string>


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
Adds tooltips to the sidebar actions in the IDE. When a user long-presses on a sidebar action, a tooltip will appear with information about the action. This fix utilizes `TooltipUtils.showIDETooltip` and the new `setupTooltip` method in `EditorSidebarFragment` to display the tooltips and get tooltip data from `EditorHandlerActivity`. A `tooltipTag` property was added to each sidebar action to enable mapping to its corresponding tooltip data.

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->

https://github.com/user-attachments/assets/3bed5841-3782-45b6-848d-6bc6514167dd


## Ticket
[ADFA-341](https://appdevforall.atlassian.net/browse/ADFA-341)

## Observation
<!-- Some important about your code --> 


[ADFA-341]: https://appdevforall.atlassian.net/browse/ADFA-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ