### PR TITLE
ADFA-1300 added deprecated warnings to filter out

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -315,7 +315,9 @@ constructor(
     "The BasePluginExtension.archivesBaseName property has been deprecated.",
     "The Provider.forUseAtConfigurationTime method has been deprecated.",
     "The BuildIdentifier.getName() method has been deprecated.",
-    "Deprecated Gradle features were used in this build"
+    "Deprecated Gradle features were used in this build",
+    "The StartParameter.isConfigurationCacheRequested property has been deprecated.",
+    "Retrieving attribute with a null key. This behavior has been deprecated."
   )
 
   private fun shouldFilter(msg: String): Boolean {


### PR DESCRIPTION
Filtering out the following deprecated warnings:

The StartParameter.isConfigurationCacheRequested property has been deprecated. This is scheduled to be removed in Gradle 10.0. Please use 'configurationCache.requested' property on 'BuildFeatures' service instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14.3/userguide/upgrading_version_8.html#deprecated_startparameter_is_configuration_cache_requested

Retrieving attribute with a null key. This behavior has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys. Consult the upgrading guide for further information: https://docs.gradle.org/8.14.3/userguide/upgrading_version_8.html#null-attribute-lookup