### PR TITLE
ADFA-2540 | Fix crash when saving file in non-existent directory

### DIFF
--- a/editor/src/main/java/com/itsaky/androidide/editor/utils/ContentReadWrite.kt
+++ b/editor/src/main/java/com/itsaky/androidide/editor/utils/ContentReadWrite.kt
@@ -156,11 +156,10 @@ object ContentReadWrite {
   }
 
   private fun checkForParentDir(file: File) {
-    if (file.parentFile?.exists() == true) return
+    val parent = file.parentFile ?: return
 
-    val created = file.parentFile?.mkdirs()
-    if (created == true) return
-
-    throw IOException("The parent directory could not be created for: ${file.absolutePath}")
+    if (!parent.exists() && !parent.mkdirs() && !parent.exists()) {
+      throw IOException("The parent directory could not be created for: ${file.absolutePath}")
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR fixes a crash (ENOENT) that occurs when attempting to save a file whose parent directory has been deleted or moved externally. It introduces a check to ensure the parent directory exists before opening the file stream, attempting to recreate the directory structure if it is missing.

## Details

* Added `checkForParentDir` in `ContentReadWrite.kt`.
* The method attempts to create missing directories using `mkdirs()`.
* Throws a specific `IOException` if the directory cannot be created, preventing the silent or obscure failure of `FileOutputStream`.

https://github.com/user-attachments/assets/7fc3aaf7-e89f-4920-95e8-ff91d36a28a4

## Ticket

[ADFA-2540](https://appdevforall.atlassian.net/browse/ADFA-2540)

## Observation

This addresses the Sentry stack trace reported where `FileOutputStream` failed with `open failed: ENOENT`.

[ADFA-2540]: https://appdevforall.atlassian.net/browse/ADFA-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ