### PR TITLE
ADFA-550 |UI-refresh-breakpoints

### DIFF
--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
@@ -17,7 +17,6 @@
 
 package io.github.rosemoe.sora.editor.ts
 
-import android.graphics.Color
 import com.itsaky.androidide.syntax.colorschemes.SchemeAndroidIDE
 import com.itsaky.androidide.treesitter.TSInputEdit
 import com.itsaky.androidide.treesitter.TSQueryCursor
@@ -34,7 +33,6 @@ import io.github.rosemoe.sora.lang.styling.Styles
 import io.github.rosemoe.sora.lang.styling.line.LineBackground
 import io.github.rosemoe.sora.lang.styling.line.LineGutterBackground
 import io.github.rosemoe.sora.text.ContentReference
-import io.github.rosemoe.sora.widget.CodeEditor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -139,6 +137,7 @@ class TsAnalyzeWorker(
       styles.lineStyles?.forEach { style ->
           style.eraseStyle(LineGutterBackground::class.java)
       }
+      refreshLineStyles()
   }
 
   fun toggleBreakpoint(line: Int, addOnly: Boolean = false, removeOnly: Boolean = false) {
@@ -161,8 +160,7 @@ class TsAnalyzeWorker(
     }
 
     if (notify) {
-      styles.finishBuilding()
-      stylesReceiver?.setStyles(analyzer, styles)
+      refreshLineStyles()
     }
   }
 
@@ -173,7 +171,7 @@ class TsAnalyzeWorker(
       styles.addLineStyle(LineBackground(line) { scheme ->
         scheme.getColor(SchemeAndroidIDE.BREAKPOINT_LINE_BG)
       })
-      stylesReceiver?.setStyles(this.analyzer, styles)
+      refreshLineStyles()
     }
   }
 
@@ -181,7 +179,16 @@ class TsAnalyzeWorker(
     styles.lineStyles?.forEach { style ->
       style.eraseStyle(LineBackground::class.java)
     }
-    stylesReceiver?.setStyles(this.analyzer, styles)
+    refreshLineStyles()
+  }
+
+  private fun refreshLineStyles() {
+    // We can call styles.finishBuilding() instead of sorting lineStyles manually
+    // but finishBuilding() performs some unnecessary tasks like iterating over and sorting
+    // blockLines as well, which we don't need to do here
+    // As a result, we manually sort the line styles to avoid that unnecessary processing
+    styles.lineStyles?.sort()
+    stylesReceiver?.setStyles(analyzer, styles)
   }
 
   private fun processNextMessage() {

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
@@ -34,6 +34,7 @@ import io.github.rosemoe.sora.lang.styling.Styles
 import io.github.rosemoe.sora.lang.styling.line.LineBackground
 import io.github.rosemoe.sora.lang.styling.line.LineGutterBackground
 import io.github.rosemoe.sora.text.ContentReference
+import io.github.rosemoe.sora.widget.CodeEditor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -160,9 +161,13 @@ class TsAnalyzeWorker(
     }
 
     if (notify) {
-        // calling updateStyles does a lot of unnecessary work
-        // instead, just reset the same styles to the receiver
-        stylesReceiver?.setStyles(analyzer, styles)
+      // Mark styles ready for rendering
+      styles.finishBuilding()
+
+      // Call setStyles with UI invalidation as pre-action
+      stylesReceiver?.setStyles(analyzer, styles) {
+        (stylesReceiver as? CodeEditor)?.invalidate()
+      }
     }
   }
 

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
@@ -161,13 +161,8 @@ class TsAnalyzeWorker(
     }
 
     if (notify) {
-      // Mark styles ready for rendering
       styles.finishBuilding()
-
-      // Call setStyles with UI invalidation as pre-action
-      stylesReceiver?.setStyles(analyzer, styles) {
-        (stylesReceiver as? CodeEditor)?.invalidate()
-      }
+      stylesReceiver?.setStyles(analyzer, styles)
     }
   }
 


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->
The solution avoids updateStyles() (heavy). Also, Avoids unnecessary recomputation and uses the safe Runnable hook on setStyles(...) to ensures CodeEditor.invalidate() happens at the right time, while also ensuring that the Styles object is properly marked as finalized before the invalidation occurs.

## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->

https://github.com/user-attachments/assets/d71cd073-ba92-4258-82a9-82503037ab72

## Ticket
[ADFA-550](https://appdevforall.atlassian.net/browse/ADFA-550)

## Observation
<!-- Some important about your code --> 

[ADFA-550]: https://appdevforall.atlassian.net/browse/ADFA-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ