### PR TITLE
ADFA-1069: handle VMDisconnectEvent gracefully if no VMs are connected

### DIFF
--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/JavaDebugAdapter.kt
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/JavaDebugAdapter.kt
@@ -432,6 +432,11 @@ internal class JavaDebugAdapter : IDebugAdapter, EventConsumer, AutoCloseable {
 
     override fun vmDisconnectEvent(e: VMDisconnectEvent) {
         logger.debug("vmDisconnectedEvent: {}", e)
+        if (!isConnected()) {
+            logger.warn("Got VM disconnect event when not connected")
+            return
+        }
+
         e.virtualMachine().checkIsCurrentVm()
         val vm = connVm()
 
@@ -473,7 +478,9 @@ internal class JavaDebugAdapter : IDebugAdapter, EventConsumer, AutoCloseable {
         }
     }
 
-    private fun checkIsConnected() = check(vms.isNotEmpty()) {
+    private fun isConnected() = vms.isNotEmpty()
+
+    private fun checkIsConnected() = check(isConnected()) {
         "No connected VMs"
     }
 


### PR DESCRIPTION
See [ADFA-1069](https://appdevforall.atlassian.net/browse/ADFA-1069) for more details.

[ADFA-1069]: https://appdevforall.atlassian.net/browse/ADFA-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ