### PR TITLE
ADFA-2081 | Force Gradle sync when project cache is missing

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -552,11 +552,8 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
 			if (gradleBuildResult.isFailure) {
 				val error = gradleBuildResult.exceptionOrNull()
 				log.error("Failed to read project cache", error)
-				if (error != null) {
-					Sentry.captureException(error)
-				}
 
-				withContext(Dispatchers.Main) { postProjectInit(false, CACHE_READ_ERROR) }
+				withContext(Dispatchers.Main) { initializeProject(forceSync = true) }
 				return@launch
 			}
 


### PR DESCRIPTION
## Description

This PR updates the project initialization flow to automatically trigger a Gradle sync when the project cache file is missing. This prevents initialization failures and ensures the IDE can recover gracefully without manual user intervention.

## Details

The previous behavior treated the missing cache as a fatal error. Now, a forced `initializeProject(true)` is executed on the main thread, allowing the Gradle Tooling server to regenerate the required cache.

https://github.com/user-attachments/assets/c9c4b3ad-0998-4864-a791-c0b9e73109f1

## Ticket

[ADFA-2081](https://appdevforall.atlassian.net/browse/ADFA-2081)

## Observation

This improves robustness when opening newly created or externally modified projects.

[ADFA-2081]: https://appdevforall.atlassian.net/browse/ADFA-2081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ