### PR TITLE
ADFA-3489 | Fix onboarding blocked by unsupported overlay permission

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/build/DebugAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/build/DebugAction.kt
@@ -7,6 +7,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
+import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import android.text.SpannableStringBuilder
@@ -17,6 +18,7 @@ import androidx.core.content.ContextCompat.startForegroundService
 import androidx.core.view.setPadding
 import com.google.android.material.textview.MaterialTextView
 import com.itsaky.androidide.actions.ActionData
+import com.itsaky.androidide.activities.editor.EditorHandlerActivity
 import com.itsaky.androidide.activities.editor.HelpActivity
 import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.lsp.api.ILanguageServerRegistry
@@ -26,6 +28,7 @@ import com.itsaky.androidide.projects.IProjectManager
 import com.itsaky.androidide.projects.isPluginProject
 import com.itsaky.androidide.resources.R
 import com.itsaky.androidide.utils.DialogUtils
+import com.itsaky.androidide.utils.PermissionsHelper
 import com.itsaky.androidide.utils.appendHtmlWithLinks
 import com.itsaky.androidide.utils.appendOrderedList
 import com.itsaky.androidide.utils.flashError
@@ -99,6 +102,15 @@ class DebugAction(
 			return false
 		}
 
+        val overlayState = withContext(Dispatchers.Main.immediate) {
+            PermissionsHelper.getOverlayPermissionState(activity)
+        }
+
+        if (overlayState != PermissionsHelper.OverlayPermissionState.GRANTED) {
+            handleMissingOverlayPermission(activity, overlayState)
+            return false
+        }
+
 		if (!Shizuku.pingBinder()) {
 			log.error("Shizuku service is not running")
 			withContext(Dispatchers.Main.immediate) {
@@ -109,6 +121,32 @@ class DebugAction(
 
 		return Shizuku.pingBinder()
 	}
+
+	private suspend fun handleMissingOverlayPermission(
+        activity: EditorHandlerActivity,
+        state: PermissionsHelper.OverlayPermissionState
+    ) {
+        withContext(Dispatchers.Main.immediate) {
+            when (state) {
+                PermissionsHelper.OverlayPermissionState.UNSUPPORTED -> {
+                    activity.flashError(activity.getString(R.string.permission_overlay_unsupported_hint))
+                }
+                PermissionsHelper.OverlayPermissionState.REQUESTABLE -> {
+                    val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION).apply {
+                        putExtra(Settings.EXTRA_APP_PACKAGE, activity.packageName)
+                        setData(Uri.fromParts("package", activity.packageName, null))
+                    }
+                    try {
+                        activity.startActivity(intent)
+                    } catch (e: Exception) {
+                        log.error("Failed to launch overlay settings", e)
+                        activity.flashError(activity.getString(R.string.err_no_activity_to_handle_action, Settings.ACTION_MANAGE_OVERLAY_PERMISSION))
+                    }
+                }
+                else -> {}
+            }
+        }
+    }
 
 	@RequiresApi(Build.VERSION_CODES.R)
 	private fun showPairingDialog(context: Context): AlertDialog? {

--- a/app/src/main/java/com/itsaky/androidide/adapters/onboarding/OnboardingPermissionsAdapter.kt
+++ b/app/src/main/java/com/itsaky/androidide/adapters/onboarding/OnboardingPermissionsAdapter.kt
@@ -21,9 +21,11 @@ import android.content.res.ColorStateList
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.ColorUtils
 import androidx.recyclerview.widget.RecyclerView
 import com.blankj.utilcode.util.SizeUtils
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.color.MaterialColors
 import com.itsaky.androidide.R
 import com.itsaky.androidide.databinding.LayoutOnboardingPermissionItemBinding
 import com.itsaky.androidide.models.OnboardingPermissionItem
@@ -36,7 +38,12 @@ class OnboardingPermissionsAdapter(private val permissions: List<OnboardingPermi
   RecyclerView.Adapter<OnboardingPermissionsAdapter.ViewHolder>() {
 
   class ViewHolder(val binding: LayoutOnboardingPermissionItemBinding) :
-    RecyclerView.ViewHolder(binding.root)
+    RecyclerView.ViewHolder(binding.root) {
+      val titleColor: Int = MaterialColors.getColor(binding.root, R.attr.colorOnSurface)
+      val descriptionColor: Int = MaterialColors.getColor(binding.root, R.attr.colorOnSurfaceVariant)
+      val disabledTitleColor: Int = ColorUtils.setAlphaComponent(titleColor, (255 * 0.38f).toInt())
+      val disabledDescriptionColor: Int = ColorUtils.setAlphaComponent(descriptionColor, (255 * 0.38f).toInt())
+  }
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
     return ViewHolder(
@@ -47,10 +54,23 @@ class OnboardingPermissionsAdapter(private val permissions: List<OnboardingPermi
   override fun onBindViewHolder(holder: ViewHolder, position: Int) {
     val binding = holder.binding
     val permission = permissions[position]
+    val context = binding.root.context
 
     binding.infoContent.apply {
       title.setText(permission.title)
       description.setText(permission.description)
+      title.setTextColor(if (permission.isSupportedOnDevice) holder.titleColor else holder.disabledTitleColor)
+      description.setTextColor(if (permission.isSupportedOnDevice) holder.descriptionColor else holder.disabledDescriptionColor)
+    }
+
+    binding.grantButton.apply {
+      isEnabled = permission.isSupportedOnDevice
+      text = context.getString(R.string.title_grant)
+      icon = null
+      iconTint = null
+      iconGravity = MaterialButton.ICON_GRAVITY_TEXT_START
+      iconPadding = 0
+      iconSize = 0
     }
 
     binding.grantButton.setOnClickListener {
@@ -61,9 +81,9 @@ class OnboardingPermissionsAdapter(private val permissions: List<OnboardingPermi
       binding.grantButton.apply {
         isEnabled = false
         text = ""
-        icon = ContextCompat.getDrawable(binding.root.context, R.drawable.ic_ok)
+        icon = ContextCompat.getDrawable(context, R.drawable.ic_ok)
         iconTint = ColorStateList.valueOf(
-          ContextCompat.getColor(binding.root.context, R.color.green_500))
+          ContextCompat.getColor(context, R.color.green_500))
         iconGravity = MaterialButton.ICON_GRAVITY_TEXT_TOP
         iconPadding = 0
         iconSize = SizeUtils.dp2px(28f)

--- a/app/src/main/java/com/itsaky/androidide/fragments/onboarding/PermissionsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/onboarding/PermissionsFragment.kt
@@ -114,7 +114,7 @@ class PermissionsFragment :
 		permissionsBinding?.let { b ->
 			recyclerView = b.onboardingItems
 			finishButton = b.finishInstallationButton
-            pulseAnimation = AnimationUtils.loadAnimation(requireContext(), R.anim.pulse_animation)
+			pulseAnimation = AnimationUtils.loadAnimation(requireContext(), R.anim.pulse_animation)
 
 			b.onboardingItems.adapter = createAdapter()
 
@@ -217,17 +217,19 @@ class PermissionsFragment :
 		viewModel.onPermissionsUpdated(allGranted)
 	}
 
-	private fun handlePostOverlayPermissionState() {
-		if (!awaitingOverlayGrantResult) {
-			return
-		}
-		awaitingOverlayGrantResult = false
-		if (PermissionsHelper.canDrawOverlays(requireContext())) {
-			return
-		}
-		flashError(getString(R.string.permission_overlay_restricted_settings_hint))
-		openAppInfoSettings()
-	}
+    private fun handlePostOverlayPermissionState() {
+       if (!awaitingOverlayGrantResult) {
+          return
+       }
+       awaitingOverlayGrantResult = false
+
+       if (PermissionsHelper.canDrawOverlays(requireContext())) {
+          return
+       }
+
+       flashError(getString(R.string.permission_overlay_restricted_settings_hint))
+       requestSettingsTogglePermission(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+    }
 
 	private fun startIdeSetup() {
 		val shouldProceed = viewModel.checkStorageAndNotify(requireContext())
@@ -294,13 +296,19 @@ class PermissionsFragment :
 		}
 	}
 
-	private fun requestOverlayPermission() {
-		awaitingOverlayGrantResult = requestSettingsTogglePermission(Settings.ACTION_MANAGE_OVERLAY_PERMISSION)
-	}
+    private fun requestOverlayPermission() {
+       val state = PermissionsHelper.getOverlayPermissionState(requireContext())
 
-	private fun openAppInfoSettings() {
-		requestSettingsTogglePermission(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-	}
+       when (state) {
+           PermissionsHelper.OverlayPermissionState.UNSUPPORTED -> {
+               flashError(getString(R.string.permission_overlay_unsupported_hint))
+           }
+           PermissionsHelper.OverlayPermissionState.REQUESTABLE -> {
+               awaitingOverlayGrantResult = requestSettingsTogglePermission(Settings.ACTION_MANAGE_OVERLAY_PERMISSION)
+           }
+           PermissionsHelper.OverlayPermissionState.GRANTED -> {}
+       }
+    }
 
 	private fun requestStoragePermission() {
 		if (isAtLeastR()) {

--- a/app/src/main/java/com/itsaky/androidide/models/OnboardingPermissionItem.kt
+++ b/app/src/main/java/com/itsaky/androidide/models/OnboardingPermissionItem.kt
@@ -32,5 +32,6 @@ data class OnboardingPermissionItem(
   val description: Int,
   var isGranted: Boolean,
 
-  var isOptional: Boolean = false
+  var isOptional: Boolean = false,
+  var isSupportedOnDevice: Boolean = true
 )

--- a/app/src/main/java/com/itsaky/androidide/services/debug/DebugOverlayManager.kt
+++ b/app/src/main/java/com/itsaky/androidide/services/debug/DebugOverlayManager.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.ViewConfiguration
 import android.view.WindowManager
+import android.widget.Toast
 import android.provider.Settings
 import androidx.core.content.ContextCompat
 import com.itsaky.androidide.R
@@ -16,7 +17,7 @@ import com.itsaky.androidide.actions.ActionsRegistry
 import com.itsaky.androidide.databinding.DebuggerActionsWindowBinding
 import com.itsaky.androidide.idetooltips.TooltipManager
 import com.itsaky.androidide.idetooltips.TooltipTag
-import com.itsaky.androidide.utils.flashError
+import com.itsaky.androidide.utils.PermissionsHelper
 import org.slf4j.LoggerFactory
 import kotlin.math.abs
 
@@ -111,9 +112,18 @@ class DebugOverlayManager private constructor(
             return
         }
 
-        if (!Settings.canDrawOverlays(binding.root.context)) {
+        val ctx = binding.root.context
+
+        if (!Settings.canDrawOverlays(ctx)) {
             logger.warn("Overlay permission denied. Skipping debugger overlay window.")
-            flashError(binding.root.context.getString(R.string.permission_overlay_restricted_settings_hint))
+
+            val state = PermissionsHelper.getOverlayPermissionState(ctx)
+            val message = if (state == PermissionsHelper.OverlayPermissionState.UNSUPPORTED) {
+                ctx.getString(R.string.permission_overlay_unsupported_hint)
+            } else {
+                ctx.getString(R.string.permission_overlay_restricted_settings_hint)
+            }
+            Toast.makeText(ctx, message, Toast.LENGTH_LONG).show()
             return
         }
 
@@ -139,10 +149,10 @@ class DebugOverlayManager private constructor(
         }
     }
 
-	fun refreshActions() {
-		// noinspection NotifyDataSetChanged
-		binding.actions.adapter?.notifyDataSetChanged()
-	}
+    fun refreshActions() {
+        // noinspection NotifyDataSetChanged
+        binding.actions.adapter?.notifyDataSetChanged()
+    }
 
     companion object {
 
@@ -172,8 +182,8 @@ class DebugOverlayManager private constructor(
             layout.actions.adapter = adapter
 
             return DebugOverlayManager(
-				windowManager = windowManager,
-				binding = layout,
+                windowManager = windowManager,
+                binding = layout,
             )
         }
     }

--- a/app/src/main/java/com/itsaky/androidide/utils/PermissionsHelper.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/PermissionsHelper.kt
@@ -3,6 +3,7 @@ package com.itsaky.androidide.utils
 import android.Manifest
 import android.app.ActivityManager
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Environment
@@ -11,6 +12,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import com.itsaky.androidide.R
 import com.itsaky.androidide.models.OnboardingPermissionItem
+import androidx.core.net.toUri
 
 /**
  * @author Akash Yadav
@@ -26,13 +28,27 @@ object PermissionsHelper {
     fun canDrawOverlays(context: Context): Boolean = Settings.canDrawOverlays(context)
 
     fun getOverlayPermissionState(context: Context): OverlayPermissionState {
-        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
-        val isLowRamDevice = activityManager?.isLowRamDevice ?: false
+        if (canDrawOverlays(context)) {
+            return OverlayPermissionState.GRANTED
+        }
 
-        return when {
-            canDrawOverlays(context) -> OverlayPermissionState.GRANTED
-            isLowRamDevice -> OverlayPermissionState.UNSUPPORTED
-            else -> OverlayPermissionState.REQUESTABLE
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        val isLowRamAndModernAndroid = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && activityManager?.isLowRamDevice == true
+
+        if (isLowRamAndModernAndroid) {
+            return OverlayPermissionState.UNSUPPORTED
+        }
+
+        val intent = Intent(
+            Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+            "package:${context.packageName}".toUri()
+        )
+        val canResolveIntent = intent.resolveActivity(context.packageManager) != null
+
+        return if (canResolveIntent) {
+            OverlayPermissionState.REQUESTABLE
+        } else {
+            OverlayPermissionState.UNSUPPORTED
         }
     }
 

--- a/app/src/main/java/com/itsaky/androidide/utils/PermissionsHelper.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/PermissionsHelper.kt
@@ -1,6 +1,7 @@
 package com.itsaky.androidide.utils
 
 import android.Manifest
+import android.app.ActivityManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
@@ -16,8 +17,29 @@ import com.itsaky.androidide.models.OnboardingPermissionItem
  */
 object PermissionsHelper {
 
+	enum class OverlayPermissionState {
+		GRANTED,
+		REQUESTABLE,
+		UNSUPPORTED,
+	}
+
+    fun canDrawOverlays(context: Context): Boolean = Settings.canDrawOverlays(context)
+
+    fun getOverlayPermissionState(context: Context): OverlayPermissionState {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        val isLowRamDevice = activityManager?.isLowRamDevice ?: false
+
+        return when {
+            canDrawOverlays(context) -> OverlayPermissionState.GRANTED
+            isLowRamDevice -> OverlayPermissionState.UNSUPPORTED
+            else -> OverlayPermissionState.REQUESTABLE
+        }
+    }
+
 	fun getRequiredPermissions(context: Context): List<OnboardingPermissionItem> {
 		val permissions = mutableListOf<OnboardingPermissionItem>()
+		val overlayState = getOverlayPermissionState(context)
+		val isOverlaySupported = overlayState != OverlayPermissionState.UNSUPPORTED
 
 		if (isAtLeastT()) {
 			permissions.add(
@@ -52,9 +74,11 @@ object PermissionsHelper {
 			OnboardingPermissionItem(
 				Manifest.permission.SYSTEM_ALERT_WINDOW,
 				R.string.permission_title_overlay_window,
-				R.string.permission_desc_overlay_window,
-				canDrawOverlays(context),
-			),
+				if (isOverlaySupported) R.string.permission_desc_overlay_window else R.string.permission_overlay_unsupported_hint,
+				overlayState == OverlayPermissionState.GRANTED,
+				isOptional = !isOverlaySupported,
+				isSupportedOnDevice = isOverlaySupported
+			)
 		)
 
 		return permissions
@@ -65,13 +89,8 @@ object PermissionsHelper {
 	fun canPostNotifications(context: Context) =
 		isPermissionGranted(context, Manifest.permission.POST_NOTIFICATIONS)
 
-
-	fun canDrawOverlays(context: Context): Boolean = Settings.canDrawOverlays(context)
-
-
 	fun areAllPermissionsGranted(context: Context): Boolean =
 		getRequiredPermissions(context).all { it.isOptional || it.isGranted }
-
 
 	fun isStoragePermissionGranted(context: Context): Boolean {
 		if (isAtLeastR()) {
@@ -87,10 +106,8 @@ object PermissionsHelper {
 		)
 	}
 
-
 	fun canRequestPackageInstalls(context: Context): Boolean =
 		context.packageManager.canRequestPackageInstalls()
-
 
 	fun isPermissionGranted(
 		context: Context,
@@ -101,7 +118,6 @@ object PermissionsHelper {
 		Manifest.permission.SYSTEM_ALERT_WINDOW -> canDrawOverlays(context)
 		else -> checkSelfPermission(context, permission)
 	}
-
 
 	fun checkSelfPermission(
 		context: Context,

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -717,6 +717,7 @@
 	<string name="permission_desc_install_packages">Allow Code on the Go to install the apps that you build on this device.</string>
 	<string name="permission_title_overlay_window">Floating debugger</string>
 	<string name="permission_desc_overlay_window">Allow Code on the Go to display floating debugger controls to inspect your code while it runs.</string>
+	<string name="permission_overlay_unsupported_hint">Floating debugger is not available on this device.</string>
 	<string name="permission_overlay_restricted_settings_hint">If you can\'t enable this permission, display App info for Code on the Go, tap the three-dot menu, and enable restricted settings.</string>
 	<string name="permission_title_notifications">Notifications</string>
 	<string name="permission_desc_notifications">Allow Code on the Go to display notifications.</string>


### PR DESCRIPTION
## Description

This PR introduces an `OverlayPermissionState` check to gracefully handle devices (such as Android Go or low-RAM devices) that do not support the `SYSTEM_ALERT_WINDOW` permission. It prevents users from getting stuck in an infinite onboarding loop by marking the permission as optional when unsupported, dynamically disabling the corresponding UI elements, and displaying informative hints instead of errors.

## Details

* **Logic**: Uses `ActivityManager.isLowRamDevice` as the official heuristic to determine if overlays are unsupported. Introduced `OverlayPermissionState` (`GRANTED`, `REQUESTABLE`, `UNSUPPORTED`) to cleanly map out scenarios.
* **UI**: `OnboardingPermissionsAdapter` now dynamically applies a 38% alpha color state to gray out the permission title, description, and grant button if unsupported. 
* **Error Handling**: Added graceful fallback toasts and alerts in `DebugAction` and `DebugOverlayManager` when attempting to open the debugger on restricted devices.

### 32 Bits device test

https://github.com/user-attachments/assets/0a71d20e-a8d5-48aa-b84d-c57f5bb2fd01

https://github.com/user-attachments/assets/b187996d-09bd-4ff9-a876-231337cac6f9


### 64 Bits device test

https://github.com/user-attachments/assets/ee35ac5b-153a-44e4-9f46-0a7b77eecb52


## Ticket

[ADFA-3489](https://appdevforall.atlassian.net/browse/ADFA-3489)

## Observation

`SYSTEM_ALERT_WINDOW` is now evaluated dynamically. If it is disabled due to hardware restrictions, it correctly bypasses the `areAllPermissionsGranted` block, allowing users to proceed to the IDE seamlessly. Ensure any future overlay features also verify `PermissionsHelper.getOverlayPermissionState` before executing.

[ADFA-3489]: https://appdevforall.atlassian.net/browse/ADFA-3489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ