### PR TITLE
ADFA-885 upgrading the fallback JIRA_URL for release notes in Firebase

### DIFF
--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -145,7 +145,7 @@ jobs:
             JIRA_URL="https://appdevforall.atlassian.net/browse/${JIRA_TICKET}"
           else
             JIRA_TICKET="N/A"
-            JIRA_URL="#"
+            JIRA_URL="https://github.com/${{ github.repository }}/commit/${{ github.sha }} (Ref: ${{ github.ref }})"
           fi
 
           echo "JIRA_TICKET=$JIRA_TICKET" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Make the APK more discoverable with:
${{ github.repository }}
${{ github.sha }}
${{ github.ref }}
