### PR TITLE
ADFA-1140 Move CoGo-specific Gradle configuration from build files to our Gradle plugins

### DIFF
--- a/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
+++ b/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
@@ -56,8 +56,11 @@ const val ARM_KEY = "armeabi"
 
 //Local maven repo
 const val LOCAL_MAVEN_REPO_ARCHIVE_ZIP_NAME = "localMvnRepository.zip"
-val LOCAL_MAVEN_CACHES_DEST = HOME_PATH + File.separator + "maven"
+const val LOCAL_MAVEN_CACHES_DEST = "$HOME_PATH/maven"
 const val LOCAL_MAVEN_REPO_FOLDER_DEST = "localMvnRepository"
+
+@Suppress("SdCardPath")
+const val MAVEN_LOCAL_REPOSITORY = "/data/data/com.itsaky.androidide/files/$LOCAL_MAVEN_CACHES_DEST/$LOCAL_MAVEN_REPO_FOLDER_DEST"
 
 // Tooltips
 const val CONTENT_KEY = "CONTENT_KEY"

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/root/settings.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/root/settings.kt
@@ -17,8 +17,6 @@
 
 package com.itsaky.androidide.templates.base.root
 
-import org.adfa.constants.LOCAL_MAVEN_CACHES_DEST
-import org.adfa.constants.LOCAL_MAVEN_REPO_FOLDER_DEST
 import com.itsaky.androidide.templates.base.ProjectTemplateBuilder
 
 /**
@@ -31,14 +29,17 @@ internal fun ProjectTemplateBuilder.settingsGradleSrcStr(): String {
   return """
 pluginManagement {
   repositories {
-    maven(uri("/data/data/com.itsaky.androidide/files/$LOCAL_MAVEN_CACHES_DEST/$LOCAL_MAVEN_REPO_FOLDER_DEST"))
+    gradlePluginPortal()
+    google()
+    mavenCentral()
   }
 }
 
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
-    maven(uri("/data/data/com.itsaky.androidide/files/$LOCAL_MAVEN_CACHES_DEST/$LOCAL_MAVEN_REPO_FOLDER_DEST"))
+    google()
+    mavenCentral()
   }
 }
 
@@ -51,16 +52,19 @@ ${modules.joinToString(separator = ", ") { "include(\"${it.name}\")" }}
 internal fun ProjectTemplateBuilder.settingsGroovyGradleSrcStr(): String {
   return """
 pluginManagement {
-    repositories {
-        maven { url = uri("/data/data/com.itsaky.androidide/files/$LOCAL_MAVEN_CACHES_DEST/$LOCAL_MAVEN_REPO_FOLDER_DEST") }
-    }
+  repositories {
+    gradlePluginPortal()
+    google()
+    mavenCentral()
+  }
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        maven { url = uri("/data/data/com.itsaky.androidide/files/$LOCAL_MAVEN_CACHES_DEST/$LOCAL_MAVEN_REPO_FOLDER_DEST") }
-    }
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+  }
 }
 
 rootProject.name = "${data.name}"


### PR DESCRIPTION
Move maven local repo configuration from template projects setting.gradle(.kts) to cogo plugin.  Restore repository values required for builds in online mode and external IDE (i.e. Android Studio)