### PR TITLE
ADFA-2944 | Fix crash when restoring BottomSheet state

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -937,6 +937,9 @@ abstract class BaseEditorActivity :
 	}
 
 	private fun updateBottomSheetState(state: BottomSheetViewModel.SheetState = BottomSheetViewModel.SheetState.EMPTY) {
+		when (state.sheetState) {
+			BottomSheetBehavior.STATE_DRAGGING, BottomSheetBehavior.STATE_SETTLING -> return
+		}
 		log.debug("updateSheetState: {}", state)
 		content.bottomSheet.setCurrentTab(state.currentTab)
 		if (editorBottomSheet?.state != state.sheetState) {


### PR DESCRIPTION
## Description

Fixed a crash caused by attempting to programmatically set the `BottomSheetBehavior` state to `STATE_SETTLING` or `STATE_DRAGGING`.

These are read-only internal states representing transient movement. If the Activity is recreated (e.g., during rotation or theme toggle) while the bottom sheet is settling, the `ViewModel` restores this state and attempts to apply it to the new view, causing an `IllegalArgumentException`.

## Details

The fix involves filtering out these transient states in `updateBottomSheetState` before applying them to the view.

**Error fixed:**
`java.lang.IllegalArgumentException: STATE_SETTLING should not be set externally.`

### Before changes
https://github.com/user-attachments/assets/8f2f432a-a6d5-4c1a-b86c-154d17be3354

### After changes

https://github.com/user-attachments/assets/2669c0e1-116a-409a-9b41-48a0995d7f74


## Ticket

[ADFA-2944](https://appdevforall.atlassian.net/browse/ADFA-2944)

## Observation

This resolves the race condition observed in Sentry reports where the app crashes upon restoration if the user was interacting with the bottom sheet during a configuration change.

[ADFA-2944]: https://appdevforall.atlassian.net/browse/ADFA-2944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ