### PR TITLE
ADFA-1760 | Refactor Debugger UI Observation to StateFlow

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/viewmodel/DebuggerViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/DebuggerViewModel.kt
@@ -105,6 +105,8 @@ class DebuggerViewModel : ViewModel() {
 		get() = _currentView.value
 		set(value) = _currentView.update { value }
 
+  val currentViewFlow = _currentView.asStateFlow()
+
 	val connectionState = _connectionState.asStateFlow()
 
 	val debugeePackageFlow = _debugeePackage.asStateFlow()
@@ -156,17 +158,6 @@ class DebuggerViewModel : ViewModel() {
 					initialValue = null to -1,
 				)
 
-	val selectedFrameVariables: StateFlow<List<ResolvableVariable<*>>>
-		get() =
-			selectedFrame
-				.map { (frame, _) ->
-					frame?.getVariables() ?: emptyList()
-				}.stateIn(
-					scope = viewModelScope,
-					started = SharingStarted.Eagerly,
-					initialValue = emptyList(),
-				)
-
 	val variablesTree: StateFlow<Tree<ResolvableVariable<*>>>
 		get() =
 			state
@@ -185,42 +176,6 @@ class DebuggerViewModel : ViewModel() {
 
 	fun setConnectionState(state: DebuggerConnectionState) {
 		_connectionState.update { state }
-	}
-
-	@OptIn(ExperimentalStdlibApi::class)
-	fun observeCurrentView(
-		scope: CoroutineScope = viewModelScope,
-		observeOn: CoroutineDispatcher = Dispatchers.Default,
-		notifyOn: CoroutineDispatcher? = null,
-		consume: suspend (Int) -> Unit,
-	) = scope.launch(observeOn) {
-		_currentView.collectLatest { viewIndex ->
-			if (notifyOn != null && notifyOn != coroutineContext[CoroutineDispatcher]) {
-				withContext(notifyOn) {
-					consume(viewIndex)
-				}
-			} else {
-				consume(viewIndex)
-			}
-		}
-	}
-
-	@OptIn(ExperimentalStdlibApi::class)
-	fun observeConnectionState(
-		scope: CoroutineScope = viewModelScope,
-		observeOn: CoroutineDispatcher = Dispatchers.Default,
-		notifyOn: CoroutineDispatcher? = null,
-		consume: suspend (DebuggerConnectionState) -> Unit,
-	) = scope.launch(observeOn) {
-		connectionState.collectLatest { state ->
-			if (notifyOn != null && notifyOn != coroutineContext[CoroutineDispatcher]) {
-				withContext(notifyOn) {
-					consume(state)
-				}
-			} else {
-				consume(state)
-			}
-		}
 	}
 
 	suspend fun setThreads(threads: List<ThreadInfo>) =
@@ -299,24 +254,6 @@ class DebuggerViewModel : ViewModel() {
 			Tree.createTree(VariableTreeNodeGenerator.newInstance(roots?.toSet() ?: emptySet()))
 		}
 
-	@OptIn(ExperimentalStdlibApi::class)
-	fun observeLatestThreads(
-		scope: CoroutineScope = viewModelScope,
-		observeOn: CoroutineDispatcher = Dispatchers.Default,
-		notifyOn: CoroutineDispatcher? = null,
-		consume: suspend (List<ResolvableThreadInfo>) -> Unit,
-	) = scope.launch(observeOn) {
-		allThreads.collectLatest { threads ->
-			if (notifyOn != null && notifyOn != coroutineContext[CoroutineDispatcher]) {
-				withContext(notifyOn) {
-					consume(threads)
-				}
-			} else {
-				consume(threads)
-			}
-		}
-	}
-
 	suspend fun setSelectedThreadIndex(index: Int) =
 		withContext(Dispatchers.IO) {
 			state.update { current ->
@@ -349,24 +286,6 @@ class DebuggerViewModel : ViewModel() {
 				)
 			}
 		}
-
-	@OptIn(ExperimentalStdlibApi::class)
-	fun observeLatestSelectedThread(
-		scope: CoroutineScope = viewModelScope,
-		observeOn: CoroutineDispatcher = Dispatchers.Default,
-		notifyOn: CoroutineDispatcher? = null,
-		consume: suspend (ResolvableThreadInfo?, Int) -> Unit,
-	) = scope.launch(observeOn) {
-		selectedThread.collectLatest { (thread, index) ->
-			if (notifyOn != null && notifyOn != coroutineContext[CoroutineDispatcher]) {
-				withContext(notifyOn) {
-					consume(thread, index)
-				}
-			} else {
-				consume(thread, index)
-			}
-		}
-	}
 
 	@OptIn(ExperimentalStdlibApi::class)
 	fun observeLatestAllFrames(
@@ -419,24 +338,6 @@ class DebuggerViewModel : ViewModel() {
 				}
 			} else {
 				consume(frame, index)
-			}
-		}
-	}
-
-	@OptIn(ExperimentalStdlibApi::class)
-	fun observeLatestVariablesTree(
-		scope: CoroutineScope = viewModelScope,
-		observeOn: CoroutineDispatcher = Dispatchers.Default,
-		notifyOn: CoroutineDispatcher? = null,
-		consume: suspend (Tree<ResolvableVariable<*>>) -> Unit,
-	) = scope.launch(observeOn) {
-		variablesTree.collectLatest { tree ->
-			if (notifyOn != null && notifyOn != coroutineContext[CoroutineDispatcher]) {
-				withContext(notifyOn) {
-					consume(tree)
-				}
-			} else {
-				consume(tree)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

This PR refactors the data observation mechanism between the `DebuggerViewModel` and its fragments (`DebuggerFragment`, `VariableListFragment`).

The custom observer methods in the ViewModel were removed in favor of fragments directly collecting from the exposed `StateFlow`s within a `lifecycleScope`. This change simplifies the ViewModel's API and aligns the implementation with modern, lifecycle-aware Android development patterns.

Additionally, potential memory leaks were addressed by properly clearing view references and detaching the `TabLayoutMediator` during the fragments' `onDestroyView` lifecycle event.

## Details

The changes are purely architectural and do not introduce visual modifications. The debugger's external behavior remains unchanged.

## Ticket

[ADFA-1760](https://appdevforall.atlassian.net/browse/ADFA-1760)

## Observation

This task is part of the larger initiative described in the parent ticket [ADFA-196](https://appdevforall.atlassian.net/browse/ADFA-196).