### PR TITLE
ADFA-2597 | Filter expected cache read errors from Sentry

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -101,6 +101,7 @@ import kotlinx.coroutines.withContext
 import org.adfa.constants.CONTENT_KEY
 import java.io.File
 import java.io.FileNotFoundException
+import java.nio.file.NoSuchFileException
 import java.util.concurrent.CompletableFuture
 import java.util.regex.Pattern
 import java.util.stream.Collectors


### PR DESCRIPTION
## Description

This PR filters out expected `FileNotFoundException` and `ErrnoException` (ENOENT) errors from Sentry reporting during project initialization. These errors often occur due to race conditions or when users manually delete cache files, creating unnecessary noise in the issue tracker.

## Details

Logs are still printed to the local console for debugging, and the UI still notifies the user of the cache read failure, but the exception is no longer sent to Sentry if the cause is a missing file.

https://github.com/user-attachments/assets/45ce0b4f-3634-4ada-8647-8e347b9ced26

## Ticket

[ADFA-2597](https://appdevforall.atlassian.net/browse/ADFA-2597)

## Observation

This change is purely internal to the error reporting logic; there are no visual changes for the user.

[ADFA-2597]: https://appdevforall.atlassian.net/browse/ADFA-2597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ