### PR TITLE
ADFA-1454 Put slf4j into dependencies to restore Web Server logging

### DIFF
--- a/logger/build.gradle.kts
+++ b/logger/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     api(libs.logging.logback.core)
     api(libs.logging.logback.classic)
+    api(libs.tooling.slf4j)
 
     implementation(projects.buildInfo)
     implementation(libs.google.auto.service)


### PR DESCRIPTION
I thought I had added this a week or two ago but I guess not

See also #353 