### PR TITLE
ADFA-2428 | Handle VMDisconnectedException in debug stack frames

### DIFF
--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/LspThreadInfo.kt
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/LspThreadInfo.kt
@@ -68,11 +68,6 @@ class JavaStackFrame(
 					}?.run {
 						val variables = mutableListOf<AbstractJavaVariable<*>>()
 
-						try {
-							logger.info("QA TEST: Waiting 5s... KILL THE APP!")
-							Thread.sleep(5000)
-						} catch (e: Exception) {}
-
 						val thisObject = runCatching {
 							this.thisObject()
 						}.getOrElse { e ->


### PR DESCRIPTION
## Description

This PR fixes a `DiagnosticCoroutineContextException` caused by a `VMDisconnectedException` occurring within the LSP debug logic.

The issue arises when the IDE attempts to fetch the `this` object or local variables from a stack frame just as the Virtual Machine (VM) disconnects. I have wrapped the `thisObject()` and `visibleVariables()` calls in try-catch blocks to handle `VMDisconnectedException`, `ObjectCollectedException`, and other unexpected errors gracefully, preventing the coroutine from crashing.

## Details

**Sentry Log:**

```text
DiagnosticCoroutineContextException: 

com.sun.jdi.VMDisconnectedException: null
    at com.sun.tools.jdi.TargetVM.waitForReply(:23)
    at com.sun.tools.jdi.VirtualMachineImpl.waitForTargetReply(:2)
    at com.sun.tools.jdi.PacketStream.waitForReply(:8)
    at com.sun.tools.jdi.StackFrameImpl.thisObject(:51)
    at com.itsaky.androidide.lsp.java.debug.JavaStackFrame$getVariables$2.invokeSuspend(:83)

```

### Before changes

https://github.com/user-attachments/assets/39843de7-6c62-4e69-aec8-c4097d8774da



### After changes

https://github.com/user-attachments/assets/dc8370a4-7618-414c-8ea5-b6e7d07be704


## Ticket

[ADFA-2428](https://appdevforall.atlassian.net/browse/ADFA-2428)

## Observation

If the VM disconnects during the evaluation, the method now returns an empty list of variables instead of throwing an unhandled exception.

[ADFA-2428]: https://appdevforall.atlassian.net/browse/ADFA-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ