### PR TITLE
ADFA-1195: Add xml.attr. prefix to XML attribute tooltips in editor

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/file/ShowTooltipAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/file/ShowTooltipAction.kt
@@ -41,7 +41,7 @@ class ShowTooltipAction(private val context: Context, override val order: Int) :
     override suspend fun execAction(data: ActionData): Any {
         val editor = data.getEditor()!!
         val cursor = editor.text.cursor
-        val activity = data.getActivity()
+        val isXml = editor.file?.extension == "xml"
         val category = when (editor.file?.extension) {
             "java" -> TooltipCategory.CATEGORY_JAVA
             "kt" -> TooltipCategory.CATEGORY_KOTLIN
@@ -50,11 +50,17 @@ class ShowTooltipAction(private val context: Context, override val order: Int) :
         }
         val word = editor.text.substring(cursor.left, cursor.right)
         if (cursor.isSelected) {
+            val tag = if (isXml) {
+                // Prepend xml.attr. and remove namespace prefix for XML attributes
+                "xml.attr.${word.substringAfterLast(":")}"
+            } else {
+                word
+            }
             TooltipManager.showTooltip(
                 context = context,
                 anchorView = editor,
                 category = category,
-                tag = word,
+                tag = tag,
             )
         }
         return true

--- a/editor/src/main/java/com/itsaky/androidide/editor/ui/EditorCompletionWindow.kt
+++ b/editor/src/main/java/com/itsaky/androidide/editor/ui/EditorCompletionWindow.kt
@@ -63,6 +63,7 @@ class EditorCompletionWindow(val editor: IDEEditor) : EditorAutoCompletion(edito
             it.adapter = this.adapter
             it.setOnItemLongClickListener { _, view, position, _ ->
 
+                val isXml = editor.file?.extension == "xml"
                 val category = when (editor.file?.extension) {
                     "java" -> TooltipCategory.CATEGORY_JAVA
                     "kt" -> TooltipCategory.CATEGORY_KOTLIN
@@ -76,7 +77,12 @@ class EditorCompletionWindow(val editor: IDEEditor) : EditorAutoCompletion(edito
 
                 val tag = if (completionData == null) {
                     // completionData is null for XML attributes; use ideLabel instead
-                    completionItem?.ideLabel?.takeIf {labelString -> labelString.contains("android") }?.substringAfterLast(":")
+                    val attrName = completionItem?.ideLabel?.takeIf {labelString -> labelString.contains("android") }?.substringAfterLast(":")
+                    if (isXml && attrName != null) {
+                        "xml.attr.$attrName"
+                    } else {
+                        attrName
+                    }
                 } else {
                     DocumentationReferenceProvider.getTag(completionData)
                 }


### PR DESCRIPTION
  When editing XML files, prepend "xml.attr." to attribute names in tooltips
  to match the format used in the GUI layout editor. This ensures consistent
  tooltip lookup across both the text editor and visual editor.

  Changes:
  - ShowTooltipAction: Add xml.attr. prefix for XML attributes
  - EditorCompletionWindow: Add xml.attr. prefix in completion tooltips
  - Strip namespace prefixes (e.g., "android:") from attribute names