### PR TITLE
ADFA-636 | demo removed

### DIFF
--- a/libs_source/termux/v7/openjdk-17_17.0-30_arm.deb
+++ b/libs_source/termux/v7/openjdk-17_17.0-30_arm.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5dcfdf0c69da5bd4bce35c3c2cb4736d86d57e755cd43c76f7addc4866937d14
-size 94581788
+oid sha256:1cecfbdfe4a5fb3e2bee4b045dafc0936b9598b3718ea524f393ff80efefe203
+size 90532884

--- a/libs_source/termux/v8/openjdk-17_17.0-30_aarch64.deb
+++ b/libs_source/termux/v8/openjdk-17_17.0-30_aarch64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdd076bee47f26d3134130788c24dc1d1b7fbcff8bbab09590d6dbbfe2791bc1
-size 98081360
+oid sha256:fde2863f8efbcecc87669ca5a86046ee8a49b2a8dc6a6d085080efa78a58959f
+size 94010508


### PR DESCRIPTION
Demo folder refactored to only allocate a README file

This PR addresses issue ADFA-636 by removing the obsolete X11 Java demos from the `openjdk-17.0.deb` packages for both v7 (arm) and v8 (aarch64) architectures. This change significantly reduces the size of these packages, contributing to a smaller overall APK.

**Changes Made:**

  * The `data.tar.xz` component within each `openjdk-17.0.deb` file was modified.
  * The demo directory, previously located at `/data/data/com.itsaky.androidide/files/usr/opt/openjdk-17.0/demo` after installation, has been removed.
  * A `README.txt` file has been added in place of the demos (at `/data/data/com.itsaky.androidide/files/usr/opt/openjdk-17.0/README.txt`). This file informs users that the demos were removed to save space.
  * Ensured the repacked `.deb` files are compatible with `dpkg` by using appropriate `tar` and `ar` flags during the modification process on macOS.

**Reason for Changes:**

The X11 Java demos are large, not essential for the primary functionality, and require X Window System, making them unsuitable for the target environment. Removing them optimizes package size.

**Impact:**

  * Reduced size of the OpenJDK 17 `.deb` packages.
  * Smaller final APK.
  * Users wishing to access the demos can do so via the provided link in the new `README.txt`.

-----

### Note for macOS Users: Modifying .deb Packages

Modifying Debian packages (`.deb` files) on macOS requires specific steps to ensure compatibility and avoid issues caused by macOS-specific file metadata or differences in command-line tools. Here’s a summary of the process used to modify the `openjdk-17.0.deb` package:

**1. Preparation and Unpacking:**

  * Create a working directory.
  * Copy the target `.deb` file (e.g., `openjdk-17_17.0-30_arm.deb`) into it.
  * Extract the components of the `.deb` package using `ar` (the archive utility):
    ```bash
    ar x openjdk-17_17.0-30_arm.deb
    ```
    This will typically extract `debian-binary`, `control.tar.xz`, and `data.tar.xz`.

**2. Modifying Package Contents (Example: `data.tar.xz`):**

  * Create a directory to hold the contents of `data.tar.xz`. Let's call the source directory for tarring `payload_staging_dir`. In this specific OpenJDK case, the archive contained paths like `data/data/com.itsaky.androidide/...`. So, after extracting `data.tar.xz`, the actual files might be inside a top-level directory (e.g. named `data`). You'd then work inside this directory.
    ```bash
    mkdir payload_staging_dir
    tar -xf data.tar.xz -C payload_staging_dir
    ```
  * Navigate into `payload_staging_dir` (or the relevant subdirectory within it, like `payload_staging_dir/data` if paths are nested as `data/data/...`):
      * Modify the contents as needed. For this task, it involved:
          * Deleting the demo directory: `rm -rf ./data/data/com.itsaky.androidide/files/usr/opt/openjdk-17.0/demo` (adjust path based on your extraction).
          * Creating a `README.txt` file in its place: `echo "Demos removed. Find them at [URL]" > ./data/data/com.itsaky.androidide/files/usr/opt/openjdk-17.0/README.txt`.
  * **Crucially, clean up macOS-specific files** from your `payload_staging_dir` before re-tarring:
    ```bash
    find payload_staging_dir -name '.DS_Store' -delete
    find payload_staging_dir -name '._*' -delete # For AppleDouble files, though COPYFILE_DISABLE helps prevent new ones
    ```
    Or manually `rm` them (e.g., `rm payload_staging_dir/data/.DS_Store` etc. as seen in your history).

**3. Re-creating the Tarball (e.g., `data.tar.xz`):**

  * This is a critical step on macOS to ensure compatibility.
  * The `tar` command must be prefixed with `COPYFILE_DISABLE=1` to prevent macOS from adding AppleDouble metadata files (e.g., `._filename`).
  * Specify the `ustar` format using `--format=ustar` to avoid PAX header issues that can make the archive unreadable by some `dpkg` versions.
  * If your modified files are now correctly structured inside `payload_staging_dir` (which itself might contain the `data/data/com.itsaky.androidide/...` path), create the new `data.tar.xz` (let's call it `new_data.tar.xz`):
    ```bash
    # Example: If 'payload_staging_dir' directly contains 'data/data/com.itsaky.androidide/...'
    COPYFILE_DISABLE=1 tar --format=ustar -cJf new_data.tar.xz -C payload_staging_dir .
    ```
      * *(Based on your log: `COPYFILE_DISABLE=1 tar --format=ustar -cJf data5.tar.xz -C data .` where your `data` directory contained the `data/data/com.itsaky.androidide...` structure. You'd then use `data5.tar.xz` as `new_data.tar.xz` below).*

**4. Re-assembling the `.deb` Package:**

  * Ensure you have `debian-binary`, `control.tar.xz` (original or modified and repacked using similar `tar` precautions), and your `new_data.tar.xz`.
  * Use `ar -rc` to create the new `.deb` file. **Do NOT use `-rcs`**, as the `s` flag (which runs `ranlib`) will corrupt the archive for `dpkg` purposes.
    ```bash
    # Assuming new_data.tar.xz is the one you just created
    ar -rc ../openjdk-17_17.0-30_arm_MODIFIED.deb debian-binary control.tar.xz new_data.tar.xz
    ```

**Summary of Key macOS Specifics:**

  * **`COPYFILE_DISABLE=1`**: Prepend to `tar` commands (e.g., `COPYFILE_DISABLE=1 tar ...`).
  * **`tar --format=ustar`**: Use when creating tarballs for the `.deb`.
  * **`ar -rc`**: Use for re-assembling the `.deb`, not `ar -rcs`.
  * **Clean `.DS_Store` / `._*` files**: Remove these from your source directories before tarring.

This process should help avoid common pitfalls like "corrupted filesystem tarfile," "unsupported PAX tar header," or issues with macOS-specific files appearing in the package.
