### PR TITLE
Fix/adfa 729 add category to tooltip database

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/file/ShowTooltipAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/file/ShowTooltipAction.kt
@@ -41,14 +41,20 @@ class ShowTooltipAction(private val context: Context, override val order: Int) :
         val editor = data.getEditor()!!
         val cursor = editor.text.cursor
         val activity = data.getActivity()
+        val category = when(editor.file!!.extension.toString()) {
+            "java" -> "java"
+            "kt" -> "kotlin"
+            else -> "ide"
+        }
         val word = editor.text.substring(cursor.left, cursor.right)
         if (cursor.isSelected) {
-            activity?.getTooltipData(word)?.let { tooltipData ->
+            activity?.getTooltipData(category, word)?.let { tooltipData ->
                 TooltipUtils.showIDETooltip(
                     context,
                     editor,
                     0,
                     IDETooltipItem(
+                        tooltipCategory = category,
                         tooltipTag = tooltipData.tooltipTag,
                         detail = tooltipData.detail,
                         summary = tooltipData.summary,

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
@@ -578,9 +578,9 @@ open class EditorHandlerActivity : ProjectHandlerActivity(), IEditorHandler {
         startActivity(intent)
     }
 
-    override suspend fun getTooltipData(word: String): IDETooltipItem? {
+    override suspend fun getTooltipData(category: String, tag: String): IDETooltipItem? {
         return withContext(Dispatchers.IO) {
-          IDEApplication.idetooltipDao.getTooltip(word)
+          IDEApplication.idetooltipDao.getTooltip(category, tag)
         }
     }
 

--- a/app/src/main/java/com/itsaky/androidide/fragments/MainFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/MainFragment.kt
@@ -137,7 +137,7 @@ class MainFragment : BaseFragment() {
         val tag = action.id.toString()
         CoroutineScope(Dispatchers.IO).launch {
             val dao = IDETooltipDatabase.getDatabase(requireContext()).idetooltipDao()
-            val item = dao.getTooltip(tag)
+            val item = dao.getTooltip("ide", tag)
             withContext((Dispatchers.Main)) {
                 (context?.let {
                     TooltipUtils.showIDETooltip(
@@ -145,6 +145,7 @@ class MainFragment : BaseFragment() {
                         view!!,
                         0,
                         IDETooltipItem(
+                            tooltipCategory = "ide",
                             tooltipTag = item?.tooltipTag ?: "",
                             detail = item?.detail ?: "",
                             summary = item?.summary ?: "",

--- a/app/src/main/java/com/itsaky/androidide/fragments/sidebar/EditorSidebarFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/sidebar/EditorSidebarFragment.kt
@@ -69,12 +69,12 @@ class EditorSidebarFragment : FragmentWithBinding<FragmentEditorSidebarBinding>(
     EditorSidebarActions.setup(this)
   }
 
-  fun setupTooltip(view: View, tooltipTag: String) {
+  fun setupTooltip(view: View, tooltipCategory: String, tooltipTag: String) {
     (requireActivity() as? EditorHandlerActivity)?.let { activity ->
       view.setOnLongClickListener { view ->
         activity.lifecycleScope.launch {
           try {
-            val tooltipData = activity.getTooltipData(tooltipTag)
+            val tooltipData = activity.getTooltipData(tooltipCategory, tooltipTag)
             tooltipData?.let {
               TooltipUtils.showIDETooltip(
                 context = view.context,

--- a/app/src/main/java/com/itsaky/androidide/idetooltips/IDETooltipDao.kt
+++ b/app/src/main/java/com/itsaky/androidide/idetooltips/IDETooltipDao.kt
@@ -24,14 +24,14 @@ import androidx.room.Query
 
 @Dao
 interface IDETooltipDao {
-  @Query("SELECT * FROM ide_tooltip_table ORDER BY tooltipTag ASC")
+  @Query("SELECT * FROM ide_tooltip_table ORDER BY tooltipCategory, tooltipTag ASC")
   fun getTooltipItems(): List<IDETooltipItem>
 
-  @Query("SELECT tooltipSummary FROM ide_tooltip_table WHERE tooltipTag == :tooltipTag")
-  fun getSummary(tooltipTag : String) : String
+  @Query("SELECT tooltipSummary FROM ide_tooltip_table WHERE tooltipCategory == :tooltipCategory AND tooltipTag == :tooltipTag")
+  fun getSummary(tooltipCategory : String, tooltipTag : String) : String
 
-  @Query("SELECT tooltipDetail FROM ide_tooltip_table WHERE tooltipTag == :tooltipTag")
-  fun getDetail(tooltipTag : String) : String
+  @Query("SELECT tooltipDetail FROM ide_tooltip_table WHERE tooltipCategory == :tooltipCategory AND tooltipTag == :tooltipTag")
+  fun getDetail(tooltipCategory : String, tooltipTag : String) : String
 
   //@Query("SELECT tooltipButtons FROM ide_tooltip_table WHERE tooltipTag == :tooltipTag")
   //fun getButtons(tooltipTag: String) : ArrayList<Pair<String, String>>
@@ -39,8 +39,8 @@ interface IDETooltipDao {
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun insert(IDETooltipItem: IDETooltipItem)
 
-  @Query("SELECT * FROM ide_tooltip_table WHERE tooltipTag == :tooltipTag")
-  suspend fun getTooltip(tooltipTag: String) : IDETooltipItem?
+  @Query("SELECT * FROM ide_tooltip_table WHERE tooltipCategory == :tooltipCategory AND tooltipTag == :tooltipTag")
+  suspend fun getTooltip(tooltipCategory : String, tooltipTag: String) : IDETooltipItem?
 
   @Query("DELETE FROM ide_tooltip_table")
   suspend fun deleteAll()

--- a/app/src/main/java/com/itsaky/androidide/idetooltips/IDETooltipDatabase.kt
+++ b/app/src/main/java/com/itsaky/androidide/idetooltips/IDETooltipDatabase.kt
@@ -71,12 +71,14 @@ abstract class IDETooltipDatabase : RoomDatabase() {
             try {
             for( index in 0 until arrayObj.length()) {
                 val jsonObj: JSONObject = arrayObj.get(index) as JSONObject
+                val category = jsonObj.getString("category")
                 val tag = jsonObj.getString("tag")
                 val summary = jsonObj.getString("summary")
                 val detail = jsonObj.getString("detail")
                 val buttonList = jsonObj.get("buttons") as JSONArray
                 val buttonsList = readJsonArrayOfArrays(context, buttonList)
                 val item = IDETooltipItem(
+                    tooltipCategory = category,
                     tooltipTag = tag,
                     summary = summary,
                     detail = detail,

--- a/app/src/main/java/com/itsaky/androidide/idetooltips/IDETooltipItem.kt
+++ b/app/src/main/java/com/itsaky/androidide/idetooltips/IDETooltipItem.kt
@@ -21,9 +21,10 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "ide_tooltip_table")
+@Entity(primaryKeys = ["tooltipCategory", "tooltipTag"], tableName = "ide_tooltip_table")
 data class IDETooltipItem(
-    @PrimaryKey @ColumnInfo(name = "tooltipTag") val tooltipTag : String,
+    @ColumnInfo(name = "tooltipCategory") val tooltipCategory : String,
+    @ColumnInfo(name = "tooltipTag") val tooltipTag : String,
     @ColumnInfo(name = "tooltipSummary") val summary: String,
     @ColumnInfo(name = "tooltipDetail")  val detail: String,
     @ColumnInfo(name = "tooltipButtons") val buttons: ArrayList<Pair<String, String>>

--- a/app/src/main/java/com/itsaky/androidide/interfaces/IEditorHandler.kt
+++ b/app/src/main/java/com/itsaky/androidide/interfaces/IEditorHandler.kt
@@ -88,5 +88,5 @@ interface IEditorHandler {
   fun closeAll(runAfter: () -> Unit)
   fun closeOthers()
   fun openFAQActivity(htmlData: String)
-  suspend fun getTooltipData(word:String): IDETooltipItem?
+  suspend fun getTooltipData(category: String, tag:String): IDETooltipItem?
 }

--- a/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -144,6 +144,7 @@ constructor(
           tabView,
           0,
           IDETooltipItem(
+            tooltipCategory = "ide",
             tooltipTag = tooltipMessage,
             detail = tooltipMessage,
             summary =  "More information about $title",

--- a/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
@@ -160,7 +160,7 @@ internal object EditorSidebarActions {
 
             if (view != null && action != null) {
                 val tag = action.tooltipTag()
-                sidebarFragment.setupTooltip(view, tag)
+                sidebarFragment.setupTooltip(view, "ide", tag)
                 tooltipTags += tag
             }
         }


### PR DESCRIPTION
Added a missing field to the database called 'Category', this is to allow the program to understand the difference between keyword that are common to multiple languages (e.g. 'if' in java and in kotlin)