### PR TITLE
recompress koltlin-compiler-embeddable jar 1.9.22 

### DIFF
--- a/assets/release/common/data/common/localMvnRepository.zip.br
+++ b/assets/release/common/data/common/localMvnRepository.zip.br
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8ff2a3c85dcaacefad4faf6877d564f4b5968903637d4f55ccdfcce6a828f30
-size 130190666
+oid sha256:dd270c61b54b9d3bb86e2d04f6eada22c9d2193ad99d4f172194bca1822245c7
+size 97485855


### PR DESCRIPTION
recompress koltlin-compiler-embeddable jar 1.9.22 and kotlin-stdlib jars versions 1.9.22 and 2.0.21