### PR TITLE
fix(ADFA-1580): Show tooltip for file tree help

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/filetree/HelpAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/filetree/HelpAction.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.R
 import com.itsaky.androidide.actions.requireContext
+import com.itsaky.androidide.idetooltips.TooltipCategory
+import com.itsaky.androidide.idetooltips.TooltipManager
+import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.utils.UrlManager
 
 class HelpAction(context: Context, override val order: Int) :
@@ -16,13 +19,13 @@ class HelpAction(context: Context, override val order: Int) :
 
     override suspend fun execAction(data: ActionData) {
         val context = data.requireContext()
-        UrlManager.openUrl(
-            url = HELP_URL,
-            context = context
+
+        TooltipManager.showTooltip(
+            context = context,
+            anchorView = data.requireTreeNode().viewHolder.view,
+            category = TooltipCategory.CATEGORY_IDE,
+            tag = TooltipTag.PROJECT_FILE_HELP,
         )
     }
 
-    companion object {
-        private const val HELP_URL = "https://code-on-the-go.com/help"
-    }
 }

--- a/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/TooltipTag.kt
+++ b/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/TooltipTag.kt
@@ -111,4 +111,5 @@ object TooltipTag {
     const val DIALOG_REPLACE_IN_FILE = "file.find.replace.dialog"
     const val PROJECT_FILENAME = "project.filename"
     const val EDITOR_FILE_CLOSE_OPTIONS = "editor.file.close.options"
+    const val PROJECT_FILE_HELP = "project.file.help"
 }


### PR DESCRIPTION
Show tooltip when `Help` is clicked from file action.

[Jira ticket](https://appdevforall.atlassian.net/browse/ADFA-1580)

https://github.com/user-attachments/assets/2c6128e3-0e83-4be9-a75a-69646e465c58

