### PR TITLE
Fix/adfa 635 remove progress bar from TemplateDetailsFragment

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/fragments/TemplateDetailsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/TemplateDetailsFragment.kt
@@ -69,7 +69,6 @@ class TemplateDetailsFragment :
 
         viewModel.creatingProject.observe(viewLifecycleOwner) {
             TransitionManager.beginDelayedTransition(binding.root)
-            binding.progress.isVisible = it
             binding.finish.isEnabled = !it
             binding.previous.isEnabled = !it
         }

--- a/app/src/main/java/com/itsaky/androidide/fragments/TemplateDetailsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/TemplateDetailsFragment.kt
@@ -58,10 +58,6 @@ class TemplateDetailsFragment :
 
     private val recentProjectsViewModel: RecentProjectsViewModel by activityViewModels()
 
-    companion object {
-
-        private val log = LoggerFactory.getLogger(TemplateDetailsFragment::class.java)
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -112,7 +108,6 @@ class TemplateDetailsFragment :
                 viewModel.creatingProject.value = false
                 if (result == null || err != null || result !is ProjectTemplateRecipeResult) {
                     err?.printStackTrace()
-                    log.error("Failed to create project. result={}, err={}", result, err?.message)
                     if (err != null) {
                         flashError(err.cause?.message ?: err.message)
                     } else {


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
Remove unused logger in TemplateDetailsFragment, hide progress bar on project creation
The progress bar is now hidden during project creation. This was done by moving the `binding.progress.isVisible = it` line from within the `viewModel.creatingProject.observe` block
## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->

https://github.com/user-attachments/assets/f4ecf27d-2793-4701-9845-10cc12c27889

## Ticket
[ADFA-635](https://appdevforall.atlassian.net/browse/ADFA-635)
## Observation
<!-- Some important about your code -->