### PR TITLE
ADFA-2580 | Fix Koin init crash on Editor launch

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -553,7 +553,12 @@ abstract class BaseEditorActivity :
 	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {
+		savedInstanceState?.getString(KEY_PROJECT_PATH)?.let(ProjectManagerImpl.getInstance()::projectPath::set)
 		super.onCreate(savedInstanceState)
+
+		editorViewModel.isBuildInProgress = false
+		editorViewModel.isInitializing = false
+
 		mLifecycleObserver = EditorActivityLifecyclerObserver()
 
 		Shizuku.addBinderReceivedListener(shizukuBinderReceivedListener)
@@ -564,12 +569,6 @@ abstract class BaseEditorActivity :
 		this.optionsMenuInvalidator = Runnable { super.invalidateOptionsMenu() }
 
 		registerLanguageServers()
-
-		if (savedInstanceState != null && savedInstanceState.containsKey(KEY_PROJECT_PATH)) {
-			savedInstanceState.getString(KEY_PROJECT_PATH)?.let { path ->
-				ProjectManagerImpl.getInstance().projectPath = path
-			}
-		}
 
 		onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
 		mLifecycleObserver?.let {

--- a/app/src/main/java/com/itsaky/androidide/app/DeviceProtectedApplicationLoader.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/DeviceProtectedApplicationLoader.kt
@@ -3,13 +3,10 @@ package com.itsaky.androidide.app
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
-import org.appdevforall.codeonthego.computervision.di.computerVisionModule
 import com.itsaky.androidide.BuildConfig
 import com.itsaky.androidide.analytics.IAnalyticsManager
 import com.itsaky.androidide.app.strictmode.StrictModeConfig
 import com.itsaky.androidide.app.strictmode.StrictModeManager
-import com.itsaky.androidide.di.coreModule
-import com.itsaky.androidide.di.pluginModule
 import com.itsaky.androidide.events.AppEventsIndex
 import com.itsaky.androidide.events.EditorEventsIndex
 import com.itsaky.androidide.events.LspApiEventsIndex
@@ -30,10 +27,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.shizuku.manager.ShizukuSettings
 import org.greenrobot.eventbus.EventBus
-import org.koin.android.ext.koin.androidContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import org.koin.core.context.startKoin
 import org.slf4j.LoggerFactory
 import kotlin.system.exitProcess
 
@@ -70,11 +65,6 @@ internal object DeviceProtectedApplicationLoader :
 				isReprieveEnabled = FeatureFlags.isReprieveEnabled,
 			),
 		)
-
-		startKoin {
-			androidContext(app)
-			modules(coreModule, pluginModule, computerVisionModule)
-		}
 
 		SentryAndroid.init(app) { options ->
 			// Reduce replay quality to LOW to prevent OOM

--- a/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -25,6 +25,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import com.itsaky.androidide.BuildConfig
+import com.itsaky.androidide.di.coreModule
+import com.itsaky.androidide.di.pluginModule
 import com.itsaky.androidide.plugins.manager.core.PluginManager
 import com.itsaky.androidide.treesitter.TreeSitter
 import com.itsaky.androidide.utils.RecyclableObjectPool
@@ -39,6 +41,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import org.appdevforall.codeonthego.computervision.di.computerVisionModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.startKoin
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 import org.slf4j.LoggerFactory
 import java.lang.Thread.UncaughtExceptionHandler
@@ -147,6 +153,8 @@ class IDEApplication : BaseApplication() {
 		// https://appdevforall.atlassian.net/browse/ADFA-2026
 		// https://appdevforall-inc-9p.sentry.io/issues/6860179170/events/7177c576e7b3491c9e9746c76f806d37/
 
+		ensureKoinStarted()
+
 		coroutineScope.launch(Dispatchers.Default) {
 			// load common stuff, which doesn't depend on access to
 			// credential protected storage
@@ -161,6 +169,14 @@ class IDEApplication : BaseApplication() {
 				logger.info("Device in Direct Boot Mode: postponing initialization...")
 				registerReceiver(deviceUnlockReceiver, IntentFilter(Intent.ACTION_USER_UNLOCKED))
 			}
+		}
+	}
+
+	private fun ensureKoinStarted() {
+		runCatching { GlobalContext.get() }.getOrNull()?.let { return }
+		startKoin {
+			androidContext(this@IDEApplication)
+			modules(coreModule, pluginModule, computerVisionModule)
 		}
 	}
 


### PR DESCRIPTION
## Description

* Moved Koin initialization to `IDEApplication` and added a safe guard to avoid future double-start issues.
* Restored `ProjectManagerImpl.projectPath` earlier in `BaseEditorActivity` before fragment/ViewModel creation to prevent `UninitializedPropertyAccessException`.
* Reset editor ViewModel flags on activity creation to ensure consistent state after recreation.

## Details

* Verified Editor launch after process death / activity recreation (e.g., returning from recents) no longer crashes with `InstanceCreationException` / `projectPath` not initialized.
* No UI changes included.

https://github.com/user-attachments/assets/f31473a1-5cfe-4b75-9917-3a7e46bdf683

## Ticket

[ADFA-2580](https://appdevforall.atlassian.net/browse/ADFA-2580)

## Observation

* The crash was caused by DI creating `ChatViewModel` before `projectPath` was restored, so the fix ensures required state is available before Koin-resolved components access it.
* `ensureKoinStarted()` is defensive: it prevents accidental future regressions if another startup path is introduced.

[ADFA-2580]: https://appdevforall.atlassian.net/browse/ADFA-2580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ