### PR TITLE
ADFA-693 cache and copy back the generated gradle-api-8.7.jar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -334,6 +334,7 @@ fun createAssetsZip(zipName: String, archDir: String) {
       "android-sdk.zip" to sourceDir.resolve("androidsdk/android-sdk.zip"),
       "localMvnRepository.zip" to sourceDir.resolve("gradle/localMvnRepository.zip"),
       "gradle-8.7-bin.zip" to sourceDir.resolve("gradle-8.7-bin.zip"),
+      "gradle-api-8.7.jar.zip" to sourceDir.resolve("gradle-api-8.7.jar.zip"),
       "documentation.db" to sourceDir.resolve("documentation.db")
     ).forEach { (fileName, filePath) ->
       if (filePath.exists()) {

--- a/common/src/main/java/com/itsaky/androidide/utils/Environment.java
+++ b/common/src/main/java/com/itsaky/androidide/utils/Environment.java
@@ -40,7 +40,7 @@ public final class Environment {
   public static final String DEFAULT_ROOT = "/data/data/com.itsaky.androidide/files";
   public static final String DEFAULT_HOME = DEFAULT_ROOT + "/home";
   private static final String DEFAULT_ANDROID_HOME = DEFAULT_HOME + "/android-sdk";
-
+  public static final String GRADLE_CACHE_DIR = DEFAULT_HOME + "/.gradle";
   private static final String ANDROID_JAR_HOME = DEFAULT_ANDROID_HOME + "/platforms/android-33";
   public static final String DEFAULT_PREFIX = DEFAULT_ROOT + "/usr";
   public static final String DEFAULT_JAVA_HOME = DEFAULT_PREFIX + "/opt/openjdk";
@@ -87,6 +87,8 @@ public final class Environment {
 
   public static File DOC_DB;
 
+  public static File GRADLE_GEN_JARS;
+
   public static void init() {
     var arch = getArchitecture();
     DOWNLOAD_DIR = new File(FileUtil.getExternalStorageDir(), "Download");
@@ -132,6 +134,9 @@ public final class Environment {
     System.setProperty("user.home", HOME.getAbsolutePath());
 
     DOC_DB = BaseApplication.getBaseInstance().getDatabasePath(DATABASE_NAME);
+
+    // .gradle\caches\8.7\generated-gradle-jars
+    GRADLE_GEN_JARS = mkdirIfNotExits(new File(GRADLE_CACHE_DIR, "caches/8.7/generated-gradle-jars"));
   }
 
   public static File mkdirIfNotExits(File in) {

--- a/common/src/main/java/com/itsaky/androidide/utils/Environment.java
+++ b/common/src/main/java/com/itsaky/androidide/utils/Environment.java
@@ -135,7 +135,6 @@ public final class Environment {
 
     DOC_DB = BaseApplication.getBaseInstance().getDatabasePath(DATABASE_NAME);
 
-    // .gradle\caches\8.7\generated-gradle-jars
     GRADLE_GEN_JARS = mkdirIfNotExits(new File(GRADLE_CACHE_DIR, "caches/8.7/generated-gradle-jars"));
   }
 

--- a/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
+++ b/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
@@ -172,3 +172,9 @@ const val DATABASE_FOLDER = "database"
 const val COPY_DOC_DB_TO_ASSETS = "copyDocDbToAssets"
 
 const val JDWP_AAR_NAME = "libjdwp-remote.aar"
+
+// Generated Gradle Api Jar
+const val GRADLE_API_NAME = "gradle-api-8.7.jar"
+const val GRADLE_API_NAME_BR = "${GRADLE_API_NAME}.br"
+const val GRADLE_API_NAME_ZIP = "${GRADLE_API_NAME}.zip"
+const val COPY_GRADLE_API_TO_ASSETS = "copyGradleApiToAssets"

--- a/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/AndroidIDEAssetsPlugin.kt
+++ b/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/AndroidIDEAssetsPlugin.kt
@@ -30,16 +30,17 @@ import com.itsaky.androidide.plugins.tasks.CopyTermuxCacheAndManifestTask
 import com.itsaky.androidide.plugins.tasks.GenerateInitScriptTask
 import com.itsaky.androidide.plugins.tasks.GradleWrapperGeneratorTask
 import com.itsaky.androidide.plugins.tasks.SetupAapt2Task
+import com.itsaky.androidide.plugins.tasks.CopyGradleApiToAssetsTask
 import com.itsaky.androidide.plugins.util.capitalized
 import org.adfa.constants.COPY_ANDROID_SDK_TO_ASSETS
 import org.adfa.constants.COPY_DOC_DB_TO_ASSETS
 import org.adfa.constants.COPY_GRADLE_CACHES_TO_ASSETS
 import org.adfa.constants.COPY_GRADLE_EXECUTABLE_TASK_NAME
 import org.adfa.constants.COPY_TERMUX_LIBS_TASK_NAME
+import org.adfa.constants.COPY_GRADLE_API_TO_ASSETS
 import org.adfa.constants.SPLIT_ASSETS
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.TaskProvider
 
 /**
  * Handles asset copying and generation.
@@ -92,11 +93,17 @@ class AndroidIDEAssetsPlugin : Plugin<Project> {
                 CopyDocDbToAssetsTask::class.java
             )
 
+            val gradleApiToAssetsTaskProvider = tasks.register(
+                COPY_GRADLE_API_TO_ASSETS,
+                CopyGradleApiToAssetsTask::class.java
+            )
+
             if (SPLIT_ASSETS) {
                 gradleExecutableToAssetsTaskProvider.configure { enabled = false }
                 gradleCachesToAssetsTaskProvider.configure { enabled = false }
                 androidSdkToAssetsTaskProvider.configure { enabled = false }
                 docDbToAssetsTaskProvider.configure { enabled = false }
+                gradleApiToAssetsTaskProvider.configure { enabled = false }
             }
 
             androidComponentsExtension.onVariants { variant ->
@@ -227,16 +234,22 @@ class AndroidIDEAssetsPlugin : Plugin<Project> {
                     CopyGradleCachesToAssetsTask::outputDirectory
                 )
 
-                // documentation db copier
+                // Local android sdk version copier
                 variant.sources.assets?.addGeneratedSourceDirectory(
                     androidSdkToAssetsTaskProvider,
                     CopySdkToAssetsTask::outputDirectory
                 )
 
-                // Local android sdk version copier
+                // documentation db copier
                 variant.sources.assets?.addGeneratedSourceDirectory(
                     docDbToAssetsTaskProvider,
                     CopyDocDbToAssetsTask::outputDirectory
+                )
+
+                // generated gradle api jar copier
+                variant.sources.assets?.addGeneratedSourceDirectory(
+                    gradleApiToAssetsTaskProvider,
+                    CopyGradleApiToAssetsTask::outputDirectory
                 )
             }
         }

--- a/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/tasks/CopyGradleApiToAssetsTask.kt
+++ b/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/tasks/CopyGradleApiToAssetsTask.kt
@@ -1,0 +1,66 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.plugins.tasks
+
+import org.adfa.constants.DATABASE_FOLDER
+import org.adfa.constants.GRADLE_API_NAME_BR
+import org.adfa.constants.SOURCE_LIB_FOLDER
+import com.google.common.io.Files
+import org.adfa.constants.ASSETS_COMMON_FOLDER
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.io.IOException
+
+abstract class CopyGradleApiToAssetsTask : DefaultTask() {
+
+    /**
+     * The output directory.
+     */
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun CopyGradleApiToAssets() {
+        val outputDirectory = this.outputDirectory.get().file(ASSETS_COMMON_FOLDER).asFile
+        val sourceFilePath =
+            this.project.projectDir.parentFile.path + File.separator + SOURCE_LIB_FOLDER + File.separator + GRADLE_API_NAME_BR
+        copy(sourceFilePath, outputDirectory)
+    }
+
+    private fun copy(sourceFilePath: String, outputDirectory: File) {
+        if (!outputDirectory.exists()) {
+            outputDirectory.mkdirs()
+        }
+
+        val destFile = outputDirectory.resolve(GRADLE_API_NAME_BR)
+        if (destFile.exists()) {
+            destFile.delete()
+        }
+
+        try {
+            Files.copy(File(sourceFilePath), destFile)
+        } catch (e: IOException) {
+            e.message?.let { throw GradleException(it) }
+        }
+    }
+
+}

--- a/libs_source/gradle-api-8.7.jar.br
+++ b/libs_source/gradle-api-8.7.jar.br
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e83fcd30c04612b266e23d8acabcf8f4759c9b2b02f3ff5ec895bd7c6c7fa45
+size 26275425

--- a/libs_source/gradle-api-8.7.jar.zip
+++ b/libs_source/gradle-api-8.7.jar.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:894fab058d0a60568ee641ab54b25aa9e3e97d50f21c71e2513d066f04399161
+size 40630789


### PR DESCRIPTION
 cache and copy back the generated gradle-api-8.7.jar during CoGo install for performance reasons