### PR TITLE
Change the 'last change' tooltip query to work with new documentation database

### DIFF
--- a/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/ToolTipManager.kt
+++ b/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/ToolTipManager.kt
@@ -54,8 +54,9 @@ object TooltipManager {
     """
 
     private const val QUERY_LAST_CHANGE = """
-        SELECT now, who
+        SELECT changeTime, who
         FROM LastChange
+        WHERE documentationSet = 'wholedb'
     """
 
     suspend fun getTooltip(context: Context, category: String, tag: String): IDETooltipItem? {


### PR DESCRIPTION


LastChange was updated to have multiple entries corresponding to different subsets of the content. New database is at https://drive.google.com/drive/u/0/folders/1uyo2M8hMLZT4WYYQmPglfeoGNqOMLVyS

Ticket [https://appdevforall.atlassian.net/browse/ADFA-1550](https://appdevforall.atlassian.net/browse/ADFA-1550) "Track date of update for documentation.db and for the individual content sets shoved into it"

--

New schema is:

CREATE TABLE LastChange (
        documentationSet TEXT,
        changeTime TIMESTAMP,
        who TEXT
    );

--

This breaks tooltips because the static LastChange query in ToolTipManager doesn't grab the correct data. Fixing column names and adding a where clause to find the full-database-change record fixes this issue,