### PR TITLE
Ensure build script selects v8 APK variant explicitly

### DIFF
--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -89,7 +89,7 @@ jobs:
             ${{ runner.os }}-gradle-deps-
 
       - name: Assemble Universal APK
-        run: ./gradlew :app:assembleDebug --parallel --configure-on-demand
+        run: ./gradlew :app:assembleDebug --parallel --configure-on-demand --stacktrace
         env:
           Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -57,6 +57,9 @@ jobs:
           git submodule init
           git submodule update --remote
 
+      - name: Install CMake
+        run: sudo apt-get update && sudo apt-get install -y cmake
+
       - name: Set up JDKs
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Assemble Universal APK
         run: ./gradlew :app:assembleDebug --parallel --configure-on-demand
         env:
-          Java_ROOT: ${{ env.JAVA_HOME_17_X64 }}
+          JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
 
       - name: Find APK file
         # We need to find the v8 APK specifically

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -85,9 +85,6 @@ jobs:
       - name: Verify cmake installation
         run: cmake --version
 
-      - name: Set CMake path manually
-        run: echo "${ANDROID_HOME}/cmake/3.31.4/bin" >> $GITHUB_PATH
-
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Assemble Universal APK
         run: ./gradlew :app:assembleDebug --parallel --configure-on-demand --stacktrace
         env:
-          Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
+          Java_ROOT: ${{ env.JAVA_HOME_17_X64 }}
 
       - name: Find APK file
         # We need to find the APK since the name is dynamically generated and it does not have a definite location

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Assemble Universal APK
         run: ./gradlew :app:assembleDebug --parallel --configure-on-demand
         env:
-          Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
+          Java_ROOT: ${{ env.JAVA_HOME_17_X64 }}
 
       - name: Find APK file
         # We need to find the v8 APK specifically

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -94,12 +94,16 @@ jobs:
           Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 
       - name: Find APK file
-        # We need to find the APK since the name is dynamically generated and it does not have a definite location
+        # We need to find the v8 APK specifically
         id: find_apk
         run: |
-          apk_path=$(find app/build/outputs/apk/ -type f -name "*.apk" | head -n 1)
+          apk_path=$(find app/build/outputs/apk/ -path "*v8*/debug/*.apk" | head -n 1)
+          if [ -z "$apk_path" ]; then
+            echo "ERROR: Could not find v8 APK"
+            exit 1
+          fi
           echo "APK_PATH=$apk_path" >> $GITHUB_OUTPUT
-          echo "Found APK at: $apk_path"
+          echo "Found v8 APK at: $apk_path"
 
       - name: Set branch name
         run: echo "BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install and Configure Git LFS - Selective pull
         run: |
           sudo apt-get update
-          sudo apt-get install -y git-lfs
+          sudo apt-get install -y git-lfs make
           git lfs install
           git lfs pull
 
@@ -56,13 +56,6 @@ jobs:
         run: |
           git submodule init
           git submodule update --remote
-
-      - name: Install CMake v3.31.4
-        run: |
-          wget --quiet https://github.com/Kitware/CMake/releases/download/v3.31.4/cmake-3.31.4-linux-x86_64.sh
-          chmod +x cmake-3.31.4-linux-x86_64.sh
-          sudo ./cmake-3.31.4-linux-x86_64.sh --skip-license --prefix=/usr/local
-          rm cmake-3.31.4-linux-x86_64.sh
 
       - name: Set up JDKs
         uses: actions/setup-java@v4
@@ -82,8 +75,13 @@ jobs:
       - name: Install Android SDK Platform 35
         run: sdkmanager "platforms;android-35" "build-tools;35.0.0"
 
-      - name: Verify cmake installation
-        run: cmake --version
+      - name: Install CMake
+        run: |
+          echo "Installing CMake from Android SDK..."
+          yes | sdkmanager "cmake;3.31.4"
+          echo "Adding CMake to PATH..."
+          export PATH=$ANDROID_SDK_ROOT/cmake/3.31.4/bin:$PATH
+          cmake --version
 
       - name: Cache Dependencies
         uses: actions/cache@v4
@@ -104,16 +102,12 @@ jobs:
           Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 
       - name: Find APK file
-        # We need to find the v8 APK specifically
+        # We need to find the APK since the name is dynamically generated and it does not have a definite location
         id: find_apk
         run: |
-          apk_path=$(find app/build/outputs/apk/ -path "*v8*/debug/*.apk" | head -n 1)
-          if [ -z "$apk_path" ]; then
-            echo "ERROR: Could not find v8 APK"
-            exit 1
-          fi
+          apk_path=$(find app/build/outputs/apk/ -type f -name "*.apk" | head -n 1)
           echo "APK_PATH=$apk_path" >> $GITHUB_OUTPUT
-          echo "Found v8 APK at: $apk_path"
+          echo "Found APK at: $apk_path"
 
       - name: Set branch name
         run: echo "BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install and Configure Git LFS - Selective pull
         run: |
           sudo apt-get update
-          sudo apt-get install -y git-lfs make
+          sudo apt-get install -y git-lfs
           git lfs install
           git lfs pull
 
@@ -57,7 +57,7 @@ jobs:
           git submodule init
           git submodule update --remote
 
-      - name: Install CMake v3.31.4 or later
+      - name: Install CMake v3.31.4
         run: |
           wget --quiet https://github.com/Kitware/CMake/releases/download/v3.31.4/cmake-3.31.4-linux-x86_64.sh
           chmod +x cmake-3.31.4-linux-x86_64.sh
@@ -80,24 +80,10 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Install Android SDK Platform 35
-        run: sdkmanager "platforms;android-35" "build-tools;35.0.0" "cmake;3.31.4"
+        run: sdkmanager "platforms;android-35" "build-tools;35.0.0"
 
       - name: Verify cmake installation
         run: cmake --version
-
-      - name: Patch jdi-support.jar location
-        run: |
-            echo "Searching for jdi-support.jar..."
-            found_path=$(find subprojects/libjdwp/.cmake -name jdi-support.jar | head -n 1)
-            if [ -f "$found_path" ]; then
-              echo "Found at: $found_path"
-              mkdir -p subprojects/libjdwp/build/libs/
-              cp "$found_path" subprojects/libjdwp/build/libs/jdi-support.jar
-              echo "Copied to subprojects/libjdwp/build/libs/jdi-support.jar"
-            else
-              echo "❌ jdi-support.jar not found!"
-              exit 1
-            fi
 
       - name: Cache Dependencies
         uses: actions/cache@v4

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -45,12 +45,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install and Configure Git LFS - Selective pull
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git-lfs make
-          git lfs install
-          git lfs pull
 
       - name: Initialize submodules
         run: |
@@ -65,6 +59,13 @@ jobs:
           java-version: |
             8
             17
+
+      - name: Install and Configure Git LFS - Selective pull
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-lfs make
+          git lfs install
+          git lfs pull
 
       - name: Install unzip
         run: sudo apt-get update && sudo apt-get install -y unzip
@@ -101,7 +102,7 @@ jobs:
       - name: Assemble Universal APK
         run: ./gradlew :app:assembleDebug --parallel --configure-on-demand --stacktrace
         env:
-          Java_ROOT: ${{ env.JAVA_HOME_17_X64 }}
+          Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 
       - name: Find APK file
         # We need to find the APK since the name is dynamically generated and it does not have a definite location

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -60,6 +60,10 @@ jobs:
             8
             17
 
+      - name: Set Java_ROOT environment variable
+        run: |
+          echo "Java_ROOT=$JAVA_HOME_8_X64" >> $GITHUB_ENV
+
       - name: Install and Configure Git LFS - Selective pull
         run: |
           sudo apt-get update
@@ -100,7 +104,7 @@ jobs:
             ${{ runner.os }}-gradle-deps-
 
       - name: Assemble Universal APK
-        run: ./gradlew :app:assembleDebug --parallel --configure-on-demand --stacktrace
+        run: ./gradlew :app:assembleDebug --parallel --configure-on-demand --stacktrace -Dorg.gradle.java.home=$Java_ROOT
         env:
           Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -85,6 +85,20 @@ jobs:
       - name: Verify cmake installation
         run: cmake --version
 
+      - name: Patch jdi-support.jar location
+        run: |
+            echo "Searching for jdi-support.jar..."
+            found_path=$(find subprojects/libjdwp/.cmake -name jdi-support.jar | head -n 1)
+            if [ -f "$found_path" ]; then
+              echo "Found at: $found_path"
+              mkdir -p subprojects/libjdwp/build/libs/
+              cp "$found_path" subprojects/libjdwp/build/libs/jdi-support.jar
+              echo "Copied to subprojects/libjdwp/build/libs/jdi-support.jar"
+            else
+              echo "❌ jdi-support.jar not found!"
+              exit 1
+            fi
+
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Set Java_ROOT environment variable
         run: |
           echo "Java_ROOT=$JAVA_HOME_8_X64" >> $GITHUB_ENV
+          echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
 
       - name: Install and Configure Git LFS - Selective pull
         run: |
@@ -104,12 +105,11 @@ jobs:
             ${{ runner.os }}-gradle-deps-
 
       - name: Assemble Universal APK
-        run: ./gradlew :app:assembleDebug --parallel --configure-on-demand --stacktrace -Dorg.gradle.java.home=$Java_ROOT
+        run: ./gradlew :app:assembleDebug --parallel --configure-on-demand --stacktrace
         env:
           Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 
       - name: Find APK file
-        # We need to find the APK since the name is dynamically generated and it does not have a definite location
         id: find_apk
         run: |
           apk_path=$(find app/build/outputs/apk/ -type f -name "*.apk" | head -n 1)

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -75,6 +75,12 @@ jobs:
       - name: Install Android SDK Platform 35
         run: sdkmanager "platforms;android-35" "build-tools;35.0.0" "cmake;3.31.4"
 
+      - name: Verify cmake installation
+        run: cmake --version
+
+      - name: Set CMake path manually
+        run: echo "${ANDROID_HOME}/cmake/3.31.4/bin" >> $GITHUB_PATH
+
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -88,6 +88,12 @@ jobs:
       - name: Install Android SDK Platform 35
         run: sdkmanager "platforms;android-35" "build-tools;35.0.0" "cmake;3.31.4"
 
+      - name: Verify CMake version
+        run: |
+          cmake --version
+          which cmake
+          echo "CMake path: $(which cmake)"
+
       - name: Set Java_ROOT environment variable
         run: echo "Java_ROOT=$JAVA_HOME_8_X64" >> $GITHUB_ENV
 
@@ -105,7 +111,8 @@ jobs:
             ${{ runner.os }}-gradle-deps-
 
       - name: Run failing task with debug output
-        run: ./gradlew :subprojects:libjdwp:collectLibJdiSupport -DJava_ROOT=${{ env.JAVA_HOME_8_X64 }}
+        run: |
+          ./gradlew :subprojects:libjdwp:build
         env:
           Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -45,6 +45,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install and Configure Git LFS - Selective pull
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-lfs make
+          git lfs install
+          git lfs pull
 
       - name: Initialize submodules
         run: |
@@ -60,18 +66,6 @@ jobs:
             8
             17
 
-      - name: Set Java_ROOT environment variable
-        run: |
-          echo "Java_ROOT=$JAVA_HOME_8_X64" >> $GITHUB_ENV
-          echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
-
-      - name: Install and Configure Git LFS - Selective pull
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git-lfs make
-          git lfs install
-          git lfs pull
-
       - name: Install unzip
         run: sudo apt-get update && sudo apt-get install -y unzip
 
@@ -81,15 +75,8 @@ jobs:
       - name: Install Android SDK Platform 35
         run: sdkmanager "platforms;android-35" "build-tools;35.0.0" "cmake;3.31.4"
 
-      - name: Verify CMake installation
-        run: |
-          if command -v cmake >/dev/null; then
-            echo "CMake is installed"
-            cmake --version
-          else
-            echo "CMake is not installed" >&2
-            exit 1
-          fi
+      - name: Set Java_ROOT environment variable
+        run: echo "Java_ROOT=$JAVA_HOME_8_X64" >> $GITHUB_ENV
 
       - name: Cache Dependencies
         uses: actions/cache@v4
@@ -105,11 +92,12 @@ jobs:
             ${{ runner.os }}-gradle-deps-
 
       - name: Assemble Universal APK
-        run: ./gradlew :app:assembleDebug --parallel --configure-on-demand --stacktrace
+        run: ./gradlew :app:assembleDebug --parallel --configure-on-demand -DJava_ROOT=${{ env.JAVA_HOME_8_X64 }}
         env:
           Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 
       - name: Find APK file
+        # We need to find the APK since the name is dynamically generated and it does not have a definite location
         id: find_apk
         run: |
           apk_path=$(find app/build/outputs/apk/ -type f -name "*.apk" | head -n 1)

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Assemble Universal APK
         run: ./gradlew :app:assembleDebug --parallel --configure-on-demand
         env:
-          JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
+          Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 
       - name: Find APK file
         # We need to find the v8 APK specifically

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -105,7 +105,7 @@ jobs:
             ${{ runner.os }}-gradle-deps-
 
       - name: Run failing task with debug output
-        run: ./gradlew :subprojects:libjdwp:collectLibJdiSupport --debug --stacktrace -DJava_ROOT=${{ env.JAVA_HOME_8_X64 }}
+        run: ./gradlew :subprojects:libjdwp:collectLibJdiSupport -DJava_ROOT=${{ env.JAVA_HOME_8_X64 }}
         env:
           Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -75,6 +75,16 @@ jobs:
       - name: Install Android SDK Platform 35
         run: sdkmanager "platforms;android-35" "build-tools;35.0.0" "cmake;3.31.4"
 
+      - name: Verify CMake installation
+        run: |
+          if command -v cmake >/dev/null; then
+            echo "CMake is installed"
+            cmake --version
+          else
+            echo "CMake is not installed" >&2
+            exit 1
+          fi
+
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -51,11 +51,24 @@ jobs:
           sudo apt-get install -y git-lfs make
           git lfs install
           git lfs pull
+          # Verify LFS files are properly pulled
+          echo "=== Checking Git LFS status ==="
+          git lfs ls-files -l | grep -v '(-)' || echo "No LFS files found"
+          # Check specific directories that might contain binary files
+          echo "=== Looking for binary files in oj-libjdwp ==="
+          find oj-libjdwp -type f -size +1M -ls || echo "No large files found"
 
       - name: Initialize submodules
         run: |
+          echo "=== Initializing submodules ==="
           git submodule init
           git submodule update --remote
+          echo "=== Submodule status ==="
+          git submodule status
+          echo "=== Checking oj-libjdwp directory ==="
+          ls -la oj-libjdwp
+          echo "=== Checking key files in oj-libjdwp ==="
+          find oj-libjdwp -name "*.jar" -o -name "CMakeLists.txt" -o -name "*.cmake"
 
       - name: Set up JDKs
         uses: actions/setup-java@v4
@@ -91,8 +104,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-deps-
 
+      - name: Run failing task with debug output
+        run: ./gradlew :subprojects:libjdwp:collectLibJdiSupport --debug --stacktrace -DJava_ROOT=${{ env.JAVA_HOME_8_X64 }}
+        env:
+          Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
+
+      - name: Check CMake build directories
+        run: |
+          echo "=== Looking for jdi-support.jar in .cmake directory ==="
+          find . -name "jdi-support.jar" -ls || echo "jdi-support.jar not found"
+          echo "=== Content of .cmake directory ==="
+          find subprojects/libjdwp/.cmake -type f -name "*.log" -o -name "*.jar" -ls || echo "No log or jar files found"
+          echo "=== CMake logs if available ==="
+          find subprojects/libjdwp/.cmake -name "*.log" -exec cat {} \; || echo "No log files found"
+        continue-on-error: true
+
       - name: Assemble Universal APK
-        run: ./gradlew :app:assembleDebug --parallel --configure-on-demand -DJava_ROOT=${{ env.JAVA_HOME_8_X64 }}
+        run: ./gradlew :app:assembleDebug --parallel --configure-on-demand --info -DJava_ROOT=${{ env.JAVA_HOME_8_X64 }}
         env:
           Java_ROOT: ${{ env.JAVA_HOME_8_X64 }}
 

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -73,15 +73,7 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Install Android SDK Platform 35
-        run: sdkmanager "platforms;android-35" "build-tools;35.0.0"
-
-      - name: Install CMake
-        run: |
-          echo "Installing CMake from Android SDK..."
-          yes | sdkmanager "cmake;3.31.4"
-          echo "Adding CMake to PATH..."
-          export PATH=$ANDROID_SDK_ROOT/cmake/3.31.4/bin:$PATH
-          cmake --version
+        run: sdkmanager "platforms;android-35" "build-tools;35.0.0" "cmake;3.31.4"
 
       - name: Cache Dependencies
         uses: actions/cache@v4

--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -57,8 +57,12 @@ jobs:
           git submodule init
           git submodule update --remote
 
-      - name: Install CMake
-        run: sudo apt-get update && sudo apt-get install -y cmake
+      - name: Install CMake v3.31.4 or later
+        run: |
+          wget --quiet https://github.com/Kitware/CMake/releases/download/v3.31.4/cmake-3.31.4-linux-x86_64.sh
+          chmod +x cmake-3.31.4-linux-x86_64.sh
+          sudo ./cmake-3.31.4-linux-x86_64.sh --skip-license --prefix=/usr/local
+          rm cmake-3.31.4-linux-x86_64.sh
 
       - name: Set up JDKs
         uses: actions/setup-java@v4


### PR DESCRIPTION
Previously, the script could pick up the v7 APK due to directory order,
causing confusion or incorrect builds. This update filters for the v8
debug APK to align with our current deployment and testing targets.