### PR TITLE
ADFA-2657 | Fix editor threading and selection logic

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/handlers/FileTreeActionHandler.kt
+++ b/app/src/main/java/com/itsaky/androidide/handlers/FileTreeActionHandler.kt
@@ -19,6 +19,7 @@ package com.itsaky.androidide.handlers
 
 import android.content.Context
 import androidx.core.view.GravityCompat
+import androidx.lifecycle.lifecycleScope
 import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.actions.ActionItem.Location.EDITOR_FILE_TREE
 import com.itsaky.androidide.actions.ActionMenu
@@ -36,6 +37,7 @@ import com.itsaky.androidide.idetooltips.TooltipManager
 import com.itsaky.androidide.models.SheetOption
 import com.itsaky.androidide.utils.flashError
 import com.unnamed.b.atv.model.TreeNode
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -87,7 +89,9 @@ class FileTreeActionHandler : BaseEventHandler() {
       return
     }
 
-    context.openFile(event.file)
+    context.lifecycleScope.launch {
+      context.openFile(event.file)
+    }
   }
 
   @Subscribe(threadMode = MAIN)

--- a/app/src/main/java/com/itsaky/androidide/interfaces/IEditorHandler.kt
+++ b/app/src/main/java/com/itsaky/androidide/interfaces/IEditorHandler.kt
@@ -33,8 +33,8 @@ interface IEditorHandler {
   fun getEditorAtIndex(index: Int) : CodeEditorView?
   fun getEditorForFile(file: File) : CodeEditorView?
   
-  fun openFile(file: File) : CodeEditorView? = openFile(file, null)
-  fun openFile(file: File, selection: Range?) : CodeEditorView?
+  suspend fun openFile(file: File) : CodeEditorView? = openFile(file, null)
+  suspend fun openFile(file: File, selection: Range?) : CodeEditorView?
   fun openFileAndSelect(file: File, selection: Range?)
   fun openFileAndGetIndex(file: File, selection: Range?) : Int
   

--- a/app/src/main/java/com/itsaky/androidide/lsp/IDELanguageClientImpl.java
+++ b/app/src/main/java/com/itsaky/androidide/lsp/IDELanguageClientImpl.java
@@ -252,10 +252,12 @@ public class IDELanguageClientImpl implements ILanguageClient {
           } else {
             // Edit is in some other file which is not opened
             // open that file and perform the edit
-            openedFrag = activity.openFile(file);
-            if (openedFrag != null && openedFrag.getEditor() != null) {
-              editInEditor(openedFrag.getEditor(), edit);
-            }
+            activity.openFileAsync(file, null, openedEditor -> {
+              if (openedEditor != null && openedEditor.getEditor() != null) {
+                editInEditor(openedEditor.getEditor(), edit);
+              }
+              return kotlin.Unit.INSTANCE;
+            });
           }
         }
       }


### PR DESCRIPTION
## Description

This PR refactors the file opening logic in `EditorHandlerActivity` to improve thread safety and prevent potential UI freezes. By shifting from blocking calls to a coroutine-based `openFileInternal` method, we ensure that file type checks (I/O operations) don't block the main thread while guaranteeing that UI updates (tab selection and editor focus) occur on the correct thread.

## Details

* Replaced `runBlocking` with `withContext(Dispatchers.IO)` for image validation.
* Introduced `openFileInternal` as a suspend function to handle the core logic.
* Implemented thread checks in `openFile` to either launch a coroutine or block appropriately based on the calling context.
* Improved editor selection logic by ensuring it runs within the `lifecycleScope`.

### After changes
> Stressed thread simulation

https://github.com/user-attachments/assets/c0cce8ae-694f-4b2f-b26d-a764cec7e06f


## Ticket

[ADFA-2657](https://appdevforall.atlassian.net/browse/ADFA-2657)

### Also fixes;
[ADFA-2653](https://appdevforall.atlassian.net/browse/ADFA-2653)
[ADFA-2694](https://appdevforall.atlassian.net/browse/ADFA-2694)
[ADFA-2722](https://appdevforall.atlassian.net/browse/ADFA-2722)
[ADFA-2764](https://appdevforall.atlassian.net/browse/ADFA-2764)
[ADFA-2848](https://appdevforall.atlassian.net/browse/ADFA-2848)

## Observation

The use of `Looper.myLooper()` allows the activity to maintain backward compatibility with synchronous calls while moving toward a more reactive, non-blocking architecture.

[ADFA-2657]: https://appdevforall.atlassian.net/browse/ADFA-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ADFA-2653]: https://appdevforall.atlassian.net/browse/ADFA-2653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ