### PR TITLE
ADFA-1045 | Hide keyboard under back navigation in create project flow

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
@@ -141,6 +141,11 @@ class MainActivity : EdgeToEdgeIDEActivity() {
     private fun onScreenChanged(screen: Int?) {
         val previous = viewModel.previousScreen
         if (previous != -1) {
+            val inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as? android.view.inputmethod.InputMethodManager
+            currentFocus?.let { view ->
+                inputMethodManager?.hideSoftInputFromWindow(view.windowToken, 0)
+            }
+
             // template list -> template details
             // ------- OR -------
             // template details -> template list


### PR DESCRIPTION
### Description:
Refactor: Dismiss keyboard when navigating between screens

The keyboard is now hidden when the user navigates away from a screen that might have it open. This improves the user experience by preventing the keyboard from obscuring content on the new screen.

### Details:

[ADFA-1045.webm](https://github.com/user-attachments/assets/3ef8c9e7-1362-4449-a91e-abd8161fa3fd)

### Ticket:
https://appdevforall.atlassian.net/browse/ADFA-1045