### PR TITLE
ADFA-781 enforce well formatted PR titles that refer to jira tickets

### DIFF
--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -18,8 +18,8 @@ jobs:
           echo "<$jira_regex> <$PR_TITLE>"
           
           if grep -q "$jira_regex" <<< "$PR_TITLE"; then
-            echo "PR title `$PR_TITLE` contains a valid JIRA issue key."
+            echo "PR title '$PR_TITLE' contains a valid JIRA issue key."
           else
-              echo "Error: PR title `$PR_TITLE` does not contain a valid JIRA issue key. Please ensure your title includes a key in the format ADFA-XXXX."
+              echo "Error: PR title '$PR_TITLE' does not contain a valid JIRA issue key. Please ensure your title includes a key in the format ADFA-XXXX."
               exit 1
           fi


### PR DESCRIPTION
Adds a GitHub Actions workflow that acts as a check for every PR that gets created. It makes sure that the title has ADFA-9999 in it somewhere.