### PR TITLE
ADFA-2250-Fix-typo-in-strings.xml-ai_api_key_not_found

### DIFF
--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -934,7 +934,7 @@
 
     <string name="retry">Retry</string>
     <string name="open_ai_settings">Open AI Settings</string>
-    <string name="new_chat">New Chat</string>
+    <string name="new_chat">New chat</string>
     <string name="experimental_ai_use_at_your_own_risk">⚠️ Experimental AI. Use at your own risk.</string>
     <string name="current_ai_backend">Current AI Backend</string>
     <string name="stop_generation">Stop Generation</string>


### PR DESCRIPTION
Could only fix changing AI key to API key. Other requested fixes are not fixable in strings.xml.

Could not test in built branch because IDK how to get the dialog box to show up.  