### PR TITLE
feat: make FAB draggable and save position

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/fragments/MainFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/MainFragment.kt
@@ -1,10 +1,13 @@
 package com.itsaky.androidide.fragments
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.activity.result.ActivityResult
@@ -12,6 +15,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.viewModels
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.itsaky.androidide.BuildConfig
 import com.itsaky.androidide.R
@@ -62,10 +66,13 @@ class MainFragment : BaseFragment() {
 
     private var currentCloneRequest: CloneRequest? = null
 
+    // Add these constants inside your companion object
     companion object {
-
         private val log = LoggerFactory.getLogger(MainFragment::class.java)
         const val KEY_TOOLTIP_URL = "tooltip_url"
+        private const val FAB_PREFS = "FabPrefs"
+        private const val KEY_FAB_X = "fab_x"
+        private const val KEY_FAB_Y = "fab_y"
     }
 
     private val shareActivityResultLauncher = registerForActivityResult<Intent, ActivityResult>(
@@ -129,8 +136,106 @@ class MainFragment : BaseFragment() {
             )
         }
 
-        binding!!.floatingActionButton?.setOnClickListener {
+        setupDraggableFab()
+    }
+
+    private fun setupDraggableFab() {
+        val fab = binding?.floatingActionButton ?: return
+
+        fab.setOnClickListener {
             performFeedbackAction()
+        }
+
+        loadFabPosition(fab)
+
+        var initialX = 0f
+        var initialY = 0f
+        var initialTouchX = 0f
+        var initialTouchY = 0f
+        var isDragging = false
+
+        fab.setOnTouchListener { v, event ->
+            val parentView = v.parent as? ViewGroup ?: return@setOnTouchListener false
+
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    initialX = v.x
+                    initialY = v.y
+                    initialTouchX = event.rawX
+                    initialTouchY = event.rawY
+                    isDragging = false
+                    true
+                }
+
+                MotionEvent.ACTION_MOVE -> {
+                    val dX = event.rawX - initialTouchX
+                    val dY = event.rawY - initialTouchY
+
+                    if (!isDragging && kotlin.math.sqrt((dX * dX + dY * dY).toDouble()) > ViewConfiguration.get(
+                            v.context
+                        ).scaledTouchSlop
+                    ) {
+                        isDragging = true
+                    }
+
+                    if (isDragging) {
+                        v.x = (initialX + dX).coerceIn(0f, (parentView.width - v.width).toFloat())
+                        v.y = (initialY + dY).coerceIn(0f, (parentView.height - v.height).toFloat())
+                    }
+                    true
+                }
+
+                MotionEvent.ACTION_UP -> {
+                    if (isDragging) {
+                        // This is the new snap-to-edge logic
+                        val middle = parentView.width / 2
+                        val targetX = if ((v.x + v.width / 2) < middle) {
+                            0f // Snap to left edge
+                        } else {
+                            (parentView.width - v.width).toFloat() // Snap to right edge
+                        }
+
+                        // Animate to the target edge after a short delay
+                        v.postDelayed({
+                            v.animate()
+                                .x(targetX)
+                                .setDuration(200)
+                                .withEndAction {
+                                    // Save the final position AFTER the animation completes
+                                    saveFabPosition(targetX, v.y)
+                                }
+                                .start()
+                        }, 500) // 500ms delay before snapping
+                    } else {
+                        v.performClick()
+                    }
+                    true
+                }
+
+                else -> false
+            }
+        }
+    }
+
+    private fun saveFabPosition(x: Float, y: Float) {
+        activity?.getSharedPreferences(FAB_PREFS, Context.MODE_PRIVATE)?.edit()?.apply {
+            putFloat(KEY_FAB_X, x)
+            putFloat(KEY_FAB_Y, y)
+            apply()
+        }
+    }
+
+    private fun loadFabPosition(fab: FloatingActionButton) {
+        val prefs = activity?.getSharedPreferences(FAB_PREFS, Context.MODE_PRIVATE) ?: return
+
+        val x = prefs.getFloat(KEY_FAB_X, -1f)
+        val y = prefs.getFloat(KEY_FAB_Y, -1f)
+
+        if (x != -1f && y != -1f) {
+            fab.post {
+                fab.x = x
+                fab.y = y
+            }
         }
     }
 


### PR DESCRIPTION
This commit introduces the ability to drag the Floating Action Button (FAB) within the MainFragment. The FAB's position is saved in SharedPreferences and restored when the fragment is recreated.

The FAB now snaps to the nearest horizontal edge (left or right) after being dragged and released, with a short delay before snapping. If the FAB is tapped without dragging, it performs its original click action.

Result:

https://appdevforall.atlassian.net/browse/ADFA-1289?focusedCommentId=16262