### PR TITLE
ADFA-1711: protect pair result receiver with signature permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
         android:protectionLevel="normal"
         tools:ignore="ManifestOrder" />
 
+    <permission android:name="${applicationId}.debug.RECEIVE_WADB_PAIR_RESULT"
+        android:protectionLevel="signature"/>
+
     <uses-feature
         android:name="android.software.leanback"
         android:required="false" />
@@ -38,6 +41,9 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <uses-permission android:name="${applicationId}.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION" />
+    <uses-permission android:name="${applicationId}.debug.RECEIVE_WADB_PAIR_RESULT" />
+    
     <application
         android:name=".app.IDEApplication"
         android:allowBackup="false"

--- a/app/src/main/java/com/itsaky/androidide/fragments/debug/WADBPermissionFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/debug/WADBPermissionFragment.kt
@@ -112,14 +112,12 @@ class WADBPermissionFragment :
 			}
 
 		ContextCompat.registerReceiver(
-			// context =
-			requireContext(),
-			// receiver =
-			pairingBroadcastReceiver,
-			// filter =
-			filter,
-			// flags =
-			ContextCompat.RECEIVER_NOT_EXPORTED,
+			/* context = */ requireContext(),
+			/* receiver = */ pairingBroadcastReceiver,
+			/* filter = */ filter,
+			/* broadcastPermission = */ AdbPairingService.PERMISSION_RECEIVE_WADB_PAIR_RESULT,
+			/* scheduler = */ null,
+			/* flags = */ ContextCompat.RECEIVER_NOT_EXPORTED,
 		)
 	}
 

--- a/subprojects/shizuku-manager/src/main/java/moe/shizuku/manager/adb/AdbPairingService.kt
+++ b/subprojects/shizuku-manager/src/main/java/moe/shizuku/manager/adb/AdbPairingService.kt
@@ -48,6 +48,8 @@ class AdbPairingService : Service() {
 		const val ACTION_PAIR_SUCCEEDED = BuildInfo.PACKAGE_NAME + ".shizuku.action.PAIR_SUCCEEDED"
 		const val ACTION_PAIR_FAILED = BuildInfo.PACKAGE_NAME + ".shizuku.action.PAIR_FAILED"
 
+		const val PERMISSION_RECEIVE_WADB_PAIR_RESULT = BuildInfo.PACKAGE_NAME + ".debug.RECEIVE_WADB_PAIR_RESULT"
+
 		fun startIntent(context: Context): Intent = Intent(context, AdbPairingService::class.java).setAction(START_ACTION)
 
 		private fun stopIntent(context: Context): Intent = Intent(context, AdbPairingService::class.java).setAction(STOP_ACTION)
@@ -214,7 +216,7 @@ class AdbPairingService : Service() {
 			text = getString(R.string.notification_adb_pairing_succeed_text)
 
 			stopSearch()
-			sendBroadcast(Intent(ACTION_PAIR_SUCCEEDED))
+			sendBroadcast(Intent(ACTION_PAIR_SUCCEEDED), PERMISSION_RECEIVE_WADB_PAIR_RESULT)
 		} else {
 			title = getString(R.string.notification_adb_pairing_failed_title)
 


### PR DESCRIPTION
See [ADFA-1711](https://appdevforall.atlassian.net/browse/ADFA-1711) for more details.

[ADFA-1711]: https://appdevforall.atlassian.net/browse/ADFA-1711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ