### PR TITLE
Correct category in tooltip query when editing a .xml file

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/file/ShowTooltipAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/file/ShowTooltipAction.kt
@@ -45,6 +45,7 @@ class ShowTooltipAction(private val context: Context, override val order: Int) :
         val category = when (editor.file?.extension) {
             "java" -> TooltipCategory.CATEGORY_JAVA
             "kt" -> TooltipCategory.CATEGORY_KOTLIN
+            "xml" -> TooltipCategory.CATEGORY_XML
             else -> TooltipCategory.CATEGORY_IDE
         }
         val word = editor.text.substring(cursor.left, cursor.right)

--- a/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/TooltipCategory.kt
+++ b/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/TooltipCategory.kt
@@ -4,5 +4,5 @@ object TooltipCategory {
     const val CATEGORY_IDE = "ide"
     const val CATEGORY_JAVA = "java"
     const val CATEGORY_KOTLIN = "kotlin"
-    const val CATEGORY_XML = "le"
+    const val CATEGORY_XML = "xml"
 }


### PR DESCRIPTION
Ticket: "Tooltips accessed through code editor inside of .xml files have category "ide"

URL: [https://appdevforall.atlassian.net/browse/ADFA-1676](https://appdevforall.atlassian.net/browse/ADFA-1676)

---

All tooltips in category TooltipCategory.CATEGORY_XML are inaccessible when editing a .xml file because a faulty extension check sets the query category to "ide".

---

Re-implementing the extension check and updating the TooltipCategory.CATEGORY_XML string to "xml" lets CoGo correctly handle XML tooltips in current database