### PR TITLE
compress documentation db in a separate workflow and  upload to google drive 

### DIFF
--- a/.github/workflows/compress_docdb.yml
+++ b/.github/workflows/compress_docdb.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: main
+      #- name: Checkout repository
+      #  uses: actions/checkout@v4
+      #  with:
+      #    ref: stage
 
       - name: Authenticate to Google Cloud for Drive access
         id: auth_drive


### PR DESCRIPTION
If updated, compress documentation db in a separate workflow and  upload the resulting documentation.db.br to google drive 