### PR TITLE
1545 | Clarify "Open from folder" text

### DIFF
--- a/app/src/main/res/layout/fragment_saved_projects.xml
+++ b/app/src/main/res/layout/fragment_saved_projects.xml
@@ -67,7 +67,7 @@
             android:layout_margin="16dp"
             android:layout_below="@id/tvCreateNewProject"
             android:layout_centerHorizontal="true"
-            android:text="@string/find_saved_project" />
+            android:text="@string/open_from_folder" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/saved_project_open_folder_layout.xml
+++ b/app/src/main/res/layout/saved_project_open_folder_layout.xml
@@ -16,7 +16,7 @@
             android:id="@+id/open_from_folder_txt"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/find_saved_project"
+            android:text="@string/open_from_folder"
             android:textColor="?attr/colorPrimary"
             android:textSize="16sp"
             app:layout_constraintStart_toStartOf="parent"

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -708,7 +708,7 @@
 	<string name="msg_create_new_project_instruction">Click the New project button to create a new project.</string>
 	<string name="date">Date</string>
 	<string name="project_directory_invalid">%s is not a valid Android project folder, please open another folder instead</string>
-	<string name="find_saved_project">Find a saved project</string>
+	<string name="open_from_folder">Open from folder</string>
 	<string name="msg_delete_selected_project">Are you sure want to delete the selected project(s)? This action cannot be undone.</string>
 	<string name="feedback_email">feedback@appdevforall.org</string>
 	<string name="no_email_apps">No email apps found</string>


### PR DESCRIPTION
## Description

This PR addresses user confusion on the "Open a saved project" screen when no recent projects are available. The patch renames the string resource `find_saved_project` to `open_from_folder` to make the action's intent clearer and more direct for the user.

## Details

The change is reflected in the UI text, updating "Find a saved project" to **"Open from folder"**. This improves consistency and usability.

<p align="center">
<img width="338" height="720" alt="Screenshot 2025-09-25 at 3 25 46 PM" src="https://github.com/user-attachments/assets/950db82f-ed8c-43c1-8c9b-320cbbb7f4e1" />

<img width="339" height="721" alt="Screenshot 2025-09-25 at 3 26 56 PM" src="https://github.com/user-attachments/assets/004f5a16-8e09-4191-85e3-9a62dae8d8bd" />
</p>


https://github.com/user-attachments/assets/0456991a-3232-49d8-92ec-d8bed607869b

https://github.com/user-attachments/assets/5b8d304e-2911-4a99-b17e-3ed1dad68b36


## Ticket

[1545](https://appdevforall.atlassian.net/browse/ADFA-1545)

## Observation

- This is a minor UI text update that improves the overall user experience by using more precise language, aligning with the functionality described in the original bug report.
- During verification, it was not possible to reproduce the main bug reported in the ticket (the descriptive text acting as a hidden button), which suggests it was already resolved in a previous commit.
- Therefore, this change focuses on resolving the secondary issue of unclear wording, improving the user experience with more precise language.