### PR TITLE
ADFA-2692 | Fix storage accessibility error reporting

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/viewmodel/InstallationViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/InstallationViewModel.kt
@@ -88,7 +88,9 @@ class InstallationViewModel : ViewModel() {
 								_state.update { InstallationComplete }
 							}
 							is AssetsInstallationHelper.Result.Failure -> {
-								result.cause?.let { Sentry.captureException(it) }
+								if (result.shouldReportToSentry) {
+									result.cause?.let { Sentry.captureException(it) }
+								}
 								val errorMsg = result.errorMessage
 									?: context.getString(R.string.title_installation_failed)
 								viewModelScope.launch {


### PR DESCRIPTION
## Description

Implemented a self-healing mechanism in `AssetsInstallationHelper` that attempts to create the installation root directory if it is missing. This resolves potential race conditions during fresh installations where the directory might not be ready yet.

Additionally, added a flag to `Result.Failure` to suppress Sentry reporting for "Storage not accessible" errors. These errors are often environmental (e.g., device locked, permissions denied) rather than application bugs, so they shouldn't clutter the crash logs.

## Details

Logic update:

* Added `shouldReportToSentry` to `Result.Failure`.
* `checkStorageAccessibility` now attempts `mkdirs()` before failing.
* `InstallationViewModel` checks the flag before capturing exceptions.

### Before changes (race condition)

https://github.com/user-attachments/assets/9c7e3201-7a67-465b-be70-da3939890d89


### After changes

https://github.com/user-attachments/assets/2a7e7234-356b-4620-8906-ca60f931f104


## Ticket

[ADFA-2692](https://appdevforall.atlassian.net/browse/ADFA-2692)

## Observation

The "Storage is not accessible" error will now only appear if the app explicitly lacks write permissions (or the device is encrypted/locked), but it won't be reported to Sentry. If the folder is simply missing, the app will recreate it and proceed.

[ADFA-2692]: https://appdevforall.atlassian.net/browse/ADFA-2692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ