### PR TITLE
ADFA-1039 | Default internal app build warnings fix

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -309,9 +309,13 @@ constructor(
   }
 
   private fun shouldFilter(msg: String): Boolean {
-    return msg.contains("Transforming transform-api-2.0.0-deprecated-use-gradle-api.jar") ||
-            msg.contains("Deprecated Gradle features were used in this build") ||
-            msg.contains("is deprecated")
+    return msg.contains("The option setting 'android.aapt2FromMavenOverride=/data/data/com.itsaky.androidide/files/home/.androidide/aapt2' is experimental") ||
+            msg.contains("The org.gradle.api.plugins.BasePluginConvention type has been deprecated.") ||
+            msg.contains("The org.gradle.api.plugins.Convention type has been deprecated.") ||
+            msg.contains("The BasePluginExtension.archivesBaseName property has been deprecated.") ||
+            msg.contains("The Provider.forUseAtConfigurationTime method has been deprecated.") ||
+            msg.contains("The BuildIdentifier.getName() method has been deprecated.") ||
+            msg.contains("Deprecated Gradle features were used in this build")
   }
 
   fun clearBuildOutput() {

--- a/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -304,7 +304,14 @@ constructor(
   }
 
   fun appendBuildOut(str: String?) {
+    if (str != null && shouldFilter(str)) return
     pagerAdapter.buildOutputFragment?.appendOutput(str)
+  }
+
+  private fun shouldFilter(msg: String): Boolean {
+    return msg.contains("Transforming transform-api-2.0.0-deprecated-use-gradle-api.jar") ||
+            msg.contains("Deprecated Gradle features were used in this build") ||
+            msg.contains("is deprecated")
   }
 
   fun clearBuildOutput() {

--- a/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -309,13 +309,16 @@ constructor(
   }
 
   private fun shouldFilter(msg: String): Boolean {
-    return msg.contains("The option setting 'android.aapt2FromMavenOverride=/data/data/com.itsaky.androidide/files/home/.androidide/aapt2' is experimental") ||
-            msg.contains("The org.gradle.api.plugins.BasePluginConvention type has been deprecated.") ||
-            msg.contains("The org.gradle.api.plugins.Convention type has been deprecated.") ||
-            msg.contains("The BasePluginExtension.archivesBaseName property has been deprecated.") ||
-            msg.contains("The Provider.forUseAtConfigurationTime method has been deprecated.") ||
-            msg.contains("The BuildIdentifier.getName() method has been deprecated.") ||
-            msg.contains("Deprecated Gradle features were used in this build")
+    val filters = listOf(
+      "The option setting 'android.aapt2FromMavenOverride=/data/data/com.itsaky.androidide/files/home/.androidide/aapt2' is experimental",
+      "The org.gradle.api.plugins.BasePluginConvention type has been deprecated.",
+      "The org.gradle.api.plugins.Convention type has been deprecated.",
+      "The BasePluginExtension.archivesBaseName property has been deprecated.",
+      "The Provider.forUseAtConfigurationTime method has been deprecated.",
+      "The BuildIdentifier.getName() method has been deprecated.",
+      "Deprecated Gradle features were used in this build"
+    )
+    return filters.any { msg.contains(it) }
   }
 
   fun clearBuildOutput() {

--- a/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -308,17 +308,18 @@ constructor(
     pagerAdapter.buildOutputFragment?.appendOutput(str)
   }
 
+  private val suppressedGradleWarnings = listOf(
+    "The option setting 'android.aapt2FromMavenOverride=/data/data/com.itsaky.androidide/files/home/.androidide/aapt2' is experimental",
+    "The org.gradle.api.plugins.BasePluginConvention type has been deprecated.",
+    "The org.gradle.api.plugins.Convention type has been deprecated.",
+    "The BasePluginExtension.archivesBaseName property has been deprecated.",
+    "The Provider.forUseAtConfigurationTime method has been deprecated.",
+    "The BuildIdentifier.getName() method has been deprecated.",
+    "Deprecated Gradle features were used in this build"
+  )
+
   private fun shouldFilter(msg: String): Boolean {
-    val filters = listOf(
-      "The option setting 'android.aapt2FromMavenOverride=/data/data/com.itsaky.androidide/files/home/.androidide/aapt2' is experimental",
-      "The org.gradle.api.plugins.BasePluginConvention type has been deprecated.",
-      "The org.gradle.api.plugins.Convention type has been deprecated.",
-      "The BasePluginExtension.archivesBaseName property has been deprecated.",
-      "The Provider.forUseAtConfigurationTime method has been deprecated.",
-      "The BuildIdentifier.getName() method has been deprecated.",
-      "Deprecated Gradle features were used in this build"
-    )
-    return filters.any { msg.contains(it) }
+    return suppressedGradleWarnings.any { msg.contains(it) }
   }
 
   fun clearBuildOutput() {

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/models/Dependency.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/models/Dependency.kt
@@ -99,6 +99,9 @@ data class Dependency(val configuration: DependencyConfiguration,
       "androidx.navigation:navigation-ui-ktx:${navigationVersion}")
 
     @JvmStatic
+    val ViewPager2 = parseDependency("androidx.viewpager2:viewpager2:1.0.0")
+
+    @JvmStatic
     val Startup_Runtime = parseDependency("androidx.startup:startup-runtime:1.1.1")
 
     @JvmStatic

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
@@ -59,8 +59,8 @@ android {
     buildToolsVersion = "34.0.4" 
     
     // disable linter
-    lintOptions {
-        isCheckReleaseBuilds = false
+    lint {
+        checkReleaseBuilds = false
     }
     
     
@@ -159,7 +159,7 @@ fun composeConfigGroovy(): String = """
     composeOptions {
         kotlinCompilerExtensionVersion '$compose_kotlinCompilerExtensionVersion'
     }
-    packagingOptions {
+    packaging {
         resources {
             resources.excludes.add("/META-INF/{AL2.0,LGPL2.1}")
             resources.excludes.add("META-INF/kotlinx_coroutines_core.version")
@@ -215,7 +215,7 @@ fun composeConfigKts(): String = """
     composeOptions {
         kotlinCompilerExtensionVersion = "$compose_kotlinCompilerExtensionVersion"
     }
-    packagingOptions {
+    packaging {
         resources {
             resources.excludes.add("/META-INF/{AL2.0,LGPL2.1}")
             resources.excludes.add("META-INF/kotlinx_coroutines_core.version")

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
@@ -116,8 +116,8 @@ android {
     buildToolsVersion = "34.0.4"
     
     // disable linter
-    lintOptions {
-        checkReleaseBuilds  false
+    lint {
+        checkReleaseBuilds =  false
     }
     
     defaultConfig {

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
@@ -94,6 +94,11 @@ android {
     }
     ${composeConfigKts()}
 }
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.add("-Xlint:deprecation")
+}
+
 ${ktJvmTarget()}
 ${dependencies()}
 """
@@ -149,6 +154,9 @@ android {
         ${if (isComposeModule) "compose true" else ""}
     }
     ${composeConfigGroovy()}
+}
+tasks.withType<JavaCompile> {
+    options.compilerArgs.add("-Xlint:deprecation")
 }
 ${ktJvmTarget()}
 ${dependencies()}

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/util/AndroidManifestBuilder.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/util/AndroidManifestBuilder.kt
@@ -76,6 +76,7 @@ class AndroidManifestBuilder {
     hashMapOf<ConfigurationType, HashSet<IndentedXmlConfigurator>>()
   private val permissions = hashSetOf<Permission>()
   private val activities = hashSetOf<ManifestActivity>()
+  var shouldRemoveInitializationProvider: Boolean = false
 
   /**
    * The name of the string resource to use in the `android:label` attribute of `<application>` tag.
@@ -200,11 +201,13 @@ class AndroidManifestBuilder {
   }
 
   private fun IndentedXmlBuilder.initializationProviderFix() {
-    createElement(TAG_PROVIDER) {
-      androidAttr("name", "androidx.startup.InitializationProvider")
-      androidAttr("authorities", "\${applicationId}.androidx-startup")
-      toolsAttr("node", "remove")
-      closeStartElement()
+    if (shouldRemoveInitializationProvider) {
+      createElement(TAG_PROVIDER) {
+        androidAttr("name", "androidx.startup.InitializationProvider")
+        androidAttr("authorities", "\${applicationId}.androidx-startup")
+        toolsAttr("node", "remove")
+        closeStartElement()
+      }
     }
   }
 

--- a/templates-impl/src/main/assets/templates/tabbed/res/layout/activity_main.xml
+++ b/templates-impl/src/main/assets/templates/tabbed/res/layout/activity_main.xml
@@ -23,7 +23,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager.widget.ViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/tabbedActivity/srcActivity.kt
+++ b/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/tabbedActivity/srcActivity.kt
@@ -25,7 +25,8 @@ package ${data.packageName}
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import androidx.viewpager.widget.ViewPager
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayoutMediator;
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
@@ -45,12 +46,16 @@ class MainActivity : AppCompatActivity() {
         
         setSupportActionBar(binding.toolbar)
 
-        val sectionsPagerAdapter = SectionsPagerAdapter(this, supportFragmentManager)
-        val viewPager: ViewPager = binding.viewPager
+        val sectionsPagerAdapter = SectionsPagerAdapter(this)
+        val viewPager: ViewPager2 = binding.viewPager
         val tabs: TabLayout = binding.tabs
         
         viewPager.adapter = sectionsPagerAdapter
-        tabs.setupWithViewPager(viewPager)
+        
+        TabLayoutMediator(tabs, viewPager) { tab, position ->
+            tab.text = sectionsPagerAdapter.getPageTitle(position)
+        }.attach()
+
 
         binding.fab.setOnClickListener { view ->
             Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
@@ -66,8 +71,9 @@ package ${data.packageName};
 import android.os.Bundle;
 
 import com.google.android.material.snackbar.Snackbar;
+import com.google.android.material.tabs.TabLayoutMediator;
 
-import androidx.viewpager.widget.ViewPager;
+import androidx.viewpager2.widget.ViewPager2;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.view.Menu;
@@ -90,9 +96,13 @@ public class MainActivity extends AppCompatActivity {
         
         setSupportActionBar(binding.toolbar);
 
-        SectionsPagerAdapter sectionsPagerAdapter = new SectionsPagerAdapter(this, getSupportFragmentManager());
-        binding.viewPager.setAdapter(sectionsPagerAdapter);
-        binding.tabs.setupWithViewPager(binding.viewPager);
+        SectionsPagerAdapter sectionsPagerAdapter = new SectionsPagerAdapter(this);
+        ViewPager2 viewPager = binding.viewPager;
+        viewPager.setAdapter(sectionsPagerAdapter);
+        
+        new TabLayoutMediator(binding.tabs, viewPager,
+            (tab, position) -> tab.setText(sectionsPagerAdapter.getPageTitle(position))
+        ).attach();
 
         binding.fab.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/tabbedActivity/srcPagerAdapter.kt
+++ b/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/tabbedActivity/srcPagerAdapter.kt
@@ -24,8 +24,8 @@ package ${data.packageName}.ui.main
 
 import android.content.Context
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentPagerAdapter
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
 import ${data.packageName}.R
 
 private val TAB_TITLES = arrayOf(
@@ -38,22 +38,15 @@ private val TAB_TITLES = arrayOf(
  * A [FragmentPagerAdapter] that returns a fragment corresponding to
  * one of the sections/tabs/pages.
  */
-class SectionsPagerAdapter(private val context: Context, fm: FragmentManager) :
-    FragmentPagerAdapter(fm) {
+class SectionsPagerAdapter(private val activity: FragmentActivity) : FragmentStateAdapter(activity) {
+    override fun getItemCount(): Int = TAB_TITLES.size
 
-    override fun getItem(position: Int): Fragment {
-        // getItem is called to instantiate the fragment for the given page.
-        // Return a PlaceholderFragment (defined as a static inner class below).
+    override fun createFragment(position: Int): Fragment {
         return PlaceholderFragment.newInstance(position + 1)
     }
-
-    override fun getPageTitle(position: Int): CharSequence? {
-        return context.resources.getString(TAB_TITLES[position])
-    }
-
-    override fun getCount(): Int {
-        // Show 3 total pages.
-        return 3
+    
+    fun getPageTitle(position: Int): CharSequence {
+        return activity.getString(TAB_TITLES[position])
     }
 }
 """.trim()
@@ -61,48 +54,43 @@ class SectionsPagerAdapter(private val context: Context, fm: FragmentManager) :
 internal fun AndroidModuleTemplateBuilder.tabbedPagerAdapterSrcJava() = """
 package ${data.packageName}.ui.main;
 
-import android.content.Context;
-
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentPagerAdapter;
-
+import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
 import ${data.packageName}.R;
 
 /**
- * A [FragmentPagerAdapter] that returns a fragment corresponding to
+ * A [FragmentStateAdapter] that returns a fragment corresponding to
  * one of the sections/tabs/pages.
  */
-public class SectionsPagerAdapter extends FragmentPagerAdapter {
+public class SectionsPagerAdapter extends FragmentStateAdapter {
 
-    @StringRes
-    private static final int[] TAB_TITLES = new int[]{R.string.tab_text_1, R.string.tab_text_2, R.string.tab_text_3};
-    private final Context mContext;
+    private final FragmentActivity activity;
 
-    public SectionsPagerAdapter(Context context, FragmentManager fm) {
-        super(fm);
-        mContext = context;
+    public SectionsPagerAdapter(@NonNull FragmentActivity fragmentActivity) {
+        super(fragmentActivity);
+        this.activity = fragmentActivity;
     }
 
+    @NonNull
     @Override
-    public Fragment getItem(int position) {
-        // getItem is called to instantiate the fragment for the given page.
-        // Return a PlaceholderFragment (defined as a static inner class below).
+    public Fragment createFragment(int position) {
         return PlaceholderFragment.newInstance(position + 1);
     }
 
-    @Nullable
     @Override
-    public CharSequence getPageTitle(int position) {
-        return mContext.getResources().getString(TAB_TITLES[position]);
-    }
-
-    @Override
-    public int getCount() {
-        // Show 3 total pages.
+    public int getItemCount() {
         return 3;
+    }
+    
+    public CharSequence getPageTitle(int position) {
+        switch (position) {
+            case 0: return activity.getString(R.string.tab_text_1);
+            case 1: return activity.getString(R.string.tab_text_2);
+            case 2: return activity.getString(R.string.tab_text_3);
+            default: return "";
+        }
     }
 }
 """.trim()

--- a/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/tabbedActivity/tabbedActivityTemplate.kt
+++ b/templates-impl/src/main/java/com/itsaky/androidide/templates/impl/tabbedActivity/tabbedActivityTemplate.kt
@@ -61,6 +61,8 @@ fun AndroidModuleTemplateBuilder.tabbedActivityProjectKt() {
   executor.apply {
     addDependency(Dependency.AndroidX.LifeCycle_LiveData_Ktx)
     addDependency(Dependency.AndroidX.LifeCycle_ViewModel_Ktx)
+    addDependency(Dependency.AndroidX.ViewPager2)
+    addDependency(Dependency.Google.Material)
 
     sources {
       writeKtSrc("${data.packageName}.ui.main", "SectionsPagerAdapter",
@@ -77,6 +79,8 @@ fun AndroidModuleTemplateBuilder.tabbedActivityProjectJava() {
   executor.apply {
     addDependency(Dependency.AndroidX.LifeCycle_LiveData)
     addDependency(Dependency.AndroidX.LifeCycle_ViewModel)
+    addDependency(Dependency.AndroidX.ViewPager2)
+    addDependency(Dependency.Google.Material)
 
     sources {
       writeJavaSrc("${data.packageName}.ui.main", "SectionsPagerAdapter",


### PR DESCRIPTION
## Description
### Warnings detected | Scenarios:

#### Warning on build and run internal app process:
- ##### Warning: The Provider.forUseAtConfigurationTime method has been deprecated. This is scheduled to be removed in Gradle 9.0. 
| Template: All | Language: Kotlin | State: HIDDEN | Reason: The Provider.forUseAtConfigurationTime() method has been deprecated since Gradle 7.4 and is scheduled for removal in Gradle 9.0. This warning suggests that a plugin or internal build logic is using the method unnecessarily during the configuration phase. If this call is not found in the app's own codebase, the warning stems from a dependency or AndroidIDE’s internal Gradle logic and cannot be resolved at the application level. Therefore, it is technically safe to ignore | Documentation: https://docs.gradle.org/8.7/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation
	at org.gradle.api.internal.provider.AbstractMinimalProvider.forUseAtConfigurationTime(AbstractMinimalProvider.java:135
- ##### Warning: The org.gradle.api.plugins.Convention type has been deprecated. This is scheduled to be removed in Gradle 9.0. 
| Template: All | Language: Kotlin | State: HIDDEN | Reason: The warning about org.gradle.api.plugins.Convention being deprecated is triggered by internal Gradle plugins or scripts bundled with AndroidIDE, not by the project’s own source code. After auditing the full codebase, no direct usage of project.convention or related API was found. This indicates the deprecation stems from upstream tooling that is outside the scope of user control. Since it does not affect the success or stability of the build process, it is technically safe to ignore until AndroidIDE or its plugins adopt the recommended replacement APIs in a future release. | Documentation: https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#deprecated_access_to_conventions

#### Warnings on build internal projec processt: 
- ##### Warning:  w: file:///storage/emulated/0/AndroidIDEProjects/My%20Application1/app/build.gradle.kts:16:5: 'lintOptions(LintOptions.() -> Unit): Unit' is deprecated. Renamed to lint 
   | Type: warning | State: FIXED
- w: file:///storage/emulated/0/AndroidIDEProjects/My%20Application1/app/build.gradle.kts:17:9: 'isCheckReleaseBuilds: Boolean' is deprecated. Moved to lint.checkReleaseBuilds 
   | Type: warning | State: FIXED
- ##### Warning:  w: file:///storage/emulated/0/AndroidIDEProjects/My%20Application1/app/build.gradle.kts:52:5: 'packagingOptions(Packaging.() -> Unit): Unit' is deprecated. Renamed to packaging
   | Type: warning | State: FIXED
- ##### Message:  Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0. 
   | Type: **### message** related with previous warnings and transform-api | HIDDEN
- ##### Warning: The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. 
   | Templates: All | Language: Java, Kotlin | State: HIDDEN | Reason: The use of BuildIdentifier.getName() has been deprecated due to its inability to guarantee a unique identifier in multi-build setups. The recommended replacement is getBuildPath(), which ensures uniqueness across included builds. If this method is not used explicitly in the application's codebase, the warning likely stems from a third-party Gradle plugin or the underlying build system, and cannot be resolved directly. In such cases, the warning can be safely ignored. | Documentation: https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation


#### Warnings on running app process:
- ##### Warning:  WARNING: The option setting 'android.aapt2FromMavenOverride=/data/data/com.itsaky.androidide/files/home/.androidide/aapt2' is experimental. 
| Template: All | Language: Java, Kotlin | State: HIDDEN | Reason: Safetely ignored because it is internally set by AndroidIDE to ensure compatibility with its mobile build environment, and does not affect build correctness or stability. | Documentation: https://developer.android.com/tools/aapt2?utm_source=chatgpt.com and https://developer.android.com/reference/kotlin/androidx/annotation/experimental/Experimental?utm_source=chatgpt.com 
- ##### Warning: Task :app:compileDebugJavaWithJavac
Note: /storage/emulated/0/AndroidIDEProjects/My Application9/app/src/main/java/com/example/myapplication9/ui/main/SectionsPagerAdapter.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details. 
| Template: Tabbet Drawer | Language: Java, Kotlin | State: FIXED
- ##### Warning:  The org.gradle.api.plugins.BasePluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. 
| Template: Jetpack Compose, Bottom Navigation, Navigation Drawer, Tabbet Drawer | Language: Kotlin | State: HIDDEN | Reason: The warning regarding BasePluginConvention deprecation originates from internal tooling or plugins used by AndroidIDE, not from the project's own codebase. A full codebase search confirms there is no usage of BasePluginConvention, archivesBaseName, or related legacy APIs. Therefore, this deprecation cannot be resolved at the project level and must be addressed upstream by the maintainers of AndroidIDE or its internal Gradle plugins. As it does not impact the functionality or correctness of the build, it can be safely ignored until a future version of the tool updates the underlying implementation. | Documentation: https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#base_convention_deprecation
- ##### Warning:  The BasePluginExtension.archivesBaseName property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the archivesName property instead. 
| Template: Jetpack Compose, Bottom Navigation, Navigation Drawer, Tabbet Drawer, No AndroidX | Language: Kotlin | State: HIDDEN | Reason: The archivesBaseName property has been officially deprecated and replaced by archivesName in Gradle 8.0+. If this property is not directly used in the project code, the warning likely comes from internal usage within AndroidIDE or a plugin, which cannot be modified by us. Therefore, it is safe to ignore this warning. | Documentation: https://docs.gradle.org/8.7/dsl/org.gradle.api.plugins.BasePluginExtension.html#org.gradle.api.plugi


### Solution:

- Rename `lintOptions` to `lint` and `packagingOptions` to `packaging` in build.gradle.kts template
- The `lintOptions` and `packagingOptions` DSL blocks in `build.gradle.kts` have been deprecated and renamed to `lint` and `packaging` respectively. This commit updates the template to use the new names.
- Updating `isCheckReleaseBuilds` within the `lint` block has been renamed to `checkReleaseBuilds`.
- update SectionsPagerAdapter deprecated APIs, ViewPager by ViewPager2
- Make initialization provider optional for AndroidmanifestBuilder


## Observations
To verify warnings need to build and run app templates and catch logs using both supported languages (java and kotlin)
Build process:
![build-process](https://github.com/user-attachments/assets/90c6dd04-e87a-439b-bab3-e0a29f5b19c1)

Run process:
![run-process](https://github.com/user-attachments/assets/351803ec-30d8-467b-bc75-a8b42537d2da)


## Ticket
See [ADFA-1039](https://appdevforall.atlassian.net/browse/ADFA-1039).

[ADFA-1039]: https://appdevforall.atlassian.net/browse/ADFA-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ