### PR TITLE
ADFA-1367: Set tooltips in editor toolbar

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/build/DebugAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/build/DebugAction.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.activities.editor.EditorHandlerActivity
+import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.lsp.java.debug.JdwpOptions
 import com.itsaky.androidide.projects.api.AndroidModule
 import com.itsaky.androidide.projects.builder.BuildService
@@ -30,6 +31,7 @@ class DebugAction(
 ) {
 
     override val id = ID
+    override var tooltipTag: String = TooltipTag.EDITOR_TOOLBAR_DEBUG
 
     companion object {
         const val ID = "ide.editor.build.debug"

--- a/app/src/main/java/com/itsaky/androidide/actions/build/ProjectSyncAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/build/ProjectSyncAction.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import androidx.core.content.ContextCompat
 import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.actions.BaseBuildAction
+import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.resources.R
 import com.itsaky.androidide.resources.R.string
 
@@ -42,6 +43,8 @@ class ProjectSyncAction(context: Context, override val order: Int) : BaseBuildAc
     label = context.getString(string.title_sync_project)
     icon = ContextCompat.getDrawable(context, R.drawable.ic_sync)
   }
+
+  override var tooltipTag: String = TooltipTag.EDITOR_TOOLBAR_SYNC
 
   override suspend fun execAction(data: ActionData): Any {
     return data.requireActivity().saveAll(requestSync = false)

--- a/app/src/main/java/com/itsaky/androidide/actions/build/QuickRunAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/build/QuickRunAction.kt
@@ -24,6 +24,7 @@ import android.graphics.PorterDuffColorFilter
 import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.actions.getContext
 import com.itsaky.androidide.activities.editor.EditorHandlerActivity
+import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.projects.api.AndroidModule
 import com.itsaky.androidide.projects.builder.BuildService
 import com.itsaky.androidide.resources.R
@@ -47,10 +48,10 @@ class QuickRunAction(context: Context, override val order: Int) :
     ) {
 
     override val id: String = ID
-
     companion object {
         const val ID = "ide.editor.build.quickRun"
     }
+    override var tooltipTag: String = TooltipTag.EDITOR_TOOLBAR_QUICK_RUN
 
     override fun onCreateTaskExecMessage(
         data: ActionData,

--- a/app/src/main/java/com/itsaky/androidide/actions/build/RunTasksAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/build/RunTasksAction.kt
@@ -22,11 +22,14 @@ import androidx.core.content.ContextCompat
 import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.actions.BaseBuildAction
 import com.itsaky.androidide.fragments.RunTasksDialogFragment
+import com.itsaky.androidide.idetooltips.TooltipCategory
+import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.resources.R
 
 /** @author Akash Yadav */
 class RunTasksAction(context: Context, override val order: Int) : BaseBuildAction() {
   override val id: String = ID
+  override var tooltipTag: String = TooltipTag.EDITOR_TOOLBAR_RUN_TASKS
   private var dialog: RunTasksDialogFragment? = null
 
   companion object {

--- a/app/src/main/java/com/itsaky/androidide/actions/etc/FindAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/etc/FindAction.kt
@@ -22,6 +22,7 @@ import androidx.core.content.ContextCompat
 import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.actions.EditorActivityAction
 import com.itsaky.androidide.actions.build.AbstractCancellableRunAction.Companion.isBuildInProgress
+import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.resources.R
 
 /** @author Akash Yadav */
@@ -29,6 +30,7 @@ class FindAction() : EditorActivityAction() {
 
     override var requiresUIThread: Boolean = true
     override var order: Int = 0
+    override var tooltipTag: String = TooltipTag.EDITOR_TOOLBAR_FIND
 
     constructor(context: Context, order: Int) : this() {
         this.label = context.getString(R.string.menu_find)

--- a/app/src/main/java/com/itsaky/androidide/actions/etc/FindInProjectAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/etc/FindInProjectAction.kt
@@ -23,6 +23,7 @@ import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.actions.ActionItem
 import com.itsaky.androidide.actions.EditorActivityAction
 import com.itsaky.androidide.actions.markInvisible
+import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.projects.IProjectManager
 import com.itsaky.androidide.resources.R
 
@@ -32,6 +33,7 @@ class FindInProjectAction() : EditorActivityAction() {
   override var requiresUIThread: Boolean = true
   override var order: Int = 0
   override var location: ActionItem.Location = ActionItem.Location.EDITOR_FIND_ACTION_MENU
+  override var tooltipTag: String = TooltipTag.EDITOR_TOOLBAR_FIND_IN_PROJECT
 
   constructor(context: Context, order: Int) : this() {
     this.label = context.getString(R.string.menu_find_project)

--- a/app/src/main/java/com/itsaky/androidide/actions/etc/LaunchAppAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/etc/LaunchAppAction.kt
@@ -25,6 +25,7 @@ import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.actions.EditorActivityAction
 import com.itsaky.androidide.actions.markInvisible
 import com.itsaky.androidide.actions.openApplicationModuleChooser
+import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.projects.IProjectManager
 import com.itsaky.androidide.utils.IntentUtils
 import com.itsaky.androidide.utils.flashError
@@ -39,6 +40,7 @@ class LaunchAppAction(context: Context, override val order: Int) : EditorActivit
 
   override val id: String = "ide.editor.launchInstalledApp"
   override var requiresUIThread: Boolean = true
+  override var tooltipTag: String = TooltipTag.EDITOR_TOOLBAR_LAUNCH_APP
 
   init {
     label = context.getString(R.string.title_launch_app)

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -480,14 +480,6 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
             this::handleUiDesignerResult
         )
 
-        content.noEditorLayout.setOnLongClickListener {
-            showTooltip(
-                category = TooltipCategory.CATEGORY_IDE,
-                tag = TooltipTag.EDITOR_PROJECT_OVERVIEW
-            )
-            true
-        }
-
         content.bottomSheet.binding.buildStatus.buildStatusLayout.setOnLongClickListener {
             showTooltip(
                 category = TooltipCategory.CATEGORY_IDE,
@@ -923,6 +915,13 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
     }
 
     private fun setupNoEditorView() {
+        content.noEditorLayout.setOnLongClickListener {
+            showTooltip(
+                category = TooltipCategory.CATEGORY_IDE,
+                tag = TooltipTag.EDITOR_PROJECT_OVERVIEW
+            )
+            true
+        }
         content.noEditorSummary.movementMethod = LinkMovementMethod()
         val sb = SpannableStringBuilder()
         val indentParent = 80

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -488,6 +488,14 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
             true
         }
 
+        content.bottomSheet.binding.buildStatus.buildStatusLayout.setOnLongClickListener {
+            showTooltip(
+                category = TooltipCategory.CATEGORY_IDE,
+                tag = TooltipTag.EDITOR_BUILD_STATUS
+            )
+            true
+        }
+
         setupMemUsageChart()
         watchMemory()
     }

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -37,6 +37,7 @@ import android.text.TextUtils
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.text.style.LeadingMarginSpan
+import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -90,6 +91,9 @@ import com.itsaky.androidide.fragments.sidebar.EditorSidebarFragment
 import com.itsaky.androidide.fragments.sidebar.FileTreeFragment
 import com.itsaky.androidide.handlers.EditorActivityLifecyclerObserver
 import com.itsaky.androidide.handlers.LspHandler.registerLanguageServers
+import com.itsaky.androidide.idetooltips.TooltipCategory
+import com.itsaky.androidide.idetooltips.TooltipManager
+import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.interfaces.DiagnosticClickListener
 import com.itsaky.androidide.lookup.Lookup
 import com.itsaky.androidide.lsp.models.DiagnosticItem
@@ -125,6 +129,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.adfa.constants.CONTENT_KEY
+import org.adfa.constants.CONTENT_TITLE_KEY
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.slf4j.Logger
@@ -499,6 +505,12 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
 
             binding.editorDrawerLayout.addDrawerListener(toggle)
             toggle.syncState()
+            setOnNavIconLongClickListener {
+                showTooltip(
+                    category = TooltipCategory.CATEGORY_IDE,
+                    tag = TooltipTag.EDITOR_TOOLTIP_NAV_ICON
+                )
+            }
         }
 
     }
@@ -709,7 +721,8 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
         fragmentClass: Class<out Fragment>,
         sheetState: Int = BottomSheetBehavior.STATE_EXPANDED
     ) {
-        val index = content.bottomSheet.pagerAdapter.findIndexOfFragmentByClass(fragmentClass)
+        val index =
+            content.bottomSheet.pagerAdapter.findIndexOfFragmentByClass(fragmentClass)
         if (index >= 0 && index < content.bottomSheet.binding.tabs.tabCount) {
             if (editorBottomSheet?.state != sheetState) {
                 editorBottomSheet?.state = sheetState
@@ -764,12 +777,14 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
     private fun handleUiDesignerResult(result: ActivityResult) {
         if (result.resultCode != RESULT_OK || result.data == null) {
             log.warn(
-                "UI Designer returned invalid result: resultCode={}, data={}", result.resultCode,
+                "UI Designer returned invalid result: resultCode={}, data={}",
+                result.resultCode,
                 result.data
             )
             return
         }
-        val generated = result.data!!.getStringExtra(UIDesignerActivity.RESULT_GENERATED_XML)
+        val generated =
+            result.data!!.getStringExtra(UIDesignerActivity.RESULT_GENERATED_XML)
         if (TextUtils.isEmpty(generated)) {
             log.warn("UI Designer returned blank generated XML code")
             return
@@ -804,8 +819,10 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
         binding.apply {
             editorDrawerLayout.apply {
                 childId = contentCard.id
-                translationBehaviorStart = ContentTranslatingDrawerLayout.TranslationBehavior.FULL
-                translationBehaviorEnd = ContentTranslatingDrawerLayout.TranslationBehavior.FULL
+                translationBehaviorStart =
+                    ContentTranslatingDrawerLayout.TranslationBehavior.FULL
+                translationBehaviorEnd =
+                    ContentTranslatingDrawerLayout.TranslationBehavior.FULL
                 setScrimColor(Color.TRANSPARENT)
             }
         }
@@ -874,8 +891,16 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
 
         binding.contentCard.progress = 0f
         binding.swipeReveal.dragListener = object : SwipeRevealLayout.OnDragListener {
-            override fun onDragStateChanged(swipeRevealLayout: SwipeRevealLayout, state: Int) {}
-            override fun onDragProgress(swipeRevealLayout: SwipeRevealLayout, progress: Float) {
+            override fun onDragStateChanged(
+                swipeRevealLayout: SwipeRevealLayout,
+                state: Int
+            ) {
+            }
+
+            override fun onDragProgress(
+                swipeRevealLayout: SwipeRevealLayout,
+                progress: Float
+            ) {
                 onSwipeRevealDragProgress(progress)
             }
         }
@@ -1012,6 +1037,35 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
 
     open fun installationSessionCallback(): SessionCallback {
         return ApkInstallationSessionCallback(this).also { installationCallback = it }
+    }
+
+
+    private fun showTooltip(category: String, tag: String) {
+        CoroutineScope(Dispatchers.Main).launch {
+            val tooltipItem = TooltipManager.getTooltip(
+                this@BaseEditorActivity,
+                category,
+                tag,
+            )
+            if (tooltipItem != null) {
+                TooltipManager.showIDETooltip(
+                    context = this@BaseEditorActivity,
+                    anchorView = content.customToolbar,
+                    level = 0,
+                    tooltipItem = tooltipItem,
+                    onHelpLinkClicked = { context, url, title ->
+                        val intent =
+                            Intent(context, HelpActivity::class.java).apply {
+                                putExtra(CONTENT_KEY, url)
+                                putExtra(CONTENT_TITLE_KEY, title)
+                            }
+                        context.startActivity(intent)
+                    }
+                )
+            } else {
+                Log.e("EditorHandlerActivity", "Tooltip item $tooltipItem is null")
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -482,7 +482,6 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
 
         content.bottomSheet.binding.buildStatus.buildStatusLayout.setOnLongClickListener {
             showTooltip(
-                category = TooltipCategory.CATEGORY_IDE,
                 tag = TooltipTag.EDITOR_BUILD_STATUS
             )
             true
@@ -515,7 +514,6 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
             toggle.syncState()
             setOnNavIconLongClickListener {
                 showTooltip(
-                    category = TooltipCategory.CATEGORY_IDE,
                     tag = TooltipTag.EDITOR_TOOLTIP_NAV_ICON
                 )
             }
@@ -917,7 +915,6 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
     private fun setupNoEditorView() {
         content.noEditorLayout.setOnLongClickListener {
             showTooltip(
-                category = TooltipCategory.CATEGORY_IDE,
                 tag = TooltipTag.EDITOR_PROJECT_OVERVIEW
             )
             true
@@ -1055,11 +1052,11 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
     }
 
 
-    private fun showTooltip(category: String, tag: String) {
+    private fun showTooltip(tag: String) {
         CoroutineScope(Dispatchers.Main).launch {
             val tooltipItem = TooltipManager.getTooltip(
                 this@BaseEditorActivity,
-                category,
+                TooltipCategory.CATEGORY_IDE,
                 tag,
             )
             if (tooltipItem != null) {

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -480,6 +480,14 @@ abstract class BaseEditorActivity : EdgeToEdgeIDEActivity(), TabLayout.OnTabSele
             this::handleUiDesignerResult
         )
 
+        content.noEditorLayout.setOnLongClickListener {
+            showTooltip(
+                category = TooltipCategory.CATEGORY_IDE,
+                tag = TooltipTag.EDITOR_PROJECT_OVERVIEW
+            )
+            true
+        }
+
         setupMemUsageChart()
         watchMemory()
     }

--- a/app/src/main/res/layout/content_editor.xml
+++ b/app/src/main/res/layout/content_editor.xml
@@ -66,6 +66,7 @@
             android:layout_marginBottom="@dimen/editor_sheet_peek_height" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/no_editor_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/layout_editor_build_status.xml
+++ b/app/src/main/res/layout/layout_editor_build_status.xml
@@ -16,39 +16,40 @@
   -->
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:layout_width="match_parent"
-  android:layout_height="56dp">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/build_status_layout"
+    android:layout_width="match_parent"
+    android:layout_height="56dp">
 
-  <TextView
-    android:id="@+id/statusText"
-    android:layout_width="0dp"
-    android:layout_height="0dp"
-    android:paddingStart="16dp"
-    android:paddingEnd="16dp"
-    android:gravity="center"
-    android:maxLines="1"
-    android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
-    app:layout_constraintBottom_toTopOf="@id/swipe_hint"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    tools:text="Configure project :app" />
+    <TextView
+        android:id="@+id/statusText"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:maxLines="1"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+        app:layout_constraintBottom_toTopOf="@id/swipe_hint"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Configure project :app" />
 
-  <TextView
-    android:id="@+id/swipe_hint"
-    android:layout_width="0dp"
-    android:layout_height="0dp"
-    android:gravity="center"
-    android:maxLines="1"
-    android:text="@string/msg_swipe_up"
-    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
-    android:textColor="?attr/colorOnBackground"
-    android:textSize="11sp"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/statusText" />
+    <TextView
+        android:id="@+id/swipe_hint"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:maxLines="1"
+        android:text="@string/msg_swipe_up"
+        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+        android:textColor="?attr/colorOnBackground"
+        android:textSize="11sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/statusText" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/common/src/main/java/com/itsaky/androidide/ui/CustomToolbar.kt
+++ b/common/src/main/java/com/itsaky/androidide/ui/CustomToolbar.kt
@@ -8,14 +8,34 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageButton
 import android.widget.LinearLayout
-import android.widget.Toast
 import com.google.android.material.appbar.MaterialToolbar
 import com.itsaky.androidide.common.R
 import com.itsaky.androidide.common.databinding.CustomToolbarBinding
 
 class CustomToolbar @JvmOverloads constructor(
-    context: Context, attrs: AttributeSet? = null
+    context: Context,
+    attrs: AttributeSet? = null,
+    var onNavIconLongClick: (() -> Unit)? = null
 ) : MaterialToolbar(context, attrs) {
+
+    init {
+        this.post {
+            var navButton: ImageButton? = null
+            for (i in 0 until this.childCount) {
+                val child = this.getChildAt(i)
+                if (child is ImageButton && child.contentDescription == this.navigationContentDescription) {
+                    navButton = child
+                    break
+                }
+            }
+
+            navButton?.setOnLongClickListener {
+                onNavIconLongClick?.invoke()
+                true
+            }
+
+        }
+    }
 
     private val binding: CustomToolbarBinding =
         CustomToolbarBinding.inflate(LayoutInflater.from(context), this, true)
@@ -67,5 +87,9 @@ class CustomToolbar @JvmOverloads constructor(
 
     fun clearMenu() {
         binding.menuContainer.removeAllViews()
+    }
+
+    fun setOnNavIconLongClickListener(listener: (() -> Unit)?) {
+        this.onNavIconLongClick = listener
     }
 }

--- a/common/src/main/java/com/itsaky/androidide/ui/CustomToolbar.kt
+++ b/common/src/main/java/com/itsaky/androidide/ui/CustomToolbar.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageButton
 import android.widget.LinearLayout
+import android.widget.Toast
 import com.google.android.material.appbar.MaterialToolbar
 import com.itsaky.androidide.common.R
 import com.itsaky.androidide.common.databinding.CustomToolbarBinding
@@ -25,7 +26,13 @@ class CustomToolbar @JvmOverloads constructor(
         }
     }
 
-    fun addMenuItem(icon: Drawable?, hint: String, onClick: () -> Unit, shouldAddMargin: Boolean) {
+    fun addMenuItem(
+        icon: Drawable?,
+        hint: String,
+        onClick: () -> Unit,
+        onLongClick: () -> Unit,
+        shouldAddMargin: Boolean
+    ) {
         val item = ImageButton(context).apply {
             tooltipText = hint
             setImageDrawable(icon)
@@ -41,6 +48,10 @@ class CustomToolbar @JvmOverloads constructor(
                 }
             }
             setOnClickListener { onClick() }
+            setOnLongClickListener {
+                onLongClick()
+                true
+            }
         }
         binding.menuContainer.addView(item)
     }

--- a/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/TooltipTag.kt
+++ b/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/TooltipTag.kt
@@ -36,5 +36,5 @@ object TooltipTag {
     const val EDITOR_TOOLBAR_FIND_IN_PROJECT = "project.find.in.project"
     const val EDITOR_TOOLBAR_SYNC = "project.sync"
     const val EDITOR_TOOLBAR_LAUNCH_APP = "project.launch.app"
-    const val EDITOR_BUILD_STATUS = "project.status.bar"
+    const val EDITOR_BUILD_STATUS = "project.status"
 }

--- a/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/TooltipTag.kt
+++ b/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/TooltipTag.kt
@@ -26,4 +26,14 @@ object TooltipTag {
     const val PREFS_BUILD_RUN = "prefs.buildrun"
     const val PREFS_TERMUX = "prefs.termux"
 
+    const val PROJECT_OVERVIEW_TEXT = "project.overview"
+    const val EDITOR_TOOLTIP_NAV_ICON = "project.menu"
+    const val EDITOR_TOOLBAR_QUICK_RUN = "project.run"
+    const val EDITOR_TOOLBAR_DEBUG = "project.debug"
+    const val EDITOR_TOOLBAR_RUN_TASKS = "project.gradle.tasks"
+    const val EDITOR_TOOLBAR_FIND = "project.find.top"
+    const val EDITOR_TOOLBAR_FIND_IN_PROJECT = "project.find.in.project"
+    const val EDITOR_TOOLBAR_SYNC = "project.sync"
+    const val EDITOR_TOOLBAR_LAUNCH_APP = "project.launch.app"
+    const val EDITOR_BUILD_STATUS = "project.status.bar"
 }

--- a/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/TooltipTag.kt
+++ b/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/TooltipTag.kt
@@ -27,6 +27,7 @@ object TooltipTag {
     const val PREFS_TERMUX = "prefs.termux"
 
     const val PROJECT_OVERVIEW_TEXT = "project.overview"
+    const val EDITOR_PROJECT_OVERVIEW = "project.overview"
     const val EDITOR_TOOLTIP_NAV_ICON = "project.menu"
     const val EDITOR_TOOLBAR_QUICK_RUN = "project.run"
     const val EDITOR_TOOLBAR_DEBUG = "project.debug"


### PR DESCRIPTION
Set tooltips on editor toolbar actions - `Menu`, `QuickRun`, `Debug`, `RunGradleTasks`, `ProjectOverview` and `ProjectStatus`

The tooltip tag - `project.overview` for `ProjectOverview` is yet to be added to the database.


https://github.com/user-attachments/assets/89b20eb4-8a0c-4e35-a59a-bd1620176836

