### PR TITLE
ADFA-2446 | Improve terminal bootstrap install resilience and user messaging

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/assets/AssetsInstallationHelper.kt
+++ b/app/src/main/java/com/itsaky/androidide/assets/AssetsInstallationHelper.kt
@@ -73,9 +73,11 @@ object AssetsInstallationHelper {
 				}
 
 			if (result.isFailure) {
-				logger.error("Failed to install assets", result.exceptionOrNull())
-				onProgress(Progress("Failed to install assets"))
-				return@withContext Result.Failure(result.exceptionOrNull())
+				val e = result.exceptionOrNull()
+				val msg = e?.message ?: "Failed to install assets"
+				logger.error("Failed to install assets", e)
+				onProgress(Progress(msg))
+				return@withContext Result.Failure(e, errorMessage = msg)
 			}
 
 			return@withContext Result.Success

--- a/app/src/main/java/com/itsaky/androidide/utils/InstallerIoUtils.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/InstallerIoUtils.kt
@@ -1,0 +1,56 @@
+package com.itsaky.androidide.utils
+
+import android.content.Context
+import com.aayushatharva.brotli4j.decoder.BrotliInputStream
+import java.nio.channels.SeekableByteChannel
+import java.nio.file.Files
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+
+internal inline fun <T> withTempZipChannel(
+    stagingDir: Path,
+    prefix: String,
+    writeTo: (Path) -> Unit,
+    useChannel: (SeekableByteChannel) -> T,
+): T {
+    val tempZipPath = Files.createTempFile(stagingDir, prefix, ".zip")
+    try {
+        writeTo(tempZipPath)
+        Files.newByteChannel(tempZipPath).use { ch ->
+            return useChannel(ch)
+        }
+    } finally {
+        Files.deleteIfExists(tempZipPath)
+    }
+}
+
+internal fun writeBrotliAssetToPath(
+    context: Context,
+    assetPath: String,
+    destPath: Path,
+) {
+    context.assets.open(assetPath).use { assetStream ->
+        BrotliInputStream(assetStream).use { brotli ->
+            Files.newOutputStream(destPath).use { output ->
+                brotli.copyTo(output)
+            }
+        }
+    }
+}
+
+internal inline fun <T> retryOnceOnNoSuchFile(
+    onFirstFailure: () -> Unit = {},
+    onSecondFailure: (NoSuchFileException) -> Nothing,
+    block: () -> T,
+): T {
+    return try {
+        block()
+    } catch (_: NoSuchFileException) {
+        onFirstFailure()
+        try {
+            block()
+        } catch (e2: NoSuchFileException) {
+            onSecondFailure(e2)
+        }
+    }
+}

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
 	<string name="msg_picked_isnt_dir">The picked file is not a directory.</string>
 	<string name="please_wait">Please wait for a moment.</string>
 	<string name="not_enough_storage">Not enough storage available for installation. An additional %1$.1fGB is required on the internal storage partition. You currently have %2$.1fGB available.</string>
+	<string name="terminal_installation_failed_low_storage">Terminal setup failed. Storage space is insufficient, or files were removed during installation. Please free up some space and try again.</string>
+	<string name="terminal_installation_failed_secondary_user">Terminal installation is only supported for the primary user.</string>
 
 	<!-- Project Builder -->
 	<string name="title_unsupported_device">This device is not supported</string>


### PR DESCRIPTION
## Description

This PR hardens the terminal bootstrap installation by retrying once when the temporary bootstrap zip disappears during channel open (likely due to cache/staging cleanup or race conditions). If the issue occurs twice, we fail fast with a localized, user-friendly message instead of a generic error, and propagate the exception message through the existing install progress reporting.

## Details

* Added a localized string for terminal setup failure guidance (low storage / cache cleared).
* Introduced small helpers to reduce duplication: temp zip creation + channel usage, brotli asset write, and a single-retry wrapper for `NoSuchFileException`.
* Updated `AssetsInstallationHelper.install()` to forward the underlying failure message to progress output and Result.Failure for better UX and debugging.
* Cleaned some unrelated code blocks

## Ticket

[ADFA-2446](https://appdevforall.atlassian.net/browse/ADFA-2446)

## Observation

The installer runs multiple asset installs concurrently against a shared staging directory, so transient `NoSuchFileException` can occur if the temp file or parent directory is removed between write and channel open. The retry is intentionally bounded to a single attempt to avoid masking persistent storage issues.

[ADFA-2446]: https://appdevforall.atlassian.net/browse/ADFA-2446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ