### PR TITLE
ADFA-11ADFA-1190: Fix build failures caused by -Xlint:deprecation Gradle flag

### DIFF
--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
@@ -155,8 +155,8 @@ android {
     }
     ${composeConfigGroovy()}
 }
-tasks.withType<JavaCompile> {
-    options.compilerArgs.add("-Xlint:deprecation")
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += "-Xlint:deprecation"
 }
 ${ktJvmTarget()}
 ${dependencies()}


### PR DESCRIPTION

This PR resolves the issue where introducing -Xlint:deprecation caused build and test task failures.

Changes made:
Updated the Gradle configuration to use the correct DSL syntax based on the build script (build.gradle vs build.gradle.kts).

Ensured deprecation warnings are enabled without breaking the build.

Verified that all build and test tasks complete successfully with the flag enabled.

