### PR TITLE
Fix/adfa 675 | Bug new Project creation

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/fragments/TemplateDetailsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/TemplateDetailsFragment.kt
@@ -77,6 +77,7 @@ class TemplateDetailsFragment :
             viewModel.setScreen(MainViewModel.SCREEN_TEMPLATE_LIST)
         }
 
+        // Fix for TemplateDetailsFragment.kt - Modified finish button click listener
         binding.finish.setOnClickListener {
             viewModel.creatingProject.value = true
             val template = viewModel.template.value ?: run {
@@ -115,21 +116,24 @@ class TemplateDetailsFragment :
                     return@executeAsyncProvideError
                 }
 
-                viewModel.setScreen(MainViewModel.SCREEN_MAIN)
-                flashSuccess(string.project_created_successfully)
+                // Store the result for direct opening
+                val projectDir = result.data.projectDir
 
+                // Add to recent projects
                 recentProjectsViewModel.insertProject(
                     RecentProject(
-                        location = result.data.projectDir.path,
+                        location = projectDir.path,
                         name = result.data.name,
                         createdAt = Date().toString()
                     )
                 )
 
-                viewModel.postTransition(viewLifecycleOwner) {
-                    // open the project
-                    (requireActivity() as MainActivity).openProject(result.data.projectDir)
-                }
+                // Flash success message
+                flashSuccess(string.project_created_successfully)
+
+                // Open project directly WITHOUT first returning to main screen
+                // This avoids the screen transition flash
+                (requireActivity() as MainActivity).openProject(projectDir)
             }
         }
 

--- a/app/src/main/java/com/itsaky/androidide/fragments/TemplateDetailsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/TemplateDetailsFragment.kt
@@ -77,7 +77,6 @@ class TemplateDetailsFragment :
             viewModel.setScreen(MainViewModel.SCREEN_TEMPLATE_LIST)
         }
 
-        // Fix for TemplateDetailsFragment.kt - Modified finish button click listener
         binding.finish.setOnClickListener {
             viewModel.creatingProject.value = true
             val template = viewModel.template.value ?: run {
@@ -116,10 +115,8 @@ class TemplateDetailsFragment :
                     return@executeAsyncProvideError
                 }
 
-                // Store the result for direct opening
                 val projectDir = result.data.projectDir
 
-                // Add to recent projects
                 recentProjectsViewModel.insertProject(
                     RecentProject(
                         location = projectDir.path,
@@ -128,11 +125,9 @@ class TemplateDetailsFragment :
                     )
                 )
 
-                // Flash success message
                 flashSuccess(string.project_created_successfully)
 
-                // Open project directly WITHOUT first returning to main screen
-                // This avoids the screen transition flash
+
                 (requireActivity() as MainActivity).openProject(projectDir)
             }
         }

--- a/app/src/main/java/com/itsaky/androidide/fragments/TemplateDetailsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/TemplateDetailsFragment.kt
@@ -116,7 +116,6 @@ class TemplateDetailsFragment :
                 }
 
                 val projectDir = result.data.projectDir
-
                 recentProjectsViewModel.insertProject(
                     RecentProject(
                         location = projectDir.path,
@@ -124,10 +123,7 @@ class TemplateDetailsFragment :
                         createdAt = Date().toString()
                     )
                 )
-
                 flashSuccess(string.project_created_successfully)
-
-
                 (requireActivity() as MainActivity).openProject(projectDir)
             }
         }


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
The `TemplateDetailsFragment` now directly opens the newly created project after successful creation, instead of first transitioning back to the main screen. This avoids a brief screen flash during the transition. The success message is flashed, and the project is added to recent projects before opening.

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->
[Screen_recording_20250508_135122.webm](https://github.com/user-attachments/assets/a1ee8686-02c3-48ae-98ab-68c1e53c00df)

## Ticket

ADFA-675](https://appdevforall.atlassian.net/browse/ADFA-675)

## Observation
<!-- Some important about your code --> 