### PR TITLE
ADFA-1698 | Add horizontal padding to the no-editor summary text

### DIFF
--- a/app/src/main/res/layout/content_editor.xml
+++ b/app/src/main/res/layout/content_editor.xml
@@ -93,6 +93,7 @@
                 android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
                 android:textColor="?attr/colorSecondaryVariant"
                 android:textSize="13sp"
+                android:paddingHorizontal="16dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/no_editor_title"


### PR DESCRIPTION
## Description

This PR adds horizontal padding to the `TextView` that is displayed on the project page when no files are open. Following a recent update where the list formatting was removed, the text ran to the edges of the screen. This change introduces a `16dp` padding on the left and right sides to improve the layout and visual appearance.

## Details

The change is purely visual. Here's how it looks **before** and **after**:

<p align="center">
<img width="45%" height="779" alt="image" src="https://github.com/user-attachments/assets/8c1b213d-af91-48a1-a36d-2fa451837314" />

<img width="45%" height="779" alt="image" src="https://github.com/user-attachments/assets/3c076629-dfbf-440a-95bc-32ec5328b3ab" />
</p>

## Ticket

[ADFA-1698](https://appdevforall.atlassian.net/browse/ADFA-1698)

## Observation

This is a minor, isolated UI fix that only affects the `no_editor_summary` TextView. It has no impact on app logic or functionality.

[ADFA-1698]: https://appdevforall.atlassian.net/browse/ADFA-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ