### PR TITLE
Fix/adfa 696 | Improve delete project fragment layout

### DIFF
--- a/app/src/main/res/layout/fragment_delete_project.xml
+++ b/app/src/main/res/layout/fragment_delete_project.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    android:orientation="vertical">
+    android:fitsSystemWindows="true">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
+        android:layout_height="match_parent"
         android:background="?attr/colorSurface"
         android:fitsSystemWindows="true"
         android:orientation="vertical">
@@ -22,84 +20,83 @@
             android:textAppearance="@style/TextAppearance.Material3.TitleLarge"
             android:transitionName="title" />
 
-        <FrameLayout
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/list_projects"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/list_projects"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clipToPadding="false" />
-
-            <RelativeLayout
-                android:id="@+id/no_projects_view"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:padding="8dp"
-                android:visibility="gone">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/tv1"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_centerHorizontal="true"
-                    android:gravity="center"
-                    android:padding="@dimen/cornerLow"
-                    android:text="@string/msg_no_recent_projects"
-                    android:textSize="22sp" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_below="@id/tv1"
-                    android:layout_centerHorizontal="true"
-                    android:padding="8dp"
-                    android:text="@string/msg_create_new" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_above="@id/tv1"
-                    android:layout_centerHorizontal="true"
-                    android:padding="8dp"
-                    android:text="@string/hmmm"
-                    android:textSize="28sp" />
-            </RelativeLayout>
-
-            <ProgressBar
-                android:id="@+id/loader"
-                style="?android:attr/progressBarStyleSmall"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:visibility="gone" />
-        </FrameLayout>
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:padding="8dp">
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/exit_button"
-            style="@style/Widget.Material3.Button.OutlinedButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/exit" />
-
-        <View
-            android:layout_width="0dp"
             android:layout_height="0dp"
-            android:layout_weight="1" />
+            android:layout_weight="1"
+            android:paddingTop="0dp"
+            android:clipToPadding="false"
+            android:background="?attr/colorSurface"/>
+        
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="8dp">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/delete"
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/exit_button"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/exit" />
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/delete"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/delete" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <RelativeLayout
+        android:id="@+id/no_projects_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="8dp"
+        android:visibility="gone">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/delete" />
-    </LinearLayout>
-</LinearLayout>
+            android:layout_centerHorizontal="true"
+            android:gravity="center"
+            android:padding="@dimen/cornerLow"
+            android:text="@string/msg_no_recent_projects"
+            android:textSize="22sp" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tv1"
+            android:layout_centerHorizontal="true"
+            android:padding="8dp"
+            android:text="@string/msg_create_new" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_above="@id/tv1"
+            android:layout_centerHorizontal="true"
+            android:padding="8dp"
+            android:text="@string/hmmm"
+            android:textSize="28sp" />
+    </RelativeLayout>
+
+    <ProgressBar
+        android:id="@+id/loader"
+        style="?android:attr/progressBarStyleSmall"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_delete_project.xml
+++ b/app/src/main/res/layout/fragment_delete_project.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:fitsSystemWindows="true"
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/white"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:background="?attr/colorSurface"
         android:fitsSystemWindows="true"
         android:orientation="vertical">
 
@@ -20,74 +22,84 @@
             android:textAppearance="@style/TextAppearance.Material3.TitleLarge"
             android:transitionName="title" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/list_projects"
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingTop="0dp" />
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/list_projects"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false" />
+
+            <RelativeLayout
+                android:id="@+id/no_projects_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:padding="8dp"
+                android:visibility="gone">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/tv1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerHorizontal="true"
+                    android:gravity="center"
+                    android:padding="@dimen/cornerLow"
+                    android:text="@string/msg_no_recent_projects"
+                    android:textSize="22sp" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/tv1"
+                    android:layout_centerHorizontal="true"
+                    android:padding="8dp"
+                    android:text="@string/msg_create_new" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_above="@id/tv1"
+                    android:layout_centerHorizontal="true"
+                    android:padding="8dp"
+                    android:text="@string/hmmm"
+                    android:textSize="28sp" />
+            </RelativeLayout>
+
+            <ProgressBar
+                android:id="@+id/loader"
+                style="?android:attr/progressBarStyleSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:visibility="gone" />
+        </FrameLayout>
     </LinearLayout>
 
-    <RelativeLayout
-        android:id="@+id/no_projects_view"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:padding="8dp"
-        android:visibility="gone">
+        android:orientation="horizontal"
+        android:padding="8dp">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/tv1"
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/exit_button"
+            style="@style/Widget.Material3.Button.OutlinedButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_centerHorizontal="true"
-            android:gravity="center"
-            android:padding="@dimen/cornerLow"
-            android:text="@string/msg_no_recent_projects"
-            android:textSize="22sp" />
+            android:text="@string/exit" />
 
-        <com.google.android.material.textview.MaterialTextView
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/delete"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/tv1"
-            android:layout_centerHorizontal="true"
-            android:padding="8dp"
-            android:text="@string/msg_create_new" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_above="@id/tv1"
-            android:layout_centerHorizontal="true"
-            android:padding="8dp"
-            android:text="@string/hmmm"
-            android:textSize="28sp" />
-
-    </RelativeLayout>
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/exit_button"
-        style="@style/Widget.Material3.Button.OutlinedButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start|bottom"
-        android:layout_margin="16dp"
-        android:text="@string/exit" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/delete"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end|bottom"
-        android:layout_margin="16dp"
-        android:text="@string/delete" />
-
-    <ProgressBar
-        android:id="@+id/loader"
-        style="?android:attr/progressBarStyleSmall"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:visibility="gone" />
-
-</FrameLayout>
+            android:text="@string/delete" />
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
The layout of the delete project fragment has been improved by:
- Switching from `LinearLayout` to `FrameLayout` for the root layout.
- Using `layout_weight` for the RecyclerView to fill available space.
- Moving the no projects view, to be under the root `FrameLayout`, so that it can overlay the whole screen.
- Adjusting padding and alignment for better visual organization.
- Moving bottom buttons to their own layout.
- Updating the layout to make the `RecyclerView` take up the remaining space and improving the overall layout structure.

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->

https://github.com/user-attachments/assets/60a2dc4a-225d-46ef-8c5e-a21fc460a5ec



## Ticket
[ADFA-696](https://appdevforall.atlassian.net/browse/ADFA-696)

## Observation
<!-- Some important about your code --> 

[ADFA-696]: https://appdevforall.atlassian.net/browse/ADFA-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ