### PR TITLE
ADFA-2600 | Fix NPE in Find in Project action

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/etc/FindInProjectAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/etc/FindInProjectAction.kt
@@ -66,7 +66,7 @@ class FindInProjectAction() : EditorActivityAction() {
 
 	override suspend fun execAction(data: ActionData): Boolean {
 		val context = data.getActivity() ?: return false
-		val dialog = context.findInProjectDialog
+		val dialog = context.findInProjectDialog ?: return false
 
 		return run {
 			dialog.show()

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -111,12 +111,12 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
 	private val buildViewModel by viewModels<BuildViewModel>()
 	protected var initializingFuture: CompletableFuture<out InitializeResult?>? = null
 
-	val findInProjectDialog: AlertDialog
+	val findInProjectDialog: AlertDialog?
 		get() {
 			if (mFindInProjectDialog == null) {
 				createFindInProjectDialog()
 			}
-			return mFindInProjectDialog!!
+			return mFindInProjectDialog
 		}
 
 	fun findActionDialog(actionData: ActionData): FindActionDialog {


### PR DESCRIPTION
## Description

Fixed a `NullPointerException` that occurred when attempting to open the "Find in Project" dialog before the project was fully initialized.

The `findInProjectDialog` getter in `ProjectHandlerActivity` was forcing a non-null return (`!!`), causing a crash if the dialog creation failed (e.g., if the workspace was null). I have updated the property to be nullable and added a safe call check in `FindInProjectAction`.

## Details

Fixed the following Sentry crash:
`java.lang.NullPointerException: null at com.itsaky.androidide.activities.editor.ProjectHandlerActivity.getFindInProjectDialog`

https://github.com/user-attachments/assets/9f0c4686-5718-4a86-b604-1753f42ea905


## Ticket

[ADFA-2600](https://appdevforall.atlassian.net/browse/ADFA-2600)

## Observation

If the project is not initialized, the action will now safely exit (triggering the existing error flashbar logic inside `createFindInProjectDialog`) instead of crashing the application.

[ADFA-2600]: https://appdevforall.atlassian.net/browse/ADFA-2600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ