### PR TITLE
ADFA-1088 | Autoplace cursor in input -Find in file- field and shpwing keyboard by default

### DIFF
--- a/editor/src/main/java/com/itsaky/androidide/editor/ui/EditorSearchLayout.kt
+++ b/editor/src/main/java/com/itsaky/androidide/editor/ui/EditorSearchLayout.kt
@@ -27,6 +27,8 @@ import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.FrameLayout
 import android.widget.PopupMenu
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.itsaky.androidide.editor.databinding.LayoutFindInFileBinding
 import com.itsaky.androidide.editor.ui.ReplaceAction.doReplace
 import com.itsaky.androidide.resources.R
@@ -104,6 +106,11 @@ class EditorSearchLayout(context: Context, val editor: IDEEditor) : FrameLayout(
       false
     }
     findInFileBinding.root.visibility = VISIBLE
+
+    findInFileBinding.searchInput.requestFocus()
+    findInFileBinding.searchInput.post {
+      ViewCompat.getWindowInsetsController(findInFileBinding.searchInput)?.show(WindowInsetsCompat.Type.ime())
+    }
   }
 
   private fun onSearchActionClick(v: View) {


### PR DESCRIPTION
### Description:
Request focus and show keyboard when EditorSearchLayout is shown
The `EditorSearchLayout` will now automatically request focus for the search input field and trigger the display of the soft keyboard when it becomes visible.

### Details:

[ADFA-1088.webm](https://github.com/user-attachments/assets/924f7f30-b3a9-47b2-a7f2-0318b12950f0)


### Ticket:
[ADFA-1088](https://appdevforall.atlassian.net/browse/ADFA-1088)


[ADFA-1088]: https://appdevforall.atlassian.net/browse/ADFA-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ