### PR TITLE
ADFA-471 | DS_store files removed

### DIFF
--- a/libs_source/termux/v7/openjdk-17_17.0-30_arm.deb
+++ b/libs_source/termux/v7/openjdk-17_17.0-30_arm.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1cecfbdfe4a5fb3e2bee4b045dafc0936b9598b3718ea524f393ff80efefe203
-size 90532884
+oid sha256:b77962d914904ad73efa17b276958ffd434a6fd2e6a244c1f51e598a1856fb64
+size 90525664

--- a/libs_source/termux/v8/openjdk-17_17.0-30_aarch64.deb
+++ b/libs_source/termux/v8/openjdk-17_17.0-30_aarch64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fde2863f8efbcecc87669ca5a86046ee8a49b2a8dc6a6d085080efa78a58959f
-size 94010508
+oid sha256:220388446a71b9e4b3bf47425d2b2215c8aa67832cced31c5df7b0e63ef02d1c
+size 94000968


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
the .DS_Store file has been removed from the demo/ directory.
Additionally, minor checksum and size changes were committed to the openjdk-17 .deb files under libs_source/termux/v7 and v8, likely due to re-packaging or a rebuild. No functional changes introduced.

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->


## Ticket
[ADFA-471](https://appdevforall.atlassian.net/browse/ADFA-471)

## Observation
<!-- Some important about your code --> 

