### PR TITLE
ADFA-2652, ADFA-2582 | Fix NPE during process restoration by initializing Termux singletons

### DIFF
--- a/termux/termux-app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux/termux-app/src/main/java/com/termux/app/TermuxActivity.java
@@ -453,7 +453,7 @@ public class TermuxActivity extends BaseIDEActivity implements ServiceConnection
     private void ensureTermuxPropertiesInitialized() {
         if (TermuxAppSharedProperties.getProperties() != null) return;
         TermuxAppSharedProperties.init(getApplicationContext());
-    };
+    }
 
     /**
      * Ensures that the TermuxShellManager singleton is initialized.


### PR DESCRIPTION
## Description

This PR fixes critical crashes that occur when the application process is killed by the system (e.g., due to memory pressure or "Don't keep activities" developer setting) and subsequently restored.

In these scenarios, the static singletons for `TermuxAppSharedProperties` and `TermuxShellManager` were null, leading to `NullPointerException` crashes in `TermuxActivity` (when loading properties) and `TermuxService` (when accessing session lists). I have added defensive initialization methods (`ensureTermuxPropertiesInitialized` and `ensureTermuxShellManagerInitialized`) in `onCreate` to ensure these components are ready before use.

## Details

**Crash 1 (Activity):**
`java.lang.NullPointerException: Attempt to invoke virtual method 'void ...TermuxAppSharedProperties.loadTermuxPropertiesFromDisk()' on a null object reference`

<img width="1339" height="554" alt="image" src="https://github.com/user-attachments/assets/855bcb4b-aa13-449f-87e1-1cb056afb212" />

**Crash 2 (Service):**
`java.lang.NullPointerException: Attempt to read from field 'java.util.List ...TermuxShellManager.mTermuxSessions' on a null object reference`

<img width="1342" height="415" alt="image" src="https://github.com/user-attachments/assets/c02c7df6-cf24-46e7-bb2b-c97fe591e5a4" />

### Before changes

https://github.com/user-attachments/assets/fc2a895c-7a91-490e-b339-8b96b7685386

### After changes

https://github.com/user-attachments/assets/a702c6ca-10c2-499c-b7f6-58b75f0c68f2


## Ticket

* [ADFA-2652](https://appdevforall.atlassian.net/browse/ADFA-2652)
* [ADFA-2582](https://appdevforall.atlassian.net/browse/ADFA-2582)

## Observation

The initialization uses the `applicationContext` to prevent memory leaks and employs an early-return pattern for cleaner readability.

[ADFA-2652]: https://appdevforall.atlassian.net/browse/ADFA-2652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ