### PR TITLE
ADFA-632 restore distributionUrl value in gradle.properties

### DIFF
--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/root/gradleWrapperSrc.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/root/gradleWrapperSrc.kt
@@ -26,7 +26,7 @@ fun gradleWrapperPropsSrc(isToml: Boolean): String {
     return """
     distributionBase=GRADLE_USER_HOME
     distributionPath=wrapper/dists
-    distributionUrl=file:$GRADLE_DISTS/${gradleVersion}
+    distributionUrl=https\://services.gradle.org/distributions/${gradleVersion}
     networkTimeout=10000
     zipStoreBase=GRADLE_USER_HOME
     zipStorePath=wrapper/dists


### PR DESCRIPTION
restoring gradle.properties distributionUrl property to standard values after gradle wrapper bypass.