### PR TITLE
Guard against IllegalStateException 

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
@@ -91,6 +91,14 @@ class BuildOutputFragment : NonEditableEditorFragment() {
 	}
 
 	override fun clearOutput() {
+		// This fragment uses `activityViewModels()`, which relies on the fragment being attached.
+		// `clearOutput()` can be triggered from build/service callbacks even after the fragment
+		// has been detached, so we must guard before touching the activity-scoped ViewModel.
+		if (!isAdded || isDetached) {
+			super.clearOutput()
+			return
+		}
+
 		buildOutputViewModel.clear()
 		super.clearOutput()
 	}

--- a/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
@@ -94,12 +94,9 @@ class BuildOutputFragment : NonEditableEditorFragment() {
 		// This fragment uses `activityViewModels()`, which relies on the fragment being attached.
 		// `clearOutput()` can be triggered from build/service callbacks even after the fragment
 		// has been detached, so we must guard before touching the activity-scoped ViewModel.
-		if (!isAdded || isDetached) {
-			super.clearOutput()
-			return
+		if (isAdded && !isDetached) {
+			buildOutputViewModel.clear()
 		}
-
-		buildOutputViewModel.clear()
 		super.clearOutput()
 	}
 

--- a/app/src/main/java/com/itsaky/androidide/fragments/output/ShareableOutputFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/ShareableOutputFragment.kt
@@ -29,6 +29,12 @@ interface ShareableOutputFragment {
 	/** Get the name of the file to which the output will be written. */
 	fun getShareableFilename(): String
 
-	/** Clear the output of this fragment. */
+	/**
+	 * Clear the output of this fragment.
+	 *
+	 * Note: Callers may invoke this while the fragment is detached (for example, from a
+	 * build/service callback). Implementations that use activity-scoped ViewModels must
+	 * guard against `!isAdded || isDetached` before touching them.
+	 */
 	fun clearOutput()
 }

--- a/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -430,7 +430,16 @@ constructor(
 		suppressedGradleWarnings.any { msg.contains(it) }
 
 	fun clearBuildOutput() {
-		pagerAdapter.buildOutputFragment?.clearOutput()
+		// Always clear the persistent build output state via the bottom sheet's
+		// activity-scoped ViewModel.
+		buildOutputViewModel.clear()
+
+		// `clearOutput()` on the fragment may touch additional UI state, so only call it when
+		// the fragment is currently attached to an activity.
+		val fragment = pagerAdapter.buildOutputFragment
+		if (fragment != null && fragment.isAdded && !fragment.isDetached) {
+			fragment.clearOutput()
+		}
 	}
 
 	fun handleDiagnosticsResultVisibility(errorVisible: Boolean) {


### PR DESCRIPTION
BuildOutputFragment.clearOutput() was being called after the fragment is detached

The bottom sheet now clears the shared build-output state via its own ViewModel first