### PR TITLE
[Used for QA] Automate rejection of branches with names that are too long

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -46,6 +46,22 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
+      - name: Validate branch name length
+        run: |
+          BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          BRANCH_LENGTH=${#BRANCH_NAME}
+          echo "Branch name: $BRANCH_NAME"
+          echo "Branch name length: $BRANCH_LENGTH characters"
+          
+          if [ $BRANCH_LENGTH -gt 80 ]; then
+            echo "ERROR: Branch name exceeds the 80 character limit ($BRANCH_LENGTH characters)"
+            echo "This causes Google Cloud authentication to fail due to subject mapping limits."
+            echo "Please rename your branch to 80 characters or fewer and try again."
+            exit 1
+          fi
+          
+          echo "Branch name length is valid ($BRANCH_LENGTH ≤ 80 characters)"
+
       - name: Install Git LFS
         run: |
           sudo apt-get update


### PR DESCRIPTION
This is to QA [ADFA-1524](https://appdevforall.atlassian.net/browse/ADFA-1524)

We have made the branch name 148 character to test for the 80 character limit

[ADFA-1524]: https://appdevforall.atlassian.net/browse/ADFA-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ