### PR TITLE
ADFA-2548 | Fix drag-and-drop crash on Android 12+ for TextViews

### DIFF
--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/editor/DesignEditor.kt
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/editor/DesignEditor.kt
@@ -14,6 +14,7 @@ import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.Spinner
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.view.isEmpty
@@ -552,23 +553,35 @@ class DesignEditor : LinearLayout {
 
 	fun isLayoutModified(): Boolean = isModified
 
+	/**
+	 * Configures the View for the design editor by disabling focus and input.
+	 *
+	 * For [TextView] subclasses, it explicitly disables text selection to prevent the
+	 * internal `android.widget.Editor` from intercepting drag events, avoiding a
+	 * `NullPointerException` on Android 12+ (API 31) caused by conflictive base class interactions.
+	 */
+	private fun View.configureForDesignMode() {
+		isFocusable = false
+		isFocusableInTouchMode = false
+
+		if (this is TextView) {
+			keyListener = null
+			isCursorVisible = false
+			setTextIsSelectable(false)
+		}
+	}
+
 	private fun rearrangeListeners(view: View) {
+		view.configureForDesignMode()
+
 		when (view) {
 			is Spinner -> {
-				view.onItemSelectedListener =
-					object : AdapterView.OnItemSelectedListener {
-						override fun onItemSelected(
-							parent: AdapterView<*>?,
-							v: View?,
-							position: Int,
-							id: Long,
-						) {
-							showDefinedAttributes(view)
-						}
-
-						override fun onNothingSelected(parent: AdapterView<*>?) {
-						}
+				view.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+					override fun onItemSelected(parent: AdapterView<*>?, v: View?, position: Int, id: Long) {
+						showDefinedAttributes(view)
 					}
+					override fun onNothingSelected(parent: AdapterView<*>?) {}
+				}
 			}
 			is AdapterView<*> -> {
 				view.setOnItemClickListener { _, _, _, _ ->


### PR DESCRIPTION
## Description

This PR fixes a `NullPointerException` occurring on Android 12+ (API 31) when dropping elements onto an `EditText` or other `TextView` subclasses within the Design Editor.

The crash happens because `android.widget.Editor` attempts to handle the `ACTION_DROP` event assuming valid `ClipData`, which is null during internal drag operations. To prevent this, I introduced a `configureForDesignMode` extension function that:

* Disables focus and touch mode focus for all views.
* Explicitly disables `textIsSelectable`, `cursorVisible`, and removes the `keyListener` for `TextView` subclasses.

This ensures these components remain passive visual elements in the editor, preventing the system's text editing logic from intercepting drag events. Additionally, I refactored the `Spinner` listener assignment for better readability.

## Details

Logic-related fix. This resolves the following crash on API 31+:
`java.lang.NullPointerException: null at android.widget.Editor.onDrop(Editor.java:3089)`

### Before changes

https://github.com/user-attachments/assets/c8d644d2-3c7d-424a-997f-4f1792470da0

### After changes

https://github.com/user-attachments/assets/2f12bf19-7b80-4fd5-bdc8-7ec6bee8688d

## Ticket

[ADFA-2548](https://appdevforall.atlassian.net/browse/ADFA-2548)

## Observation

This fix applies to all views inheriting from `TextView` (e.g., `Button`, `CheckBox`, `EditText`), ensuring consistency across the editor.

[ADFA-2548]: https://appdevforall.atlassian.net/browse/ADFA-2548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ