### PR TITLE
ADFA-1705 | Fix memory leaks in debugger tabs by switching to fragment factories

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/fragments/debug/DebuggerFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/debug/DebuggerFragment.kt
@@ -37,7 +37,7 @@ import rikka.shizuku.Shizuku
  * @author Akash Yadav
  */
 class DebuggerFragment : EmptyStateFragment<FragmentDebuggerBinding>(FragmentDebuggerBinding::inflate) {
-	private lateinit var tabs: Array<Pair<String, Fragment>>
+	private lateinit var tabs: Array<Pair<String, () -> Fragment>>
 	private val viewModel by activityViewModels<DebuggerViewModel>()
 
 	var currentView: Int
@@ -78,8 +78,8 @@ class DebuggerFragment : EmptyStateFragment<FragmentDebuggerBinding>(FragmentDeb
 		tabs =
 			Array(TABS_COUNT) { position ->
 				when (position) {
-					TAB_INDEX_VARIABLES -> getString(R.string.debugger_variables) to VariableListFragment()
-					TAB_INDEX_CALL_STACK -> getString(R.string.debugger_call_stack) to CallStackFragment()
+					TAB_INDEX_VARIABLES -> getString(R.string.debugger_variables) to { VariableListFragment() }
+					TAB_INDEX_CALL_STACK -> getString(R.string.debugger_call_stack) to { CallStackFragment() }
 					else -> throw IllegalStateException("Unknown position: $position")
 				}
 			}
@@ -246,11 +246,11 @@ class DebuggerFragment : EmptyStateFragment<FragmentDebuggerBinding>(FragmentDeb
 
 class DebuggerPagerAdapter(
 	fragment: DebuggerFragment,
-	private val fragments: List<Fragment>,
+	private val factories: List<() -> Fragment>,
 ) : FragmentStateAdapter(fragment) {
-	override fun getItemCount(): Int = fragments.size
+	override fun getItemCount(): Int = factories.size
 
-	override fun createFragment(position: Int): Fragment = fragments[position]
+	override fun createFragment(position: Int): Fragment = factories[position].invoke()
 }
 
 class ThreadSelectorListAdapter(


### PR DESCRIPTION
## Description

This PR fixes a **memory leak issue** caused by directly storing fragment instances (`VariableListFragment`, `CallStackFragment`) inside the `DebuggerFragment`.
Instead of holding those fragments permanently, we now use **factory functions (lambdas)** that create the fragments only when needed by `FragmentStateAdapter`.

This change ensures the **Android system** (FragmentManager) fully controls each fragment’s lifecycle — so when the tab is closed or the screen is destroyed, its memory and coroutines are automatically released.

## Details

* Replaced:

  ```kotlin
  tabs = Array(TABS_COUNT) { ... to VariableListFragment() }
  ```

  with:

  ```kotlin
  tabs = Array(TABS_COUNT) { ... to { VariableListFragment() } }
  ```
* Updated `DebuggerPagerAdapter` to use lambdas and call `.invoke()` to create fragments on demand.
* Behavior, UI, and navigation remain exactly the same.
* Verified by rotating the device, switching apps, and recreating the fragment — no retained instances detected.

## Ticket

[ADFA-1705](https://appdevforall.atlassian.net/browse/ADFA-1705)
Parent: [ADFA-196](https://appdevforall.atlassian.net/browse/ADFA-196)

## Observation

* No new dependencies or UI changes introduced.
* Developers maintaining `VariableListFragment` and `CallStackFragment` should ensure all coroutines use `viewLifecycleOwner.lifecycleScope` to remain lifecycle-safe.