### PR TITLE
fix/ADFA-3549 compose logsender runtime error

### DIFF
--- a/logsender/src/main/java/com/itsaky/androidide/logsender/LogSenderService.java
+++ b/logsender/src/main/java/com/itsaky/androidide/logsender/LogSenderService.java
@@ -169,7 +169,7 @@ public class LogSenderService extends Service {
 
 		// Set Exit button action
 		Intent exitIntent = new Intent(this, LogSenderService.class).setAction(ACTION_STOP_SERVICE);
-		builder.addAction(R.drawable.ic_delete,
+		builder.addAction(android.R.drawable.ic_delete,
 				res.getString(R.string.notification_action_exit),
 				PendingIntent.getService(this, 0, exitIntent, PendingIntent.FLAG_IMMUTABLE));
 


### PR DESCRIPTION
fix error cause by invalid reference to ic_delete