### PR TITLE
ADFA-927 brotli compression of local maven repo, android sdk and gradle bin blobs

### DIFF
--- a/.github/workflows/deploy-to-firestore-app-distribution.yml
+++ b/.github/workflows/deploy-to-firestore-app-distribution.yml
@@ -72,11 +72,6 @@ jobs:
         if: env.nix_installed == 'false'
         uses: flox/install-flox-action@v2
 
-      - name: Disable SPLIT_ASSETS in CI
-        run: |
-          sed -i 's/const val SPLIT_ASSETS = \/\* false \*\/ true/const val SPLIT_ASSETS = \/\* false \*\/ false/' ./composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
-
-
       - name: Assemble Universal APK
         run: |
           flox activate -d flox/base -- ./gradlew :app:assembleV8Debug --no-daemon

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -238,6 +238,9 @@ dependencies {
 
   androidTestImplementation(libs.tests.androidx.test.runner)
 
+  // brotli
+  implementation(libs.common.orgbrotli.dec)
+
 }
 
 

--- a/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
@@ -344,7 +344,7 @@ class OnboardingActivity : AppIntro2() {
             ZipUtils.unzipFile(mavenZipFile, outputDirectory)
             mavenZipFile.delete()
 
-            if (SPLIT_ASSETS) {
+            if (!SPLIT_ASSETS) {
                 mavenBrotliFile.delete()
             }
 

--- a/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
@@ -344,7 +344,7 @@ class OnboardingActivity : AppIntro2() {
             ZipUtils.unzipFile(mavenZipFile, outputDirectory)
             mavenZipFile.delete()
 
-            if (!SPLIT_ASSETS) {
+            if (SPLIT_ASSETS) {
                 mavenBrotliFile.delete()
             }
 

--- a/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
@@ -56,11 +56,15 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.withContext
 import org.adfa.constants.ANDROID_SDK_ZIP
+import org.adfa.constants.ANDROID_SDK_ZIP_BR
 import org.adfa.constants.DESTINATION_ANDROID_SDK
 import org.adfa.constants.DOCUMENTATION_DB
+import org.adfa.constants.GRADLE_WRAPPER_FILE_NAME
+import org.adfa.constants.GRADLE_WRAPPER_FILE_NAME_BR
 import org.adfa.constants.HOME_PATH
 import org.adfa.constants.LOCAL_MAVEN_CACHES_DEST
 import org.adfa.constants.LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME
+import org.adfa.constants.LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME_BR
 import org.adfa.constants.LOCAL_SOURCE_AGP_8_0_0_CACHES
 import org.adfa.constants.LOCAL_SOURCE_ANDROID_SDK
 import org.adfa.constants.LOCAL_SOURCE_TERMUX_LIB_FOLDER_NAME
@@ -69,6 +73,10 @@ import org.adfa.constants.SPLIT_ASSETS
 import org.adfa.constants.TERMUX_DEBS_PATH
 import java.io.File
 import java.io.IOException
+import java.io.FileInputStream
+import java.io.FileOutputStream
+
+import org.brotli.dec.BrotliInputStream;
 
 class OnboardingActivity : AppIntro2() {
 
@@ -268,6 +276,8 @@ class OnboardingActivity : AppIntro2() {
             File(application.filesDir.path + File.separator + DESTINATION_ANDROID_SDK)
         val zipFile =
             File(application.filesDir.path + File.separator + DESTINATION_ANDROID_SDK + File.separator + ANDROID_SDK_ZIP)
+        val brotliFile =
+            File(application.filesDir.path + File.separator + DESTINATION_ANDROID_SDK + File.separator + ANDROID_SDK_ZIP_BR)
         if (!outputDirectory.exists()) {
             outputDirectory.mkdirs()
         }
@@ -280,11 +290,27 @@ class OnboardingActivity : AppIntro2() {
                     ToolsManager.getCommonAsset(LOCAL_SOURCE_ANDROID_SDK),
                     outputDirectory.path
                 )
+
+                if (!brotliFile.exists()) {
+                    Log.e("OnboardingActivityInstall", "Brotli file ${brotliFile.path} doesn't exist!")
+                }
+
+                decompressBrotli(brotliFile.path, zipFile.path)
+                if (!zipFile.exists()) {
+                    Log.e("OnboardingActivityInstall", "Brotli decompression of ${brotliFile.path} failed!")
+                }
+
             }
+
             ZipUtils.unzipFile(zipFile, outputDirectory)
             zipFile.delete()
+
+            if (!SPLIT_ASSETS) {
+                brotliFile.delete()
+            }
+
         } catch (e: IOException) {
-            println("Android SDK copy failed + ${e.message}")
+            Log.e("OnboardingActivityInstall", "Android SDK copy failed: ${e.message}")
         }
     }
 
@@ -293,6 +319,8 @@ class OnboardingActivity : AppIntro2() {
             File(application.filesDir.path + File.separator + LOCAL_MAVEN_CACHES_DEST)
         val mavenZipFile =
             File("$outputDirectory${File.separator}$LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME")
+        val mavenBrotliFile =
+            File("$outputDirectory${File.separator}$LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME_BR")
         if (!outputDirectory.exists()) {
             outputDirectory.mkdirs()
         }
@@ -305,36 +333,73 @@ class OnboardingActivity : AppIntro2() {
                     ToolsManager.getCommonAsset(LOCAL_SOURCE_AGP_8_0_0_CACHES),
                     outputDirectory.path
                 )
+
+                decompressBrotli(mavenBrotliFile.path, mavenZipFile.path)
+                if (!mavenZipFile.exists()) {
+                    Log.e("OnboardingActivityInstall", "Brotli decompression of ${mavenBrotliFile.path} failed!")
+                }
+
             }
 
             ZipUtils.unzipFile(mavenZipFile, outputDirectory)
             mavenZipFile.delete()
+
+            if (SPLIT_ASSETS) {
+                mavenBrotliFile.delete()
+            }
+
         } catch (e: IOException) {
-            println("Android Gradle caches copy failed + ${e.message}")
+            Log.e("OnboardingActivityInstall", "Android Gradle caches copy failed: ${e.message}")
         }
     }
 
     private fun copyGradleDists() {
 
         try {
-            val binToCopy = arrayOf("gradle-8.7-bin.zip")
-            for (binFile in binToCopy) {
-                val outputDirectory =
-                    File(Environment.GRADLE_DISTS.absolutePath)
-                if (!outputDirectory.exists()) {
-                    outputDirectory.mkdirs()
-                }
-                if (SPLIT_ASSETS) {
-                    ZipUtils.unzipFileByKeyword(Environment.SPLIT_ASSETS_ZIP, outputDirectory, binFile)
-                } else {
-                    ResourceUtils.copyFileFromAssets(
-                        ToolsManager.getCommonAsset(binFile),
-                        outputDirectory.resolve(binFile).absolutePath
-                    )
-                }
+            val outputDirectory =
+                File(Environment.GRADLE_DISTS.absolutePath)
+            if (!outputDirectory.exists()) {
+                outputDirectory.mkdirs()
             }
+
+            val brotliFile = outputDirectory.resolve(GRADLE_WRAPPER_FILE_NAME_BR)
+            val zipFile = outputDirectory.resolve(GRADLE_WRAPPER_FILE_NAME)
+
+            if (SPLIT_ASSETS) {
+                ZipUtils.unzipFileByKeyword(Environment.SPLIT_ASSETS_ZIP, outputDirectory, GRADLE_WRAPPER_FILE_NAME)
+            } else {
+                ResourceUtils.copyFileFromAssets(
+                    ToolsManager.getCommonAsset(GRADLE_WRAPPER_FILE_NAME_BR),
+                    brotliFile.absolutePath
+                )
+
+                decompressBrotli(brotliFile.absolutePath, zipFile.absolutePath)
+
+                if (!zipFile.exists()) {
+                    Log.e("OnboardingActivityInstall", "Brotli decompression of ${brotliFile.path} failed!")
+                }
+
+                // copy duplicate kotlin embeddable jar to local maven repo
+                val kotlin_embed_jar = "lib/kotlin-compiler-embeddable-1.9.22.jar"
+                Log.d("OnboardingActivityInstall", "Copying $kotlin_embed_jar to ${zipFile.parentFile?.path}")
+                ZipUtils.unzipFileByKeyword(zipFile, zipFile.parentFile, kotlin_embed_jar)
+                val jarSrc = File("${zipFile.parentFile?.path}/gradle-8.7/${kotlin_embed_jar}")
+                val jarDest = File("${application.filesDir.path}/$LOCAL_MAVEN_CACHES_DEST/" +
+                        "localMvnRepository/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.9.22/${jarSrc.name}")
+                if (jarSrc.exists()) {
+                    Log.d("OnboardingActivityInstall", "Copying ${jarSrc.path} to ${jarDest.path}")
+                    jarSrc.copyTo(jarDest, overwrite = true)
+                    // delete source jar and parent folder
+                    zipFile.parentFile.resolve("gradle-8.7").deleteRecursively()
+                } else {
+                    Log.e("OnboardingActivityInstall", "${jarSrc.absolutePath} does not exist!")
+                }
+
+                brotliFile.delete()
+            }
+
         } catch (e: IOException) {
-            println("Gradle Dists copy failed + ${e.message}")
+            Log.e("OnboardingActivityInstall", "Gradle Dists copy failed: ${e.message}")
         }
     }
 
@@ -378,7 +443,7 @@ class OnboardingActivity : AppIntro2() {
                 Environment.TOOLING_API_JAR.absolutePath
             )
         } catch (e: IOException) {
-            println("Tooling API jar copy failed + ${e.message}")
+            Log.e("OnboardingActivityInstall", "Tooling API jar copy failed: ${e.message}")
         }
     }
 
@@ -477,4 +542,21 @@ class OnboardingActivity : AppIntro2() {
 
     private fun archConfigExperimentalWarningIsShown() =
         prefManager.getBoolean(KEY_ARCHCONFIG_WARNING_IS_SHOWN, false)
+
+    private fun decompressBrotli(inputPath: String, outputPath: String) {
+        FileInputStream(inputPath).use { input ->
+            BrotliInputStream(input).use { brotliIn ->
+                FileOutputStream(outputPath).use { output ->
+                    val buffer = ByteArray(1024 * 1024) // 1Mb buffer
+                    var bytesRead: Int
+
+                    while (brotliIn.read(buffer).also { bytesRead = it } != -1) {
+                        output.write(buffer, 0, bytesRead)
+                    }
+
+                }
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -621,9 +621,6 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
     }
 
     private fun handleUiDesignerResult(result: ActivityResult) {
-        if (this is EditorHandlerActivity) {
-            this.closeCurrentFile()
-        }
         if (result.resultCode != RESULT_OK || result.data == null) {
             log.warn(
                 "UI Designer returned invalid result: resultCode={}, data={}", result.resultCode,

--- a/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
+++ b/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
@@ -27,7 +27,7 @@ import java.io.File
  * Moved from template-api in case of a roor repo merge we have to manuall move changes here.
  */
 
-// TODO: get value from BuildConfig.DEBUG -- jm 2025-05-28
+// TODO: get the value from BuildConfig.DEBUG -- jm 2025-05-28
 //       import com.itsaky.androidide.BuildConfig
 const val SPLIT_ASSETS = /* false */ true
 

--- a/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
+++ b/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
@@ -49,6 +49,7 @@ const val SOURCE_LIB_FOLDER = "libs_source"
 const val HOME_PATH = "home"
 const val ANDROID_SDK_PATH = "android-sdk"
 const val ANDROID_SDK_ZIP = "android-sdk.zip"
+const val ANDROID_SDK_ZIP_BR = "$ANDROID_SDK_ZIP.br"
 const val USR = "usr"
 
 // Gradle folder
@@ -62,7 +63,9 @@ const val LOCAL_COMPOSE_GRADLE_DISTRIBUTION_VERSION = "8.7"
 const val GRADLE_VERSION = "gradle-$LOCAL_GRADLE_DISTRIBUTION_VERSION"
 const val COMPOSE_GRADLE_VERSION = "gradle-$LOCAL_COMPOSE_GRADLE_DISTRIBUTION_VERSION"
 const val GRADLE_WRAPPER_FILE_NAME = "$GRADLE_VERSION-bin.zip"
+const val GRADLE_WRAPPER_FILE_NAME_BR = "$GRADLE_WRAPPER_FILE_NAME.br"
 const val COMPOSE_GRADLE_WRAPPER_FILE_NAME = "$COMPOSE_GRADLE_VERSION-bin.zip"
+const val COMPOSE_GRADLE_WRAPPER_FILE_NAME_BR = "$COMPOSE_GRADLE_WRAPPER_FILE_NAME.br"
 val GRADLE_WRAPPER_PATH_SUFFIX = GRADLE_FOLDER_NAME + File.separator + "wrapper" + File.separator
 
 // AGP
@@ -130,6 +133,7 @@ const val LOCAL_SOURCE_AGP_8_5_1_CACHES = "files-2.1-8.5.1/files-2.1"
 
 //Local maven repo
 const val LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME = "localMvnRepository.zip"
+const val LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME_BR = "${LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME}.br"
 val LOCAL_MAVEN_CACHES_DEST = HOME_PATH + File.separator + "maven"
 const val LOCAL_MAVEN_REPO_FOLDER_DEST = "localMvnRepository"
 

--- a/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/tasks/CopyGradleCachesToAssetsTask.kt
+++ b/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/tasks/CopyGradleCachesToAssetsTask.kt
@@ -17,8 +17,10 @@
 
 package com.itsaky.androidide.plugins.tasks
 
+import com.google.common.io.Files
 import org.adfa.constants.ASSETS_COMMON_FOLDER
 import org.adfa.constants.LOCAL_GRADLE_8_0_0_CACHES_PATH
+import org.adfa.constants.LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME_BR
 import org.adfa.constants.SOURCE_LIB_FOLDER
 import com.itsaky.androidide.plugins.util.FolderCopyUtils.Companion.copyFolderWithInnerFolders
 import org.gradle.api.DefaultTask
@@ -53,10 +55,11 @@ abstract class CopyGradleCachesToAssetsTask : DefaultTask() {
          * folder.
          */
         val sourceFilePath =
-            this.project.projectDir.parentFile.path + File.separator + SOURCE_LIB_FOLDER + File.separator + LOCAL_GRADLE_8_0_0_CACHES_PATH
+            this.project.projectDir.parentFile.path + File.separator + SOURCE_LIB_FOLDER + File.separator +
+                    LOCAL_GRADLE_8_0_0_CACHES_PATH + File.separator + LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME_BR
 
         try {
-            copyFolderWithInnerFolders(Path(sourceFilePath), Path(outputDirectory.path))
+            Files.copy(File(sourceFilePath), outputDirectory.resolve(LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME_BR))
         } catch (e: IOException) {
             e.message?.let { throw GradleException(it) }
         }

--- a/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/tasks/CopyGradleExecutableToAssetsTask.kt
+++ b/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/tasks/CopyGradleExecutableToAssetsTask.kt
@@ -18,8 +18,8 @@
 package com.itsaky.androidide.plugins.tasks
 
 import org.adfa.constants.ASSETS_COMMON_FOLDER
-import org.adfa.constants.COMPOSE_GRADLE_WRAPPER_FILE_NAME
-import org.adfa.constants.GRADLE_WRAPPER_FILE_NAME
+import org.adfa.constants.COMPOSE_GRADLE_WRAPPER_FILE_NAME_BR
+import org.adfa.constants.GRADLE_WRAPPER_FILE_NAME_BR
 import org.adfa.constants.SOURCE_LIB_FOLDER
 import com.google.common.io.Files
 import org.gradle.api.DefaultTask
@@ -45,8 +45,8 @@ abstract class CopyGradleExecutableToAssetsTask : DefaultTask() {
             outputDirectory.mkdirs()
         }
 
-        val destFile = outputDirectory.resolve(GRADLE_WRAPPER_FILE_NAME)
-        val destFileCompose = outputDirectory.resolve(COMPOSE_GRADLE_WRAPPER_FILE_NAME)
+        val destFile = outputDirectory.resolve(GRADLE_WRAPPER_FILE_NAME_BR)
+        val destFileCompose = outputDirectory.resolve(COMPOSE_GRADLE_WRAPPER_FILE_NAME_BR)
 
         if (destFile.exists()) {
             destFile.delete()
@@ -56,9 +56,9 @@ abstract class CopyGradleExecutableToAssetsTask : DefaultTask() {
         }
 
         val sourceFilePath =
-            this.project.projectDir.parentFile.path + File.separator + SOURCE_LIB_FOLDER + File.separator + GRADLE_WRAPPER_FILE_NAME
+            this.project.projectDir.parentFile.path + File.separator + SOURCE_LIB_FOLDER + File.separator + GRADLE_WRAPPER_FILE_NAME_BR
         val sourceFilePathCompose =
-            this.project.projectDir.parentFile.path + File.separator + SOURCE_LIB_FOLDER + File.separator + COMPOSE_GRADLE_WRAPPER_FILE_NAME
+            this.project.projectDir.parentFile.path + File.separator + SOURCE_LIB_FOLDER + File.separator + COMPOSE_GRADLE_WRAPPER_FILE_NAME_BR
 
         try {
             Files.copy(File(sourceFilePath), destFile)

--- a/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/tasks/CopySdkToAssetsTask.kt
+++ b/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/tasks/CopySdkToAssetsTask.kt
@@ -17,10 +17,13 @@
 
 package com.itsaky.androidide.plugins.tasks
 
+import com.google.common.io.Files
 import org.adfa.constants.ASSETS_COMMON_FOLDER
 import org.adfa.constants.LOCAL_SOURCE_ANDROID_SDK
+import org.adfa.constants.ANDROID_SDK_ZIP_BR
 import org.adfa.constants.SOURCE_LIB_FOLDER
 import com.itsaky.androidide.plugins.util.FolderCopyUtils.Companion.copyFolderWithInnerFolders
+import org.adfa.constants.LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME_BR
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
@@ -43,8 +46,16 @@ abstract class CopySdkToAssetsTask : DefaultTask() {
         val outputDirectory = this.outputDirectory.get()
             .file(ASSETS_COMMON_FOLDER + File.separator + LOCAL_SOURCE_ANDROID_SDK).asFile
         val sourceFilePath =
-            this.project.projectDir.parentFile.path + File.separator + SOURCE_LIB_FOLDER + File.separator + LOCAL_SOURCE_ANDROID_SDK
-        copy(sourceFilePath, outputDirectory)
+            this.project.projectDir.parentFile.path + File.separator + SOURCE_LIB_FOLDER + File.separator +
+                    LOCAL_SOURCE_ANDROID_SDK + File.separator + ANDROID_SDK_ZIP_BR
+
+        if (!outputDirectory.exists()) {
+            outputDirectory.mkdirs()
+        }
+
+        Files.copy(File(sourceFilePath), outputDirectory.resolve(
+            ANDROID_SDK_ZIP_BR
+        ))
     }
 
     private fun copy(sourceFilePath: String, outputDirectory: File) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -109,6 +109,7 @@ common-markwon-recycler = { module = "io.noties.markwon:recycler", version.ref =
 common-hiddenApiBypass = { module = "org.lsposed.hiddenapibypass:hiddenapibypass", version = "6.1" }
 common-termuxAmLib = { module = "com.termux:termux-am-library", version = "v2.0.0" }
 common-charts = { module = "com.github.AppDevNext:AndroidChart", version = "3.1.0.21" }
+common-orgbrotli-dec = { module = "org.brotli:dec", version = "0.1.2"}
 
 # AndroidX
 androidx-annotation = { module = "androidx.annotation:annotation", version = "1.9.1" }

--- a/libs_source/androidsdk/android-sdk.zip.br
+++ b/libs_source/androidsdk/android-sdk.zip.br
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7b0d1b3ce83bb0449cc2dda2b23fd5665334e2cb16584b7a7c55fdddad3e0e5
+size 105978683

--- a/libs_source/gradle-8.7-bin.zip.br
+++ b/libs_source/gradle-8.7-bin.zip.br
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28def78513fac6d8205bc5fbba6adb9d94a6196986c05d54b8384f304611ff6e
+size 88938550

--- a/libs_source/gradle/localMvnRepository.zip.br
+++ b/libs_source/gradle/localMvnRepository.zip.br
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9496029523d9f0551e64808ebe241ec71c7abd2814f555362f37bc4ee17d792c
+size 73777528


### PR DESCRIPTION
The local maven repo, android sdk and gradle bin blobs are now brotli compressed for full non-split asset builds, to achieve better compression.  Split asset builds still rely on the same assets-v?.zip for the usual zip files of three blobs mentioned above