### PR TITLE
ADFA-1675-Main-page-change-learn-msg-to-quickstart

### DIFF
--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -75,7 +75,7 @@
     <string name="new_project">New project</string>
     <string name="package_name">Package name</string>
     <string name="project_app_name">App name</string>
-    <string name="msg_create_new_project_greeting">Learn about <b>Code on the Go</b> here!</string>
+    <string name="msg_create_new_project_greeting">Read the Quick Start guide</string>
     <string name="title_confirm_open_project">Open last project?</string>
     <string name="msg_confirm_open_project">Do you want to open the last opened project? Opened project was:\n%s</string>
     <string name="title_close_project">Close this project</string>


### PR DESCRIPTION
Changed "Learn about Code on the Go here" to direct the user to the quick start instead. There's another ticket to make that entire section clickable and point at the Quick Start page. 