### PR TITLE
ADFA-1157: Fix TreeSitter native library loading during tests to prevent failures

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,10 +63,20 @@ android {
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     testInstrumentationRunnerArguments["androidx.test.orchestrator.ENABLE"] = "true"
+    testInstrumentationRunnerArguments["androidide.test.mode"] = "true"
   }
 
   testOptions {
     execution = "ANDROIDX_TEST_ORCHESTRATOR"
+    
+    unitTests {
+      isIncludeAndroidResources = true
+      all {
+        // Skip TreeSitter native library loading in tests
+        it.systemProperty("java.library.path", System.getProperty("java.library.path"))
+        it.systemProperty("androidide.test.mode", "true")
+      }
+    }
   }
 
   androidResources {

--- a/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -59,6 +59,7 @@ import com.itsaky.androidide.ui.themes.IThemeManager
 import com.itsaky.androidide.utils.RecyclableObjectPool
 import com.itsaky.androidide.utils.VMUtils
 import com.itsaky.androidide.utils.flashError
+import com.itsaky.androidide.utils.isTestMode
 import com.termux.app.TermuxApplication
 import com.termux.shared.reflection.ReflectionUtils
 import io.github.rosemoe.sora.widget.schemes.EditorColorScheme
@@ -93,28 +94,7 @@ class IDEApplication : TermuxApplication() {
         RecyclableObjectPool.DEBUG = BuildConfig.DEBUG
     }
 
-    private fun isTestMode(): Boolean {
-        // Check system property (for unit tests)
-        if (System.getProperty("androidide.test.mode") == "true") {
-            return true
-        }
-        
-        // Check if we're running under test instrumentation
-        try {
-            val instrumentationClass = Class.forName("androidx.test.platform.app.InstrumentationRegistry")
-            val getInstrumentationMethod = instrumentationClass.getMethod("getInstrumentation")
-            val instrumentation = getInstrumentationMethod.invoke(null)
-            if (instrumentation != null) {
-                Log.i("IDEApplication", "Running under test instrumentation, skipping TreeSitter loading")
-                return true
-            }
-        } catch (e: Exception) {
-            // Not running under instrumentation
-        }
-        
-        return false
-    }
-
+  
     @OptIn(DelicateCoroutinesApi::class)
     override fun onCreate() {
         instance = this

--- a/app/src/main/java/com/itsaky/androidide/fragments/output/LogViewFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/LogViewFragment.kt
@@ -32,6 +32,7 @@ import com.itsaky.androidide.fragments.EmptyStateFragment
 import com.itsaky.androidide.models.LogLine
 import com.itsaky.androidide.utils.ILogger.Level
 import com.itsaky.androidide.utils.jetbrainsMono
+import com.itsaky.androidide.utils.isTestMode
 import io.github.rosemoe.sora.widget.style.CursorAnimator
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ArrayBlockingQueue
@@ -258,26 +259,6 @@ abstract class LogViewFragment :
     }
   }
 
-  private fun isTestMode(): Boolean {
-    // Check system property (for unit tests)
-    if (System.getProperty("androidide.test.mode") == "true") {
-      return true
-    }
-    
-    // Check if we're running under test instrumentation
-    try {
-      val instrumentationClass = Class.forName("androidx.test.platform.app.InstrumentationRegistry")
-      val getInstrumentationMethod = instrumentationClass.getMethod("getInstrumentation")
-      val instrumentation = getInstrumentationMethod.invoke(null)
-      if (instrumentation != null) {
-        return true
-      }
-    } catch (e: Exception) {
-      // Not running under instrumentation
-    }
-    
-    return false
-  }
 
   override fun onDestroyView() {
     _binding?.editor?.release()

--- a/common/src/main/java/com/itsaky/androidide/utils/TestModeUtils.kt
+++ b/common/src/main/java/com/itsaky/androidide/utils/TestModeUtils.kt
@@ -1,0 +1,24 @@
+package com.itsaky.androidide.utils
+
+import android.util.Log
+
+fun isTestMode(): Boolean {
+    // Check system property (for unit tests)
+    if (System.getProperty("androidide.test.mode") == "true") {
+        return true
+    }
+    // Check if we're running under test instrumentation
+    try {
+        val instrumentationClass =
+            Class.forName("androidx.test.platform.app.InstrumentationRegistry")
+        val getInstrumentationMethod = instrumentationClass.getMethod("getInstrumentation")
+        val instrumentation = getInstrumentationMethod.invoke(null)
+        if (instrumentation != null) {
+            Log.i("TestModeUtils", "Running under test instrumentation")
+            return true
+        }
+    } catch (e: Exception) {
+        // Not running under instrumentation
+    }
+    return false
+}


### PR DESCRIPTION
Tree-sitter is a parsing library responsible for syntax highlighting and language analysis in the code editor.

Tests don't need syntax highlighting but the app tried to load Tree-sitter anyway, causing UnsatisfiedLinkError, this PR aims to fix this issue by disabling Tree-sitter during tests [unit and instrumentation]

See [this](https://appdevforall.atlassian.net/browse/ADFA-1157) for more details