### PR TITLE
ADFA-1355: add feature flag for experiments based on file existence

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/utils/FeatureFlags.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/FeatureFlags.kt
@@ -1,0 +1,17 @@
+
+package com.itsaky.androidide.utils
+
+import android.os.Environment
+import java.io.File
+
+class FeatureFlags {
+    companion object {
+        private const val EXPERIMENTS_FILE_NAME = "CodeOnTheGo.exp"
+        
+        fun isExperimentsEnabled(): Boolean {
+            val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            val experimentsFile = File(downloadsDir, EXPERIMENTS_FILE_NAME)
+            return experimentsFile.exists()
+        }
+    }
+}


### PR DESCRIPTION
See [ADFA-1355](https://appdevforall.atlassian.net/browse/ADFA-1355)  for more info

Following our 2025 retreat hackathon, we have three experimental features ready for early testing:

  - Plugins - Extensibility system for IDE functionality
  - AI Agent - Intelligent code assistance and suggestions
  - Code Playground - Interactive code experimentation environment

  These features need a gating mechanism to control access during development and early testing phases.

  Implementation

  The feature flag checks for the existence of /sdcard/Download/CodeOnTheGo.exp - the file content, size, and metadata don't matter, only presence. This provides:
  - Easy activation for developers and testers (just create the file)
  - Safe default behavior (features disabled by default)
  - Simple cleanup (delete file to disable)

  Developers can now use `FeatureFlags.isExperimentsEnabled()` to conditionally show/hide experimental UI and functionality.

[ADFA-641]: https://appdevforall.atlassian.net/browse/ADFA-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ADFA-1355]: https://appdevforall.atlassian.net/browse/ADFA-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ