### PR TITLE
ADFA-471 | Remove demo folder in JDK

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
@@ -75,6 +75,12 @@ class OnboardingActivity : AppIntro2() {
     ) {
         Log.d(TAG, "TerminalActivity: resultCode=${it.resultCode}")
         if (!isFinishing) {
+            val currentFragment = supportFragmentManager.fragments
+                .filterIsInstance<IdeSetupConfigurationFragment>()
+                .firstOrNull()
+
+            currentFragment?.removeJdkDemoFolderIfExists()
+
             reloadJdkDistInfo {
                 tryNavigateToMainIfSetupIsCompleted()
             }

--- a/app/src/main/java/com/itsaky/androidide/fragments/onboarding/IdeSetupConfigurationFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/onboarding/IdeSetupConfigurationFragment.kt
@@ -51,6 +51,7 @@ import com.itsaky.androidide.utils.ConnectionInfo
 import com.itsaky.androidide.utils.Environment
 import com.itsaky.androidide.utils.flashError
 import com.itsaky.androidide.utils.getConnectionInfo
+import java.io.File
 
 /**
  * @author Akash Yadav
@@ -305,5 +306,13 @@ class IdeSetupConfigurationFragment : OnboardingFragment(), SlidePolicy {
       backgroundDataRestrictionReceiver = null
     }
   }
+
+  fun removeJdkDemoFolderIfExists() {
+    val demoDir = File(Environment.PREFIX, "opt/openjdk-17.0/demo")
+    if (demoDir.exists()) {
+      demoDir.deleteRecursively()
+    }
+  }
+
 
 }


### PR DESCRIPTION

## Description
<!-- Short description about what, how and why you did in the PR -->
The demo folder in the JDK is now removed after onboarding is completed. This change ensures that the demo directory is deleted if it exists within the JDK. It's triggered by the `removeJdkDemoFolderIfExists` method within the `IdeSetupConfigurationFragment`.

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->
![image](https://github.com/user-attachments/assets/c7dc193a-75f4-4fcc-84bf-4c3df24d7056)

## Ticket
[ADFA-471](https://appdevforall.atlassian.net/browse/ADFA-471)

## Observation
<!-- Some important about your code --> 

[ADFA-471]: https://appdevforall.atlassian.net/browse/ADFA-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ