### PR TITLE
ADFA-380 | Set tabGravity to start for TabLayout

### DIFF
--- a/resources/src/main/res/values/styles.xml
+++ b/resources/src/main/res/values/styles.xml
@@ -74,6 +74,7 @@
     <item name="tabIndicatorGravity">bottom</item>
     <item name="tabIndicatorHeight">3dp</item>
     <item name="tabMode">scrollable</item>
+    <item name="tabGravity">start</item>
     <!-- Increase tab's width according to its title -->
     <item name="tabMaxWidth">0px</item>
     <!-- Make icons appear inline with tab's title -->


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
The `tabGravity` attribute is set to `start` for `AppTabLayout` style. This ensures tabs are aligned to the start of the `TabLayout` when in scrollable mode, fixing the Warn problem in MODE_SCROLLABLE + GRAVITY_FILL is not supported, GRAVITY_START will be used instead.

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->

## Ticket
[ADFA-380](https://appdevforall.atlassian.net/browse/ADFA-380)

## Observation
<!-- Some important about your code --> 

