### PR TITLE
ADFA-2620 | Prevent sub-agent infinite loops

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/sidebar/adapter/ChatAdapter.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/sidebar/adapter/ChatAdapter.kt
@@ -162,9 +162,23 @@ class ChatAdapter(
             if (!expandedMessageIds.remove(message.id)) {
                 expandedMessageIds.add(message.id)
             }
-            // Notify the adapter with the specific payload for an efficient update
-            notifyItemChanged(holder.bindingAdapterPosition, ExpansionPayload)
+
+            val pos = holder.bindingAdapterPosition
+            if (pos == RecyclerView.NO_POSITION) return@setOnClickListener
+
+            holder.itemView.post {
+                val latestPos = holder.bindingAdapterPosition
+                if (latestPos != RecyclerView.NO_POSITION) {
+                    // Notify the adapter with the specific payload for an efficient update
+                    notifyItemChanged(latestPos, ExpansionPayload)
+                }
+            }
         }
+    }
+
+    override fun onCurrentListChanged(previousList: MutableList<ChatMessage>, currentList: MutableList<ChatMessage>) {
+        super.onCurrentListChanged(previousList, currentList)
+        expandedMessageIds.clear()
     }
 
     /**

--- a/app/src/main/java/com/itsaky/androidide/agent/fragments/ChatFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/agent/fragments/ChatFragment.kt
@@ -162,6 +162,8 @@ class ChatFragment : EmptyStateFragment<FragmentChatBinding>(FragmentChatBinding
 		}
 
 		binding.promptInputEdittext.text?.clear()
+		binding.promptInputEdittext.clearFocus()
+		hideKeyboard()
 
 		viewLifecycleOwner.lifecycleScope.launch {
 			if (selectedContext.isEmpty()) {

--- a/app/src/main/java/com/itsaky/androidide/agent/repository/AgenticRunner.kt
+++ b/app/src/main/java/com/itsaky/androidide/agent/repository/AgenticRunner.kt
@@ -39,6 +39,7 @@ import kotlinx.serialization.json.putJsonObject
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.time.LocalDateTime
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.jvm.optionals.getOrNull
 
 
@@ -46,6 +47,10 @@ class AgenticRunner(
     private val context: Context,
     private val maxSteps: Int = 20
 ) : GeminiRepository {
+
+    private var currentAIAgentThought: String = ""
+    private var currentProcessTitle: String = ""
+
     private val _messages = MutableStateFlow<List<ChatMessage>>(
         listOf(
         )
@@ -54,6 +59,9 @@ class AgenticRunner(
 
     private var runnerJob: Job = SupervisorJob()
     private var runnerScope: CoroutineScope = CoroutineScope(Dispatchers.IO + runnerJob)
+    private val runToken = AtomicLong(0L)
+    private fun nextRunToken(): Long = runToken.incrementAndGet()
+    private fun isTokenActive(token: Long): Boolean = runToken.get() == token
 
     private val plannerClient: GeminiClient by lazy {
         // Fetch the key when the client is first needed
@@ -91,7 +99,12 @@ class AgenticRunner(
      * cause the run loop to terminate with a CancellationException.
      */
     override fun stop() {
-        log.info("Stop requested for AgenticRunner. Cancelling job.")
+        val cancelledToken = nextRunToken()
+        log.info("Stop requested for AgenticRunner. Cancelling job. token=$cancelledToken")
+
+        updateLastMessageIfActive(cancelledToken, "Operation cancelled by user.")
+        onStateUpdate?.invoke(AgentState.Idle)
+
         runnerScope.cancel("User requested to stop the agent.")
         runnerJob = SupervisorJob()
         runnerScope = CoroutineScope(Dispatchers.IO + runnerJob)
@@ -113,6 +126,9 @@ class AgenticRunner(
     private val planner: Planner
     private val critic: Critic
     private val tools: List<Tool>
+    private val toolRequirements = agentToolRequiredArgs
+    private val blockedToolNames = mutableSetOf<String>()
+    private var impliedToolTextErrors = 0
     private val globalPolicy: String
     private val globalStaticExamples: List<Map<String, Any>>
 
@@ -148,17 +164,28 @@ class AgenticRunner(
 
 
         var header = """
-            You are an expert Android developer agent specializing in both Views and Jetpack Compose. Your goal is to fulfill user requests by interacting with an IDE.
-            Follow policies strictly.
+            [ROLE]
+            You are the AndroidIDE Automation Engine. You do not explain; you execute changes.
 
-            [Session Information]
-            - Current Date and Time: $formattedTime
+            [OPERATIONAL PROTOCOL - MANDATORY]
+            1. **STRICT DISCOVERY**: Before suggesting or writing any code, you MUST verify the project structure. 
+                - Call `list_files` on "." to see the module structure.
+                - Call `read_file` on `build.gradle` or `build.gradle.kts` to detect if the project uses Compose or XML Views.
+                - Call `read_file` on `AndroidManifest.xml` to find the `package` name and the Main Activity.
 
-            [Autonomy & Permissions]
-            1. **Read Access (Implicit):** You have full, permanent authorization to analyze the project directory, list files, and read contents. **DO NOT ask for permission to read files or explore directories**; do it immediately using the available tools if needed to understand the project or answer a question.
-            2. **Write Access (Explicit):** You MUST ask for user confirmation ONLY when you are about to modify, create, or delete files.
-            3. **Proactivity:** If a request is vague (e.g., "fix the bug in the main screen"), use your tools to explore the codebase and find the relevant files automatically instead of asking the user where they are.
-        
+            2. **INCREMENTAL MODIFICATION**: 
+                - If a requested UI element (e.g., a Button or Label) requires a View ID, check `R.id` or existing XML tags first.
+                - If adding a dependency, you MUST check the existing `dependencies { ... }` block to avoid duplicates.
+
+            3. **NO CONVERSATIONAL FILLER**: 
+                - DO NOT start responses with "I can help with that" or "I will do X". 
+                - If the user says "Add a button", your first and ONLY response must be the tool calls to find where to add it.
+                - Verbal confirmation is only allowed AFTER all tool calls have returned "OK".
+
+            [TECHNICAL CONSTRAINTS]
+                - Android Context: Assume the project is a standard Gradle Android project.
+                - File Paths: Always use relative paths from the project root.
+                - Idempotency: If a tool fails, analyze the error and try a different path (e.g., if `src/main/java` fails, try `src/main/kotlin`).
         """.trimIndent()
 
         val globalRulesText = globalPolicy
@@ -189,11 +216,12 @@ class AgenticRunner(
         }
 
         val finalInstruction =
-            "Use tools only when they are necessary to fulfill the user's request. " +
-                "If the request requires reading, creating, updating, or deleting files, " +
-                "or any IDE action, you MUST call the appropriate tool(s). " +
-                "If you already have enough information to answer without tools, answer directly. " +
-                "Do not respond with a plan or suggested actions—either call tools or provide the final answer."
+            "Use tools whenever the user's request implies a change, creation, or deep analysis of the project. " +
+            "If the request requires reading, creating, updating, or deleting files, or any IDE action, you MUST call the appropriate tool(s). " +
+            "ONLY answer directly without tools if the request is a general question that does not require project context or modifications. " +
+            "When choosing not to run tools, you must still provide a full textual answer that addresses the question—never return an empty reply. " +
+            "Do not just describe what you will do; if code needs to be written, use the tools to write it. " +
+            "Either call tools or provide the final answer after the tools have been executed."
 
         return "$header$formattedExamples$formattedHistory" +
                 "$finalInstruction\n\nUser Request: $prompt"
@@ -209,23 +237,33 @@ class AgenticRunner(
         // 2. Add the user's new message to the flow so it appears instantly
         addMessage(prompt, Sender.USER)
 
+        val token = nextRunToken()
+
         val finalMessage = try {
             runnerScope.async {
-                run()
+                run(token)
             }.await()
         } catch (e: CancellationException) {
-            log.warn("generateASimpleResponse caught cancellation.")
-            updateLastMessage("Operation cancelled by user.") // Update UI on cancellation
+            log.warn("generateASimpleResponse caught cancellation. token=$token")
+            updateLastMessageIfActive(token, "Operation cancelled by user.") // Update UI on cancellation
             "Operation cancelled by user."
         }
 
-        onStateUpdate?.invoke(AgentState.Idle)
+        if (isTokenActive(token)) {
+            onStateUpdate?.invoke(AgentState.Idle)
+        }
     }
 
-    private suspend fun run(): String {
+    private suspend fun run(token: Long): String {
+        if (!isTokenActive(token)) return "Operation cancelled by user."
+
         startLog()
-        addMessage("...", Sender.AGENT)
-        onStateUpdate?.invoke(AgentState.Processing("Initializing..."))
+        currentAIAgentThought = ""
+        currentProcessTitle = ""
+        addMessageIfActive(token, "...", Sender.AGENT)
+        onStateUpdateIfActive(token, AgentState.Processing("Initializing..."))
+        blockedToolNames.clear()
+        impliedToolTextErrors = 0
 
         val initialContent = buildInitialContent()
         val history = mutableListOf(initialContent)
@@ -233,23 +271,71 @@ class AgenticRunner(
         try {
             for (step in 0 until maxSteps) {
                 runnerScope.ensureActive()
-                onStateUpdate?.invoke(AgentState.Processing("Step ${step + 1}..."))
+                if (!isTokenActive(token)) throw CancellationException("Run token invalidated.")
 
-                val plan = processPlannerStep(history)
-                val functionCalls = plan.parts().get().mapNotNull { it.functionCall().getOrNull() }
+                val stepNumber = step + 1
+                updateProcessingState(token, stepNumber)
 
-                if (functionCalls.isEmpty()) {
-                    val finalText = plan.parts().get().first().text().getOrNull()?.trim() ?: ""
-                    updateLastMessage(finalText)
-                    logTurn("final_answer", listOf(Part.builder().text(finalText).build()))
-                    return finalText
+                val plan = try {
+                    processPlannerStep(token, history)
+                } catch (fallback: PlannerFallbackException) {
+                    return generateFinalAnswer(history, fallback.instruction)
+                }
+                updateProcessingState(token, stepNumber)
+                val planParts = plan.parts().get()
+                val functionCalls = planParts.mapNotNull { it.functionCall().getOrNull() }
+
+                val validationErrors = if (functionCalls.isEmpty()) emptyList() else validateFunctionCalls(functionCalls)
+                if (validationErrors.isNotEmpty()) {
+                    handleInvalidToolPlanning(token, history, validationErrors)
+                    continue
                 }
 
-                val toolResultsParts = processToolExecutionStep(functionCalls)
+                if (functionCalls.isEmpty()) {
+                    val impliedTool = detectImpliedToolMention(planParts)
+                    if (impliedTool != null) {
+                        impliedToolTextErrors++
+                        handleInvalidToolPlanning(
+                            token,
+                            history,
+                            listOf("You described calling tool `$impliedTool`, but no structured function call was emitted. Use the function-call interface instead of plain text.")
+                        )
+                        if (impliedToolTextErrors >= 2) {
+                            log.warn("Repeated implied tool call text detected; switching to text-only finalization.")
+                            return generateFinalAnswer(
+                                history,
+                                "Tool usage descriptions kept failing. Provide the best possible high-level answer without calling tools."
+                            )
+                        }
+                        continue
+                    }
+                }
+
+                if (functionCalls.isEmpty()) {
+                    val finalText = planParts
+                        .asSequence()
+                        .mapNotNull { it.text().getOrNull()?.trim() }
+                        .firstOrNull { it.isNotBlank() }
+                        .orEmpty()
+
+                    if (finalText.isNotBlank()) {
+                        updateLastMessageIfActive(token, finalText)
+                        logTurn("final_answer", listOf(Part.builder().text(finalText).build()))
+                        return finalText
+                    }
+
+                    log.warn("Planner returned no tool calls and no textual response; generating fallback answer.")
+                    return generateFinalAnswer(
+                        history,
+                        "The planner produced no tool calls or reasoning, but the user still requires a response. Provide the best possible direct answer or clarification using the conversation so far, even if it must remain high level."
+                    )
+                }
+
+                val toolResultsParts = processToolExecutionStep(token, functionCalls)
                 history.add(Content.builder().role("tool").parts(toolResultsParts).build())
                 logTurn("tool", toolResultsParts)
 
-                val critiqueResult = processCriticStep(history)
+                val critiqueResult = processCriticStep(token, history)
                 if (critiqueResult.trim().equals("OK", ignoreCase = true)) {
                     return generateFinalAnswer(history)
                 }
@@ -257,15 +343,126 @@ class AgenticRunner(
             throw RuntimeException("Exceeded max steps")
         } catch (err: Exception) {
             if (err is CancellationException) {
-                log.warn("Agentic run was cancelled during execution.")
+                log.warn("Agentic run was cancelled during execution. token=$token")
                 return "Operation cancelled by user."
             }
             log.error("Agentic run failed", err)
-            updateLastMessage("An error occurred: ${err.message}")
+            updateLastMessageIfActive(token, "An error occurred: ${err.message}")
             return "Agentic run failed: ${err.message}"
         } finally {
             writeLog()
         }
+    }
+
+    private fun updateProcessingState(token: Long, stepNumber: Int) {
+        onStateUpdateIfActive(token, AgentState.Processing("Step $stepNumber: ${getCurrentThoughtTitle()}"))
+		}
+
+    private fun getCurrentThoughtTitle(): String {
+        if (currentProcessTitle.isNotBlank()) {
+            return currentProcessTitle
+        }
+
+        if (currentAIAgentThought.isBlank()) {
+            return "Processing current request..."
+        }
+
+        val fallback = currentAIAgentThought
+            .lineSequence()
+            .map { extractTaskDescription(it) }
+            .firstOrNull { it.isNotBlank() }
+            .orEmpty()
+
+        return fallback.ifBlank { "Processing current request..." }
+    }
+
+    private fun extractTaskDescription(line: String): String {
+        var workingLine = line.trim()
+        if (workingLine.isEmpty()) {
+            return ""
+        }
+
+        // Remove bullet and numbering prefixes ("- ", "1. ", "2)" etc.)
+        val bulletPrefixes = listOf("- ", "* ", "• ", "– ")
+        for (prefix in bulletPrefixes) {
+            if (workingLine.startsWith(prefix)) {
+                workingLine = workingLine.removePrefix(prefix).trimStart()
+                break
+            }
+        }
+
+        val numberedPrefixRegex = Regex("^\\d+[\\.)]\\s*")
+        workingLine = workingLine.replaceFirst(numberedPrefixRegex, "").trimStart()
+
+        val labelPrefixes = listOf(
+            "Thought Process:",
+            "Thought:",
+            "Process:",
+            "Goal:",
+            "Task:",
+            "Plan:"
+        )
+        for (prefix in labelPrefixes) {
+            if (workingLine.startsWith(prefix, ignoreCase = true)) {
+                workingLine = workingLine.substring(prefix.length)
+                    .trimStart { it == ':' || it.isWhitespace() }
+                break
+            }
+        }
+
+        val separatorCandidates = listOf(". ", ";", " - ")
+        val shortened = separatorCandidates
+            .map { workingLine.indexOf(it) }
+            .filter { it > 0 }
+            .minOrNull()
+
+        return if (shortened != null) {
+            workingLine.substring(0, shortened).trim()
+        } else {
+            workingLine.trim()
+        }
+    }
+
+    private fun extractPlannerMetadata(text: String): Pair<String?, String> {
+			if (text.isBlank()) {
+				return null to ""
+        }
+
+        var processTitle: String? = null
+        val remainingLines = mutableListOf<String>()
+
+        text.lineSequence().forEach { line ->
+            val trimmed = line.trim()
+            if (processTitle == null && trimmed.startsWith("Process Title:", ignoreCase = true)) {
+                processTitle = trimmed.substringAfter(":").trim()
+            } else {
+                remainingLines += line
+            }
+        }
+
+        return processTitle to remainingLines.joinToString("\n").trim()
+    }
+
+    private fun updateProcessTitle(titleCandidate: String?, fallbackSource: String) {
+        val sanitizedCandidate = titleCandidate?.let { sanitizeProcessTitle(it) }.orEmpty()
+        val fallbackTitle = fallbackSource
+            .lineSequence()
+            .map { extractTaskDescription(it) }
+            .firstOrNull { it.isNotBlank() }
+            .orEmpty()
+
+        currentProcessTitle = when {
+            sanitizedCandidate.isNotBlank() -> sanitizedCandidate
+            fallbackTitle.isNotBlank() -> fallbackTitle
+            else -> ""
+        }
+    }
+
+    private fun sanitizeProcessTitle(title: String): String {
+        return title
+            .replace("\n", " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
     }
 
     // --- Helper methods for the run loop ---
@@ -286,23 +483,64 @@ class AgenticRunner(
             .build()
     }
 
-    private fun processPlannerStep(history: MutableList<Content>): Content {
-        updateLastMessage("Planning...")
-        val plan = planner.plan(history)
+    private fun processPlannerStep(token: Long, history: MutableList<Content>): Content {
+        updateLastMessageIfActive(token, "Planning...")
+        val plan = requestPlannerContent(token, history)
+        val combinedText = plan.parts().get()
+            .mapNotNull { it.text().getOrNull() }
+            .joinToString("\n")
+            .trim()
+
+        val (processTitle, remainingThought) = extractPlannerMetadata(combinedText)
+        updateProcessTitle(processTitle, remainingThought)
+
+        if (remainingThought.isNotEmpty()) {
+            currentAIAgentThought = remainingThought
+            val formattedText = formatThoughtWithCode(remainingThought)
+            updateLastMessageIfActive(token, formattedText)
+        } else {
+            currentAIAgentThought = "Analyzing and planning next steps..."
+            updateLastMessageIfActive(token, currentAIAgentThought)
+        }
+
         history.add(plan)
         logTurn("model", plan.parts().get())
         return plan
     }
 
-    private suspend fun processToolExecutionStep(functionCalls: List<com.google.genai.types.FunctionCall>): List<Part> {
+    private fun formatThoughtWithCode(text: String): String {
+        if (!text.contains("```")) {
+            return "<font color='#888888'><i>$text</i></font>"
+        }
+
+        val parts = text.split("```")
+        val sb = StringBuilder()
+        for (i in parts.indices) {
+            if (i % 2 == 0) {
+                if (parts[i].isNotBlank()) {
+                    sb.append("<font color='#888888'><i>${parts[i]}</i></font>")
+                }
+            } else {
+                sb.append("\n```").append(parts[i]).append("```\n")
+            }
+        }
+        return sb.toString()
+    }
+
+    private suspend fun processToolExecutionStep(token: Long, functionCalls: List<com.google.genai.types.FunctionCall>): List<Part> {
         val toolCallSummary =
-            functionCalls.joinToString("\n") { "Calling tool: `${it.name().get()}`" }
-        updateLastMessage(toolCallSummary)
+            functionCalls.joinToString("\n") { "Calling tool: `${it.name().getOrNull().orEmpty()}`" }
+        val fullStatus = if (currentAIAgentThought.isNotEmpty()) {
+            "$currentAIAgentThought\n\n$toolCallSummary"
+        } else {
+            toolCallSummary
+        }
+        updateLastMessageIfActive(token, fullStatus)
         return executor.execute(functionCalls)
     }
 
-    private suspend fun processCriticStep(history: MutableList<Content>): String {
-        updateLastMessage("Reviewing results...")
+    private suspend fun processCriticStep(token: Long, history: MutableList<Content>): String {
+        updateLastMessageIfActive(token, "$currentAIAgentThought\n\nReviewing results and verifying changes...")
         val critiqueResult = critic.reviewAndSummarize(history)
         if (critiqueResult != "OK") {
             history.add(
@@ -314,22 +552,170 @@ class AgenticRunner(
         return critiqueResult
     }
 
-    private fun generateFinalAnswer(history: List<Content>): String {
-        val finalInstruction = Content.builder()
-            .role("user")
-            .parts(
-                Part.builder()
-                    .text("Provide a final, concise answer to the user's request based on the conversation so far.")
-                    .build()
-            )
-            .build()
+    private fun requestPlannerContent(token: Long, history: MutableList<Content>): Content {
+        var attempts = 0
+        while (attempts < 2) {
+            try {
+                return planner.plan(history)
+            } catch (e: PlannerToolCallException) {
+                attempts++
+                e.toolName?.let { blockedToolNames.add(it) }
+                handlePlannerToolCallException(token, history, e, attempts)
+            }
+        }
+        val instruction =
+            "The planner could not produce a valid tool invocation after multiple attempts. Provide a direct textual answer without calling any tools."
+        history.add(
+            Content.builder().role("user").parts(Part.builder().text(instruction).build()).build()
+        )
+        throw PlannerFallbackException(instruction)
+    }
 
-        val finalHistory = history.toMutableList().apply { add(finalInstruction) }
-        val response = plannerClient.generateContent(finalHistory, tools = emptyList())
-        val finalText = response.text()?.trim().orEmpty()
-        updateLastMessage(finalText)
-        logTurn("final_answer", listOf(Part.builder().text(finalText).build()))
-        return finalText
+    private fun handlePlannerToolCallException(
+        token: Long,
+        history: MutableList<Content>,
+        error: PlannerToolCallException,
+        attempt: Int
+    ) {
+        val reason = when (error) {
+            is UnexpectedToolCallException -> "The previous plan was rejected because the model attempted to call a tool even though no tool calls were allowed at that time."
+            is MalformedToolCallException -> "The previous plan failed because the tool invocation was malformed."
+            else -> "The previous plan was rejected due to an invalid tool invocation."
+        }
+        log.warn("Planner tool call rejected on attempt {}: {}", attempt, error.message)
+        val toolNote = error.toolName?.let { " Tool `${it}` is now blocked until you can explain how to call it safely." } ?: ""
+        val instructionText =
+            "$reason$toolNote Before attempting another tool call, double-check the required parameters and confirm that calling a tool is necessary. If the request can be answered conceptually, respond with text instead of forcing a tool call."
+        history.add(
+            Content.builder().role("user")
+                .parts(Part.builder().text(instructionText).build()).build()
+        )
+        updateLastMessageIfActive(
+            token,
+            "Planner output was invalid. Asking it to correct the plan..."
+        )
+    }
+
+    private fun validateFunctionCalls(functionCalls: List<com.google.genai.types.FunctionCall>): List<String> {
+        val errors = mutableListOf<String>()
+        functionCalls.forEach { call ->
+            val name = call.name().getOrNull().orEmpty()
+            if (name.isBlank()) {
+                errors += "A function call without a name was emitted. Provide a valid tool name."
+                return@forEach
+            }
+            if (!toolRequirements.containsKey(name)) {
+                blockedToolNames.add(name)
+                errors += "Unknown tool `$name` was requested. Use only the supported tools."
+                return@forEach
+            }
+            if (blockedToolNames.contains(name)) {
+                errors += "Tool `$name` is temporarily blocked after a malformed invocation. Choose a different tool or respond with a textual answer."
+            }
+            val requiredArgs = toolRequirements[name].orEmpty()
+            val args = call.args().getOrNull() ?: emptyMap()
+            val missingArgs = requiredArgs.filterNot { key ->
+                args[key]?.toString()?.isNotBlank() == true
+            }
+            if (missingArgs.isNotEmpty()) {
+                blockedToolNames.add(name)
+                errors += "Tool `$name` is missing required arguments: ${missingArgs.joinToString(", ")}."
+            }
+        }
+        return errors.distinct()
+    }
+
+    private fun handleInvalidToolPlanning(
+        token: Long,
+        history: MutableList<Content>,
+        validationErrors: List<String>
+    ) {
+        log.warn(
+            "Planner emitted invalid tool usage: {}",
+            validationErrors.joinToString(" | ")
+        )
+        val instruction = buildString {
+            append("The previous plan violated tool requirements:\n")
+            validationErrors.forEach { append("- ").append(it).append("\n") }
+            append("Re-plan with valid tool arguments, or provide a textual response if tools are unnecessary.")
+        }
+        history.add(
+            Content.builder().role("user")
+                .parts(Part.builder().text(instruction).build()).build()
+        )
+        updateLastMessageIfActive(
+            token,
+            "Planner proposed invalid tool usage. Requesting a corrected plan..."
+        )
+    }
+
+    private fun detectImpliedToolMention(parts: List<Part>): String? {
+        val concatenated = parts.joinToString("\n") { part -> part.text().getOrNull().orEmpty() }
+        if (concatenated.isBlank()) return null
+
+        val normalizedNoWhitespace =
+            concatenated.lowercase().replace(Regex("\\s+"), "")
+
+        for (tool in toolRequirements.keys) {
+            val name = tool.lowercase()
+            val simpleRegex =
+                Regex("(?i)(call|invoke|use)\\s*[:=]?\\s*`?$tool`?")
+            if (simpleRegex.containsMatchIn(concatenated)) {
+                return tool
+            }
+
+            val markers = listOf(
+                "call:$name",
+                "call$name",
+                "invoke:$name",
+                "use:$name"
+            )
+            if (markers.any { normalizedNoWhitespace.contains(it) }) {
+                return tool
+            }
+        }
+
+        return null
+    }
+
+    private fun generateFinalAnswer(
+        history: List<Content>,
+        instruction: String = "Provide a final, concise answer to the user's request based on the conversation so far. If the solution involves code, provide the full source code blocks using Markdown formatting."
+    ): String {
+        val finalHistory = history.toMutableList()
+        var instructionText = instruction
+        repeat(2) { attempt ->
+            val finalInstruction = Content.builder()
+                .role("user")
+                .parts(Part.builder().text(instructionText).build())
+                .build()
+            finalHistory.add(finalInstruction)
+            try {
+                val response = plannerClient.generateContent(finalHistory, tools = emptyList())
+                val finalText = response.text()?.trim().orEmpty()
+                if (finalText.isNotBlank()) {
+                    updateLastMessage(finalText)
+                    logTurn("final_answer", listOf(Part.builder().text(finalText).build()))
+                    return finalText
+                }
+            } catch (e: PlannerToolCallException) {
+                log.warn(
+                    "Final answer attempt {} failed because the model tried to call a tool: {}",
+                    attempt + 1,
+                    e.message
+                )
+                instructionText =
+                    "Tool calls are forbidden when providing the final answer. Respond with direct text only.\n$instruction"
+                return@repeat
+            }
+        }
+        val thoughtSummary = currentAIAgentThought.takeIf { it.isNotBlank() }
+            ?: "Please review the latest tool outputs to continue where I left off."
+        val fallbackText =
+            "Unable to complete tool-based actions, but here is the current understanding:\n\n$thoughtSummary"
+        updateLastMessage(fallbackText)
+        logTurn("final_answer", listOf(Part.builder().text(fallbackText).build()))
+        return fallbackText
     }
 
     private fun startLog() {
@@ -434,7 +820,7 @@ class AgenticRunner(
     }
 
     override fun loadHistory(history: List<ChatMessage>) {
-        _messages.value = history
+        _messages.value = history.toList()
     }
 
     private fun addMessage(text: String, sender: Sender) {
@@ -444,13 +830,35 @@ class AgenticRunner(
 
     private fun updateLastMessage(newText: String) {
         _messages.update { currentList ->
-            if (currentList.isEmpty()) return@update currentList
+            if (currentList.isEmpty()) {
+                return@update currentList + ChatMessage(text = newText, sender = Sender.AGENT)
+            }
+
             val lastMessage = currentList.last()
-            val updatedMessage = lastMessage.copy(text = newText)
-            currentList.dropLast(1) + updatedMessage
+            return@update if (lastMessage.sender == Sender.AGENT) {
+                currentList.dropLast(1) + lastMessage.copy(text = newText)
+            } else {
+                currentList + ChatMessage(text = newText, sender = Sender.AGENT)
+            }
         }
     }
 
+    private fun addMessageIfActive(token: Long, text: String, sender: Sender) {
+        if (!isTokenActive(token)) return
+        addMessage(text, sender)
+    }
+
+    private fun updateLastMessageIfActive(token: Long, newText: String) {
+        if (!isTokenActive(token)) return
+        updateLastMessage(newText)
+    }
+
+    private fun onStateUpdateIfActive(token: Long, state: AgentState) {
+        if (!isTokenActive(token)) return
+        onStateUpdate?.invoke(state)
+    }
+
+    private class PlannerFallbackException(val instruction: String) : Exception()
 }
 
 /**

--- a/app/src/main/java/com/itsaky/androidide/agent/repository/Critic.kt
+++ b/app/src/main/java/com/itsaky/androidide/agent/repository/Critic.kt
@@ -111,7 +111,12 @@ class Critic(private val client: GeminiClient) {
 
         // The Critic only needs to see the tool output, not the entire history that led to it.
         // We already framed it above.
-        val response = client.generateContent(criticHistory, tools = emptyList())
+        val response = try {
+            client.generateContent(criticHistory, tools = emptyList())
+        } catch (e: PlannerToolCallException) {
+            log.warn("Critic model attempted an invalid tool call: {}", e.message)
+            return "OK"
+        }
         val summaryText = response.text()?.trim()
 
         if (summaryText.isNullOrBlank()) {

--- a/app/src/main/java/com/itsaky/androidide/agent/repository/GeminiTools.kt
+++ b/app/src/main/java/com/itsaky/androidide/agent/repository/GeminiTools.kt
@@ -212,3 +212,17 @@ val allAgentTools: List<Tool> = listOf(
     Tool.builder().functionDeclarations(triggerGradleSync).build(),
     Tool.builder().functionDeclarations(getBuildOutput).build()
 )
+
+val agentToolRequiredArgs: Map<String, List<String>> = mapOf(
+    "create_file" to listOf("path", "content"),
+    "read_file" to listOf("path"),
+    "update_file" to listOf("path", "content"),
+    "delete_file" to listOf("path"),
+    "list_files" to listOf("path"),
+    "read_multiple_files" to listOf("paths"),
+    "add_dependency" to listOf("dependency", "build_file_path"),
+    "add_string_resource" to listOf("name", "value"),
+    "run_app" to emptyList(),
+    "trigger_gradle_sync" to emptyList(),
+    "get_build_output" to emptyList()
+)

--- a/app/src/main/java/com/itsaky/androidide/agent/repository/MalformedToolCallException.kt
+++ b/app/src/main/java/com/itsaky/androidide/agent/repository/MalformedToolCallException.kt
@@ -1,0 +1,28 @@
+package com.itsaky.androidide.agent.repository
+
+/**
+ * Base exception for scenarios where the planner's response is rejected due to tool invocation issues.
+ */
+open class PlannerToolCallException(
+    message: String,
+    val toolName: String? = null,
+    val rawCandidate: String? = null
+) : Exception(message)
+
+/**
+ * Thrown when the model emits a syntactically invalid tool call payload.
+ */
+class MalformedToolCallException(
+    message: String,
+    toolName: String? = null,
+    rawCandidate: String? = null
+) : PlannerToolCallException(message, toolName, rawCandidate)
+
+/**
+ * Thrown when the model tries to call a tool even though the platform rejected tool use altogether.
+ */
+class UnexpectedToolCallException(
+    message: String,
+    toolName: String? = null,
+    rawCandidate: String? = null
+) : PlannerToolCallException(message, toolName, rawCandidate)

--- a/app/src/main/java/com/itsaky/androidide/agent/repository/Planner.kt
+++ b/app/src/main/java/com/itsaky/androidide/agent/repository/Planner.kt
@@ -20,10 +20,111 @@ class Planner(
         private val log = LoggerFactory.getLogger(Planner::class.java)
 
         private const val SYSTEM_PROMPT = """
-        You are an expert AI developer agent. Your sole purpose is to analyze the user's request and the conversation history, then select the most appropriate tool and parameters to call next. 
-        You MUST respond with only a valid JSON object for a tool call. Do not provide any conversational text, explanations, or markdown formatting.
+        You are an expert AI developer agent. Your sole purpose is to analyze the user's request and the conversation history, then select the most appropriate tool and parameters to call next.
 
-        **CRITICAL RULE**: If a tool call has failed in the previous step, do NOT call the exact same tool with the exact same parameters again. You must try a different tool or different parameters to debug the problem.
+        ==================================================
+        LINE BREAK ENFORCEMENT (CRITICAL)
+        ==================================================
+        You MUST output REAL newline characters.
+        Single-line responses are strictly forbidden.
+
+        The response MUST contain AT LEAST two blank lines (i.e., "\n\n") to separate the three required sections.
+        The exact structure MUST look like this, with real line breaks:
+        
+        <Process Title line>
+        
+        <Thought Process text...>
+        
+        Response: <Final Response text OR tool calls...>
+        
+        Additional formatting constraints:
+        - The first line MUST contain ONLY the Process Title (no prefixes, no extra text).
+        - The second line MUST be EMPTY (blank line).
+        - "Thought Process" content MUST start on the third line.
+        - There MUST be exactly ONE blank line between sections (minimum one; more is allowed only if needed for readability).
+        - DO NOT inline the section names on the same line (e.g., "Process Title: ... Thought Process: ...") — forbidden.
+        - Never collapse the full response into a single paragraph.
+        
+        ==================================================
+        FINAL RESPONSE WRAPPING (CRITICAL)
+        ==================================================
+        The Final Response section MUST start with the literal prefix `Response:`.
+        
+        This rule applies to ALL responses, including those that contain tool calls.
+        
+        Rules:
+        - The `Response:` prefix is mandatory.
+        - Anything that belongs to the final answer or tool calls MUST appear after `Response:`.
+        - Nothing is allowed after the Final Response.
+        - Do NOT omit, rename, or move the `Response:` prefix.
+        
+        ==================================================
+        MANDATORY RESPONSE FORMAT (NO EXCEPTIONS)
+        ==================================================
+        
+        Every response MUST strictly follow this exact structure and order:
+        
+        1) Process Title
+        2) Thought Process
+        3) Final Response (or Tool Calls, if applicable)
+        
+        The response MUST ALWAYS contain all three sections in this order.
+        
+        --------------------------------------------------
+        
+        SECTION 1: Process Title
+        - The very first line of the response.
+        - A single short line.
+        - Maximum 6 words.
+        - Human-friendly description of the action.
+        - Example:
+          Review gradle files
+        
+        --------------------------------------------------
+        
+        SECTION 2: Thought Process
+        - Plain text explanation.
+        - MUST appear immediately after the Process Title.
+        - MUST appear BEFORE any tool call.
+        - MUST include:
+          1. What is your current goal for this specific step.
+          2. Which files or directories you are going to analyze and EXACTLY why they are relevant to the request.
+          3. What is your overall strategy and what you expect to find.
+        
+        IMPORTANT:
+        - DO NOT include code blocks in the Thought Process.
+        - DO NOT include tool arguments here.
+        
+        --------------------------------------------------
+        
+        SECTION 3: Final Response / Tool Calls
+        - This section MUST begin with the literal prefix `Response:`
+        - If the user requested an action (implement, modify, create):
+          - You MUST call the appropriate tools.
+        - If no tools are needed:
+          - Provide a complete textual answer to the user here.
+        - This section must NEVER be empty.
+        
+        ==================================================
+        CRITICAL RULES
+        ==================================================
+        
+        CRITICAL RULE 1:
+        If a tool call failed in the previous step, do NOT call the exact same tool with the exact same parameters again. You must try a different tool or different parameters to debug the problem.
+        
+        CRITICAL RULE 2:
+        If the user asks to implement a feature, modify code, or create a UI, you MUST NOT just explain it. You MUST call the appropriate tools (list_files, read_file, update_file, etc.) to perform the action. A response with only text when an action is requested is considered a failure.
+        
+        CRITICAL RULE 3:
+        Before modifying any file to implement a feature (like adding a calculator logic or a label), you MUST first use read_file to understand the existing code context. Never overwrite a file with placeholder code; always preserve existing logic unless the task requires its replacement.
+        
+        CRITICAL RULE 4:
+        DO NOT PROVIDE CODE BLOCKS IN THE THOUGHT PROCESS. All code changes must be sent exclusively through the tool arguments.
+        
+        CRITICAL RULE 5:
+        If you decide that no tool calls are needed (for example, the user only needs a conceptual explanation), you must still produce a complete textual response within the same message. Provide the Process Title, your detailed thought process, and then a final answer paragraph addressed to the user. Never leave the response empty or without a clear answer.
+        
+        Failure to follow this format is considered an invalid response.
     """
     }
 

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -42,7 +42,7 @@
         app:layout_constraintTop_toBottomOf="@id/chat_toolbar"
         tools:listitem="@layout/list_item_chat_message" />
 
-    <RelativeLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/agent_status_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -58,31 +58,34 @@
 
         <TextView
             android:id="@+id/agent_status_message"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
-            android:layout_centerVertical="true"
             android:layout_marginEnd="8dp"
-            android:layout_toStartOf="@+id/agent_status_timer"
             android:ellipsize="end"
             android:fontFamily="monospace"
-            android:maxLines="10"
+            android:maxLines="1"
             android:textAppearance="?attr/textAppearanceCaption"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/agent_status_timer"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             tools:text="Executing tool: create_file..." />
 
         <TextView
             android:id="@+id/agent_status_timer"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
             android:fontFamily="monospace"
             android:gravity="end"
             android:minWidth="130dp"
             android:textAppearance="?attr/textAppearanceCaption"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             tools:text="(1m 20.5s of 5m 10.1s)" />
 
-    </RelativeLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/input_bar_card"


### PR DESCRIPTION
## Description

Refactored the `AgenticRunner` and `Planner` to prevent sub-agents from getting stuck in infinite tool-calling loops. This change allows the agent to provide a direct answer when it has sufficient information, rather than being forced to call a tool repeatedly.

## Details

* **Prompt Engineering:** Updated `finalInstruction` to explicitly tell the agent to answer directly if no tools are needed, instead of mandating tool usage.
* **Planner Logic:** Changed `forceToolUse` to `false` in `Planner.kt` to respect the updated prompt.
* **Termination Flow:** `processCriticStep` now returns a status; if the status is "OK", `generateFinalAnswer` is triggered to conclude the session immediately.


https://github.com/user-attachments/assets/c01380cb-0ce3-46d5-abcd-2d3d4cd4f925


## Ticket

[ADFA-2620](https://appdevforall.atlassian.net/browse/ADFA-2620)

## Observation

The logic now specifically checks for an "OK" result from the critic to break the loop and generate the final user-facing response.

[ADFA-2620]: https://appdevforall.atlassian.net/browse/ADFA-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ