### PR TITLE
ADFA-873: Removing manual setup option 

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
@@ -222,13 +222,12 @@ class OnboardingActivity : AppIntro2() {
 
                 runOnUiThread {
                     val intent = Intent(this@OnboardingActivity, TerminalActivity::class.java)
-                    if (currentFragment.isAutoInstall()) {
-                        intent.putExtra(TerminalActivity.EXTRA_ONBOARDING_RUN_IDESETUP, true)
-                        intent.putExtra(
-                            TerminalActivity.EXTRA_ONBOARDING_RUN_IDESETUP_ARGS,
-                            currentFragment.buildIdeSetupArguments()
-                        )
-                    }
+                    intent.putExtra(TerminalActivity.EXTRA_ONBOARDING_RUN_IDESETUP, true)
+                    intent.putExtra(
+                        TerminalActivity.EXTRA_ONBOARDING_RUN_IDESETUP_ARGS,
+                        currentFragment.buildIdeSetupArguments()
+                    )
+
                     terminalActivityCallback.launch(intent)
                 }
             }

--- a/app/src/main/java/com/itsaky/androidide/fragments/onboarding/IdeSetupConfigurationFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/onboarding/IdeSetupConfigurationFragment.kt
@@ -91,14 +91,10 @@ class IdeSetupConfigurationFragment : OnboardingFragment(), SlidePolicy {
       meteredConnection.root.setText(R.string.msg_connected_to_metered_connection)
       backgroundDataRestricted.root.setText(R.string.msg_disable_background_data_restriction)
 
-      autoInstallSwitch.setOnCheckedChangeListener { button, isChecked ->
-        button.setText(
-          if (isChecked) R.string.action_auto_install else R.string.action_manual_install)
-        sdkVersionLayout.isEnabled = isChecked
-        jdkVersionLayout.isEnabled = isChecked
-        installGit.isEnabled = isChecked
-        installOpenssh.isEnabled = isChecked
-      }
+      sdkVersionLayout.isEnabled = true
+      jdkVersionLayout.isEnabled = true
+      installGit.isEnabled = true
+      installOpenssh.isEnabled = true
 
       val sdkVersions = SdkVersion.entries.map { "SDK ${it.version}" }.reversed()
       sdkVersion.setText(sdkVersions[0])
@@ -119,8 +115,6 @@ class IdeSetupConfigurationFragment : OnboardingFragment(), SlidePolicy {
 
     updateConnectionStatus()
   }
-
-  fun isAutoInstall(): Boolean = content.autoInstallSwitch.isChecked
 
   fun buildIdeSetupArguments(): Array<String> {
     val args = mutableListOf<String>()

--- a/app/src/main/res/layout/layout_onboardng_setup_config.xml
+++ b/app/src/main/res/layout/layout_onboardng_setup_config.xml
@@ -27,7 +27,6 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:orientation="vertical"
-        app:layout_constraintBottom_toTopOf="@id/auto_install_switch"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -74,7 +73,7 @@
         android:checked="true"
         android:text="@string/action_install_git"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/auto_install_switch"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/jdk_version_layout" />
 
     <com.google.android.material.checkbox.MaterialCheckBox
@@ -84,19 +83,8 @@
         android:checked="true"
         android:text="@string/action_install_openssh"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/auto_install_switch"
-        app:layout_constraintTop_toBottomOf="@id/install_git" />
-
-    <com.google.android.material.materialswitch.MaterialSwitch
-        android:id="@+id/auto_install_switch"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:checked="true"
-        android:text="@string/action_auto_install"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/connection_info_container" />
+        app:layout_constraintTop_toBottomOf="@id/install_git" />
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/jdk_version_layout"
@@ -107,8 +95,8 @@
         android:hint="@string/hin_jdk_version"
         android:labelFor="@id/jdk_version"
         android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="@id/auto_install_switch"
-        app:layout_constraintStart_toStartOf="@id/auto_install_switch"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/sdk_version_layout">
 
         <com.google.android.material.textfield.MaterialAutoCompleteTextView
@@ -129,9 +117,9 @@
         android:hint="@string/hint_android_sdk_version"
         android:labelFor="@id/sdk_version"
         android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="@id/auto_install_switch"
-        app:layout_constraintStart_toStartOf="@id/auto_install_switch"
-        app:layout_constraintTop_toBottomOf="@id/auto_install_switch">
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/connection_info_container">
 
         <com.google.android.material.textfield.MaterialAutoCompleteTextView
             android:id="@+id/sdk_version"

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -589,7 +589,7 @@
   <string name="msg_project_dir_doesnt_exist">Project directory does not exist</string>
   <string name="msg_files_being_saved">A file save operation is already in progress!</string>
   <string name="title_install_tools">Install Development Tools</string>
-  <string name="subtitle_install_tools">\nTo install the tools needed to build Android projects, tap the button at the bottom right of the screen\n\nManual installation is not recommended.</string>
+  <string name="subtitle_install_tools">\nTo install the tools needed to build Android projects, tap the button at the bottom right of the screen\n</string>
   <string name="msg_install_tools"> </string>
   <string name="greeting_title">Welcome</string>
   <string name="greeting_subtitle">Learn, build, launch. All on your Android.</string>


### PR DESCRIPTION
## Description
<!-- Short description about what, how and why you did in the PR -->

Removes the "Auto-install" switch from the IDE setup configuration screen. The related logic that enabled/disabled other options based on this switch has also been removed.
The IDE setup process will now always proceed as if "Auto-install" was enabled, simplifying the user experience during onboarding.


## Details
<!-- Screenshots or videos of the PR in action if it's related to the UI, or logs if it's related to logic. -->

[ADFA-873.webm](https://github.com/user-attachments/assets/5d3748b7-5384-4b18-8ebf-0b4112df61b3)

## Ticket
[ADFA-873](https://appdevforall.atlassian.net/browse/ADFA-873)

## Observation
<!-- Some important about your code --> 


[ADFA-873]: https://appdevforall.atlassian.net/browse/ADFA-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ