### PR TITLE
ADFA-1728-Fix-grammar-nonvalid-folder-msg

### DIFF
--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -691,7 +691,7 @@
 	<string name="msg_no_projects_to_delete">There are no projects available to delete.</string>
 	<string name="msg_create_new_project_instruction">Click the New project button to create a new project.</string>
 	<string name="date">Date</string>
-	<string name="project_directory_invalid">%s is not a valid Android project folder, please open another folder instead</string>
+	<string name="project_directory_invalid">%s is not a valid Android project folder. Please open another folder instead.</string>
 	<string name="open_from_folder">Open from folder</string>
 	<string name="msg_delete_selected_project">Are you sure want to delete the selected project(s)? This action cannot be undone.</string>
 	<string name="feedback_email">feedback@appdevforall.org</string>


### PR DESCRIPTION
Fixed comma splice in message displayed when you
1. open saved project
2. choose to use a folder that doesn't have an Android project in it.

Note - I have to record a video to be able to read the message because it disappears so quickly