### PR TITLE
ADFA-1401 Fix getting started URL

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/fragments/MainFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/MainFragment.kt
@@ -132,7 +132,7 @@ class MainFragment : BaseFragment() {
         binding!!.greetingText.setOnClickListener {
             TooltipUtils.showWebPage(
                 requireContext(),
-                "file:///android_asset/idetooltips/getstarted_top.html"
+                "http://localhost:6174/i/getstarted_top.html"
             )
         }
 


### PR DESCRIPTION
Old one was here: file:///android_asset/idetooltips/getstarted_top.htm (wrong)
New one is here: http://localhost:6174/i/getstarted_top.html (correct)