### PR TITLE
ADFA-550 | Debugger lifecycle management

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/lsp/IDEDebugClientImpl.kt
+++ b/app/src/main/java/com/itsaky/androidide/lsp/IDEDebugClientImpl.kt
@@ -13,6 +13,7 @@ import com.itsaky.androidide.lsp.debug.model.PositionalBreakpoint
 import com.itsaky.androidide.lsp.debug.model.ResumePolicy
 import com.itsaky.androidide.lsp.debug.model.Source
 import com.itsaky.androidide.lsp.debug.model.ThreadListRequestParams
+import com.itsaky.androidide.services.debug.DebuggerService
 import com.itsaky.androidide.viewmodel.DebuggerViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -97,6 +98,8 @@ object IDEDebugClientImpl : IDebugClient, IDebugEventHandler {
 
         state = state.copy(clients = state.clients + client)
 
+        DebuggerService.currentInstance()?.markClientConnected()
+
         clientScope.launch {
             client.adapter.addBreakpoints(
                 BreakpointRequest(
@@ -115,5 +118,10 @@ object IDEDebugClientImpl : IDebugClient, IDebugEventHandler {
     override fun onDisconnect(client: RemoteClient) = stateGuard.write {
         logger.debug("onDisconnect: client={}", client)
         state = state.copy(clients = state.clients - client)
+
+        if (state.clients.isEmpty()) {
+            DebuggerService.currentInstance()?.stopSelf()
+        }
     }
+
 }

--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/JavaDebugAdapter.kt
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/JavaDebugAdapter.kt
@@ -127,7 +127,6 @@ internal class JavaDebugAdapter : IDebugAdapter, EventConsumer, AutoCloseable {
             // TODO: Maybe add support for debugging multiple VMs?
             throw UnsupportedOperationException("Debugging multiple VMs is not supported yet")
         }
-
         val vmCanBeModified = vm.canBeModified()
         val client = RemoteClient(
             adapter = this,
@@ -419,6 +418,7 @@ internal class JavaDebugAdapter : IDebugAdapter, EventConsumer, AutoCloseable {
     }
 
     override fun close() {
+        logger.debug("Closing JavaDebugAdapter...")
         try {
             _listenerState?.stopListening()
             listenerThread?.interrupt()
@@ -436,6 +436,7 @@ internal class JavaDebugAdapter : IDebugAdapter, EventConsumer, AutoCloseable {
                 vms.remove(vm)
             }
         }
+        logger.debug("JavaDebugAdapter closed successfully.")
     }
 
     private fun ResumePolicy.doResume(


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
Refactor: Improve DebuggerService lifecycle and resource management

This commit introduces several improvements to the `DebuggerService`:

- **Client Connection Tracking:**
    - The `IDEDebugClientImpl` now informs `DebuggerService` upon client connection.
    - If no clients connect, the `DebuggerService` will now automatically shut down after a timeout (currently 2 minutes).
    - The service also stops itself when the last client disconnects.
- **Resource Cleanup:**
    - The `JavaDebugAdapter` now implements `AutoCloseable` and its `close()` method is called when `DebuggerService` is destroyed, ensuring proper cleanup of resources like the listener thread and VMs.
    - Logging has been added to `JavaDebugAdapter.close()` for better visibility into the closing process.
- **Instance Access:**
    - `DebuggerService` now provides a static `currentInstance()` method for easier access to the running service instance.

These changes enhance the robustness and resource efficiency of the debugging system.

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->

## Ticket
[ADFA-550](https://appdevforall.atlassian.net/browse/ADFA-550)

## Observation
<!-- Some important about your code --> 



https://github.com/user-attachments/assets/5c986160-791a-44c5-9874-261bfbb7dcb4



[ADFA-550]: https://appdevforall.atlassian.net/browse/ADFA-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ