### PR TITLE
ADFA-3084 | Respect system screen orientation lock

### DIFF
--- a/common/src/main/java/com/itsaky/androidide/utils/OrientationUtilities.kt
+++ b/common/src/main/java/com/itsaky/androidide/utils/OrientationUtilities.kt
@@ -29,7 +29,7 @@ class OrientationUtilities {
         }
 
         fun setAdaptiveOrientation(setRequestedOrientation: (Int) -> Unit) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR)
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER)
         }
     }
 


### PR DESCRIPTION
## Description

Updated `setAdaptiveOrientation` in `OrientationUtilities.kt` to use `ActivityInfo.SCREEN_ORIENTATION_USER` instead of `SCREEN_ORIENTATION_SENSOR`. This ensures the application correctly respects the user's system-level screen rotation lock settings rather than forcing rotation based purely on device hardware sensors.

## Details

### Before fix

https://github.com/user-attachments/assets/9b625306-43a9-4f46-af8a-7a19650dc530


### After fix

https://github.com/user-attachments/assets/d1ddee28-74b1-4026-80a3-9920d9d68dfc


## Ticket

[ADFA-3084](https://appdevforall.atlassian.net/browse/ADFA-3084)

## Observation

This fixes the bug where the application would rotate in landscape mode even if the user explicitly locked the device's orientation.

[ADFA-3084]: https://appdevforall.atlassian.net/browse/ADFA-3084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ