### PR TITLE
ADFA-2542 Change preference gradle offline default from true to false 

### DIFF
--- a/preferences/src/main/java/com/itsaky/androidide/preferences/internal/BuildPreferences.kt
+++ b/preferences/src/main/java/com/itsaky/androidide/preferences/internal/BuildPreferences.kt
@@ -67,7 +67,7 @@ object BuildPreferences {
 
 	/** Switch for Gradle `--offline` option. */
 	var isOfflineEnabled: Boolean
-		get() = prefManager.getBoolean(OFFLINE_MODE, true)
+		get() = prefManager.getBoolean(OFFLINE_MODE, false)
 		set(enabled) {
 			prefManager.putBoolean(OFFLINE_MODE, enabled)
 		}


### PR DESCRIPTION
We need this to encourage user retention during Phase 1 and Phase 2; this will be reverted when we shift to Phase 3 (the 2 billion people lacking low cost high speed internet)
We see requests for this in Telegram often