### PR TITLE
ADFA-2730 | Fix crash during file tree loading

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/fragments/sidebar/FileTreeSelectionFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/sidebar/FileTreeSelectionFragment.kt
@@ -88,21 +88,21 @@ class FileTreeSelectionFragment : Fragment(R.layout.fragment_file_tree_selection
 
             val baseDir = IProjectManager.getInstance().projectDir
 
-            selectedFiles.forEach { it ->
-                val itemText = it.relativeTo(baseDir).path
-                // Create a File object by joining the project root with the relative path (itemText)
-                val file = File(baseDir, itemText)
+            selectedFiles.forEach { selectedPath ->
+                val relativePath = selectedPath.relativeTo(baseDir).path
+                // Create a File object by joining the project root with the relative path
+                val target = File(baseDir, relativePath)
 
-                if (file.exists() && file.isDirectory) {
+                if (target.exists() && target.isDirectory) {
                     // It's a valid directory, so walk through it and add all readable files
-                    file.walkTopDown()
-                        .filter { it.isFile && it.canRead() }
-                        .forEach {
-                            finalContextList.add(it.relativeTo(baseDir).path)
+                    target.walkTopDown()
+                        .filter { walkedFile -> walkedFile.isFile && walkedFile.canRead() }
+                        .forEach { walkedFile ->
+                            finalContextList.add(walkedFile.relativeTo(baseDir).path)
                         }
-                } else if (file.exists() && file.isFile && file.canRead()) {
+                } else if (target.exists() && target.isFile && target.canRead()) {
                     // It's a single, readable file
-                    finalContextList.add(itemText)
+                    finalContextList.add(relativePath)
                 }
             }
 


### PR DESCRIPTION
## Description

Fixed a `DiagnosticCoroutineContextException` (caused by `IllegalStateException: Fragment not attached to a context`) that occurred when navigating back from the file tree selection screen while files were still loading.

The crash happened because `requireContext()` was being invoked inside a background coroutine (`Dispatchers.IO`) after the Fragment had already been detached.

I fixed this by:

1. Capturing the Context safely in the main thread before the background operation starts.
2. Passing this context as a parameter to the recursive `buildTreeNodes` function.
3. Adding `currentCoroutineContext().ensureActive()` inside the loop. This ensures the background operation stops immediately if the user navigates away, preventing the code from attempting to use resources after detachment.

## Details

**Stacktrace addressed:**

```bash
java.lang.IllegalStateException: Fragment FileTreeSelectionFragment not attached to a context.
    at androidx.fragment.app.Fragment.requireContext
    at com.itsaky.androidide.fragments.sidebar.FileTreeSelectionFragment.buildTreeNodes

```

### Before changes

https://github.com/user-attachments/assets/293cdf2c-4900-4f06-b00e-f45f1434bcd6


### After changes

https://github.com/user-attachments/assets/d53fb066-1938-4d12-a5bd-e25573415e04


## Ticket

[ADFA-2730](https://appdevforall.atlassian.net/browse/ADFA-2730)

## Observation

The addition of `ensureActive()` is critical to ensure cooperative cancellation, preventing the background thread from continuing to process files unnecessarily after the screen is closed.

[ADFA-2730]: https://appdevforall.atlassian.net/browse/ADFA-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ