### PR TITLE
ADFA-2073 | Fix: "Automatically open last project" preference is ignored

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
@@ -307,6 +307,7 @@ class MainActivity : EdgeToEdgeIDEActivity() {
 
     internal fun openProject(root: File) {
         ProjectManagerImpl.getInstance().projectPath = root.absolutePath
+        GeneralPreferences.lastOpenedProject = root.absolutePath
 
         // Track project open in Firebase Analytics
         analyticsManager.trackProjectOpened(root.absolutePath)

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
@@ -1187,8 +1187,6 @@ open class EditorHandlerActivity :
 				(content.editorContainer.getChildAt(i) as? CodeEditorView)?.editor?.markUnmodified()
 			}
 
-			GeneralPreferences.lastOpenedProject = GeneralPreferences.NO_OPENED_PROJECT
-
 			performCloseAllFiles(manualFinish = true)
 		}
 
@@ -1197,7 +1195,6 @@ open class EditorHandlerActivity :
 			dialog.dismiss()
 
 			saveAllAsync(notify = false) {
-				GeneralPreferences.lastOpenedProject = GeneralPreferences.NO_OPENED_PROJECT
 
 				runOnUiThread {
 					performCloseAllFiles(manualFinish = true)

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -50,7 +50,6 @@ import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.lookup.Lookup
 import com.itsaky.androidide.lsp.IDELanguageClientImpl
 import com.itsaky.androidide.lsp.java.utils.CancelChecker
-import com.itsaky.androidide.preferences.internal.GeneralPreferences
 import com.itsaky.androidide.projects.ProjectManagerImpl
 import com.itsaky.androidide.projects.builder.BuildService
 import com.itsaky.androidide.projects.models.projectDir
@@ -770,7 +769,6 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
 
 	private fun initialSetup() {
 		val manager = ProjectManagerImpl.getInstance()
-		GeneralPreferences.lastOpenedProject = manager.projectDirPath
 		try {
 			val project = manager.workspace?.rootProject
 			if (project == null) {

--- a/app/src/main/java/com/itsaky/androidide/fragments/RecentProjectsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/RecentProjectsFragment.kt
@@ -85,30 +85,16 @@ class RecentProjectsFragment : BaseFragment() {
                     }
 
                     if (projectToOpen != null) {
-                        withContext(Dispatchers.Main) {
-                            openProjectAndSetAsLast(projectToOpen)
-                        }
+                        withContext(Dispatchers.Main) { openProject(projectToOpen) }
                         return@launch
                     }
 
                     val lastCreated = validProjects.maxByOrNull { it.lastModified() }
 
                     if (lastCreated != null) {
-                        withContext(Dispatchers.Main) { openProjectAndSetAsLast(lastCreated) }
+                        withContext(Dispatchers.Main) { openProject(lastCreated) }
                     }
                 }
-            } catch (e: Throwable) {
-                Sentry.captureException(e)
-            }
-        }
-    }
-
-    private fun openProjectAndSetAsLast(project: File) {
-        openProject(project)
-
-        viewLifecycleScope.launch(Dispatchers.IO) {
-            try {
-                GeneralPreferences.lastOpenedProject = project.absolutePath
             } catch (e: Throwable) {
                 Sentry.captureException(e)
             }


### PR DESCRIPTION
## Description

This PR fixes a bug where the "Automatically open last project" preference was being ignored.

The previous logic was hardcoded to open the *first* project created on a fresh install, regardless of the user's setting.

The logic in `bootstrapFromFixedFolderIfNeeded` is updated to:

1.  Properly check the `GeneralPreferences.autoOpenProjects` flag.
2.  If `true`, it now attempts to open the correct `lastOpenedProject` path.
3.  If `false`, it opens no project, correctly respecting the user's preference.

## Details

https://github.com/user-attachments/assets/bced41b1-af3f-4fea-8c9e-a12a43b1417f

## Ticket

[ADFA-2073](https://appdevforall.atlassian.net/browse/ADFA-2073)

## Observation

A new helper function `openProjectAndSetAsLast` was added to ensure the `lastOpenedProject` preference is correctly updated when a project is automatically opened on launch.

[ADFA-2073]: https://appdevforall.atlassian.net/browse/ADFA-2073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ