### PR TITLE
ADFA-2807 Webserver endpoint pr/ex returns 200 if experimental mode is on, 404 if not

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
+++ b/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
@@ -59,7 +59,6 @@ class WebServer(private val config: ServerConfig) {
         return timestamp
     }
 
-    // NEW FEATURE: Log database last change information
     fun logDatabaseLastChanged() {
         try {
             val query = """


### PR DESCRIPTION
Added endpoint, pr/ex, to return 200 if experimental mode is on, 404 if not. Moved the db and pr endpoints to pr/db and pr/pr. Added more debug messages. Made a few cleanups to get rid of warnings and use idiomatic Kotlin.