### PR TITLE
ADFA-2673 | Refactor and centralize auto-open project logic

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/MainActivity.kt
@@ -19,7 +19,6 @@ package com.itsaky.androidide.activities
 
 import android.content.Intent
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
@@ -46,6 +45,7 @@ import com.itsaky.androidide.utils.DialogUtils
 import com.itsaky.androidide.utils.Environment
 import com.itsaky.androidide.utils.FeatureFlags
 import com.itsaky.androidide.utils.UrlManager
+import com.itsaky.androidide.utils.findValidProjects
 import com.itsaky.androidide.utils.flashInfo
 import com.itsaky.androidide.viewmodel.MainViewModel
 import com.itsaky.androidide.viewmodel.MainViewModel.Companion.SCREEN_DELETE_PROJECTS
@@ -56,6 +56,7 @@ import com.itsaky.androidide.viewmodel.MainViewModel.Companion.SCREEN_TEMPLATE_L
 import com.itsaky.androidide.viewmodel.MainViewModel.Companion.TOOLTIPS_WEB_VIEW
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.appdevforall.localwebserver.ServerConfig
 import org.appdevforall.localwebserver.WebServer
 import org.koin.android.ext.android.inject
@@ -104,7 +105,7 @@ class MainActivity : EdgeToEdgeIDEActivity() {
 		// Start WebServer after installation is complete
 		startWebServer()
 
-		openLastProject()
+		if (savedInstanceState == null) { openLastProject() }
 
 		if (FeatureFlags.isExperimentsEnabled) {
 			binding.codeOnTheGoLabel.title = getString(R.string.app_name) + "."
@@ -259,32 +260,37 @@ class MainActivity : EdgeToEdgeIDEActivity() {
 	}
 
 	private fun tryOpenLastProject() {
-		if (!GeneralPreferences.autoOpenProjects) {
-			return
-		}
+		if (!GeneralPreferences.autoOpenProjects) return
 
-		val openedProject = GeneralPreferences.lastOpenedProject
-		if (GeneralPreferences.NO_OPENED_PROJECT == openedProject) {
-			return
-		}
+		lifecycleScope.launch(Dispatchers.IO) {
+			val validProjects = findValidProjects(Environment.PROJECTS_DIR)
+			val lastOpenedPath = GeneralPreferences.lastOpenedProject
 
-		if (TextUtils.isEmpty(openedProject)) {
-			flashInfo(string.msg_opened_project_does_not_exist)
-			return
-		}
+			val projectToOpen = validProjects.find { it.absolutePath == lastOpenedPath }
+				?: validProjects.maxByOrNull { it.lastModified() }
 
-		val project = File(openedProject)
-		if (!project.exists()) {
-			flashInfo(string.msg_opened_project_does_not_exist)
-			return
-		}
+			withContext(Dispatchers.Main) {
+				when {
+        	projectToOpen != null -> handleOpenProject(projectToOpen)
 
+        	lastOpenedPath.isNotBlank() && lastOpenedPath != GeneralPreferences.NO_OPENED_PROJECT -> {
+        		if (!File(lastOpenedPath).exists()) {
+        			flashInfo(string.msg_opened_project_does_not_exist)
+        		}
+        	}
+
+        	else -> Unit
+				}
+			}
+		}
+	}
+
+	private fun handleOpenProject(root: File) {
 		if (GeneralPreferences.confirmProjectOpen) {
-			askProjectOpenPermission(project)
+			askProjectOpenPermission(root)
 			return
 		}
-
-		openProject(project)
+		openProject(root)
 	}
 
 	private fun askProjectOpenPermission(root: File) {

--- a/app/src/main/java/com/itsaky/androidide/utils/ProjectValidations.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/ProjectValidations.kt
@@ -1,0 +1,59 @@
+package com.itsaky.androidide.utils
+
+import java.io.File
+import kotlin.collections.filter
+import kotlin.collections.orEmpty
+
+/** Checks if the file is a readable, visible directory. */
+internal fun File.isProjectCandidateDir(): Boolean = isDirectory && canRead() && !name.startsWith(".") && !isHidden
+
+/** Scans the given root directory for valid Android project subdirectories. */
+internal fun findValidProjects(projectsRoot: File): List<File> {
+	if (!projectsRoot.isProjectCandidateDir()) return emptyList()
+
+	val subdirs = projectsRoot.listFiles()
+		?.filter { it.isProjectCandidateDir() }
+		.orEmpty()
+	if (subdirs.isEmpty()) return emptyList()
+
+	return subdirs.filter { dir -> isValidProjectDirectory(dir) }
+}
+
+/** Determines if the directory contains a valid Android project structure. */
+fun isValidProjectDirectory(selectedDir: File): Boolean {
+	if (isPluginProject(selectedDir)) {
+		return true
+	}
+
+	val appFolder = File(selectedDir, "app")
+	val buildGradleFile = File(appFolder, "build.gradle")
+	val buildGradleKtsFile = File(appFolder, "build.gradle.kts")
+	return appFolder.exists() && appFolder.isDirectory &&
+		(buildGradleFile.exists() || buildGradleKtsFile.exists())
+}
+
+/**
+ * Determines if the selected directory is either:
+ *  1. A valid Android project itself, OR
+ *  2. A container that includes one or more valid Android projects.
+ */
+internal fun isValidProjectOrContainerDirectory(selectedDir: File): Boolean {
+	if (!selectedDir.isProjectCandidateDir()) {
+		return false
+	}
+
+	if (isValidProjectDirectory(selectedDir)) {
+		return true
+	}
+
+	// Check if it contains valid Android projects as subdirectories
+	val subDirs = selectedDir.listFiles()?.filter { it.isProjectCandidateDir() } ?: return false
+	return subDirs.any { sub -> isValidProjectDirectory(sub) }
+}
+
+/** Checks if the directory contains a specific plugin project structure. */
+internal fun isPluginProject(dir: File): Boolean {
+	val pluginApiJar = File(dir, "libs/plugin-api.jar")
+	val buildGradle = File(dir, "build.gradle.kts")
+	return pluginApiJar.exists() && buildGradle.exists()
+}


### PR DESCRIPTION
## Description

This PR refactors the project opening logic to centralize the "Auto Open" feature within `MainActivity`, removing the dependency on `RecentProjectsFragment` for this task. It introduces a robust fallback mechanism that scans the file system to ensure the project exists before attempting to open it.

## Details

* **Refactor**: Extracted project validation methods (`findValidProjects`, `isValidProjectDirectory`, etc.) from `RecentProjectsFragment` into a new utility file `ProjectValidations.kt` to allow shared access.
* **Logic Update**: Updated `MainActivity.tryOpenLastProject()` to run on `Dispatchers.IO`. It now verifies physically existing projects.
* **Fallback Mechanism**: If the `lastOpenedProject` preference points to a non-existent directory (or is empty), the app now automatically attempts to open the most recently modified valid project found in the projects directory.
* **UX Improvement**: Added guard clauses to prevent "Project does not exist" toast messages on fresh installations.


https://github.com/user-attachments/assets/2e50e4e7-534b-4480-b175-c10ad6079481


## Ticket

[ADFA-2673](https://appdevforall.atlassian.net/browse/ADFA-2673)

## Observation

The validation logic was duplicated and isolated in the fragment previously. Moving it to `ProjectValidations.kt` makes it reusable and testable. The new logic in `MainActivity` handles edge cases where the user might have deleted the project folder externally.

[ADFA-2673]: https://appdevforall.atlassian.net/browse/ADFA-2673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ