### PR TITLE
ADFA-2415 | Fix LSP compiler crashes by skipping missing files

### DIFF
--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/JavaLanguageServer.kt
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/JavaLanguageServer.kt
@@ -77,6 +77,7 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.slf4j.LoggerFactory
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Objects
 
@@ -328,9 +329,10 @@ class JavaLanguageServer : ILanguageServer {
 	}
 
 	private fun analyzeSelected() {
-		if (selectedFile == null || client == null) {
-			return
-		}
+		val file = selectedFile ?: return
+		if (client == null) return
+
+		if (!Files.exists(file)) return
 
 		CoroutineScope(Dispatchers.Default).launch {
 			val result = analyze(selectedFile!!)

--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/compiler/SourceFileManager.java
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/compiler/SourceFileManager.java
@@ -34,6 +34,7 @@ import com.itsaky.androidide.utils.SourceClassTrie;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
@@ -139,6 +140,8 @@ public class SourceFileManager extends ForwardingJavaFileManager<JavacFileManage
 			for (SourceClassTrie.SourceNode node : classes) {
 				final Path path = node.getFile();
 				if (path.getFileName().toString().equals(simpleClassName + kind.extension)) {
+				    if (!Files.exists(path)) return null;
+
 					return new SourceFileObject(path);
 				}
 			}
@@ -190,7 +193,8 @@ public class SourceFileManager extends ForwardingJavaFileManager<JavacFileManage
 
 			final Stream<JavaFileObject> stream = nodes
 					.filter(it -> it instanceof SourceClassTrie.SourceNode)
-					.map(it -> asJavaFileObject((SourceClassTrie.SourceNode) it));
+					.map(it -> asJavaFileObject((SourceClassTrie.SourceNode) it))
+					.filter(Objects::nonNull);
 
 			return stream::iterator;
 		}
@@ -211,6 +215,9 @@ public class SourceFileManager extends ForwardingJavaFileManager<JavacFileManage
 	}
 
 	private JavaFileObject asJavaFileObject(SourceClassTrie.SourceNode node) {
+	    final Path path = node.getFile();
+	    if (!Files.exists(path)) return null;
+
 		// TODO erase method bodies of files that are not open
 		return new SourceFileObject(node.getFile());
 	}


### PR DESCRIPTION
## Description

This PR fixes an issue where the Java language server would crash or throw exceptions when attempting to analyze project files that had been deleted from the disk but were still referenced in internal caches.

I modified `SourceFileManager` and `JavaLanguageServer` to perform a silent check for file existence using `Files.exists()` before attempting to create file objects or run analysis. Specifically, the stream pipeline in the source manager now filters out `null` values resulting from missing files, ensuring the compiler only processes valid sources.

## Details

Logic-related change:

* **JavaLanguageServer:** Aborts `analyzeSelected` immediately if the target file is not found on disk.
* **SourceFileManager:** Returns `null` for missing files during lookup and filters them out of the `JavaFileObject` stream to prevent `NullPointerException` and compiler crashes.

https://github.com/user-attachments/assets/e9950fb4-ed49-485f-9ae0-5e779e14428c

## Ticket

[ADFA-2415](https://appdevforall.atlassian.net/browse/ADFA-2415)

## Observation

This implementation addresses previous code review feedback by ensuring these checks happen silently internally, without triggering any UI notifications (Toasts) to the user.

[ADFA-2415]: https://appdevforall.atlassian.net/browse/ADFA-2415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ