### PR TITLE
ADFA-1639 Rename .androidide/ to .cg/ in multiple locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ sentry.properties
 
 # Generated files for tooling API
 tests/test-home
-/tests/**/.androidide/init/model.jar
+/tests/**/.cg/init/model.jar
 
 /composite-builds/build-deps-common/constants/build/
 /composite-builds/build-deps/build/

--- a/common/src/main/java/com/itsaky/androidide/utils/Environment.java
+++ b/common/src/main/java/com/itsaky/androidide/utils/Environment.java
@@ -127,7 +127,10 @@ public final class Environment {
 	}
 
 	public static File getProjectCacheDir(File projectDir) {
-		return new File(projectDir, ANDROIDIDE_PROJECT_CACHE_DIR);
+		File current = new File(projectDir, ANDROIDIDE_PROJECT_CACHE_DIR);
+		File legacy = new File(projectDir, SharedEnvironment.LEGACY_PROJECT_CACHE_DIR_NAME);
+		LegacyIdeDataDirKt.migrateLegacyIdeDataDirIfNeeded(legacy, current);
+		return current;
 	}
 
 	public static void init(Context context) {
@@ -142,7 +145,10 @@ public final class Environment {
 		ROOT = mkdirIfNotExists(new File(DEFAULT_ROOT));
 		PREFIX = mkdirIfNotExists(new File(ROOT, "usr"));
 		HOME = mkdirIfNotExists(new File(ROOT, "home"));
-		ANDROIDIDE_HOME = mkdirIfNotExists(new File(HOME, ".androidide"));
+		File ideHomeCandidate = new File(HOME, SharedEnvironment.PROJECT_CACHE_DIR_NAME);
+		File legacyIdeHome = new File(HOME, SharedEnvironment.LEGACY_PROJECT_CACHE_DIR_NAME);
+		LegacyIdeDataDirKt.migrateLegacyIdeDataDirIfNeeded(legacyIdeHome, ideHomeCandidate);
+		ANDROIDIDE_HOME = mkdirIfNotExists(ideHomeCandidate);
 		TMP_DIR = mkdirIfNotExists(new File(PREFIX, "tmp"));
 		BIN_DIR = mkdirIfNotExists(new File(PREFIX, "bin"));
 		OPT_DIR = mkdirIfNotExists(new File(PREFIX, "opt"));

--- a/common/src/main/java/com/itsaky/androidide/utils/Environment.java
+++ b/common/src/main/java/com/itsaky/androidide/utils/Environment.java
@@ -129,7 +129,7 @@ public final class Environment {
 	public static File getProjectCacheDir(File projectDir) {
 		File current = new File(projectDir, ANDROIDIDE_PROJECT_CACHE_DIR);
 		File legacy = new File(projectDir, SharedEnvironment.LEGACY_PROJECT_CACHE_DIR_NAME);
-		LegacyIdeDataDirKt.migrateLegacyIdeDataDirIfNeeded(legacy, current);
+		LegacyIdeDataDirMigration.migrateLegacyIdeDataDirIfNeeded(legacy, current);
 		return current;
 	}
 
@@ -147,7 +147,7 @@ public final class Environment {
 		HOME = mkdirIfNotExists(new File(ROOT, "home"));
 		File ideHomeCandidate = new File(HOME, SharedEnvironment.PROJECT_CACHE_DIR_NAME);
 		File legacyIdeHome = new File(HOME, SharedEnvironment.LEGACY_PROJECT_CACHE_DIR_NAME);
-		LegacyIdeDataDirKt.migrateLegacyIdeDataDirIfNeeded(legacyIdeHome, ideHomeCandidate);
+		LegacyIdeDataDirMigration.migrateLegacyIdeDataDirIfNeeded(legacyIdeHome, ideHomeCandidate);
 		ANDROIDIDE_HOME = mkdirIfNotExists(ideHomeCandidate);
 		TMP_DIR = mkdirIfNotExists(new File(PREFIX, "tmp"));
 		BIN_DIR = mkdirIfNotExists(new File(PREFIX, "bin"));

--- a/common/src/main/java/com/itsaky/androidide/utils/Environment.java
+++ b/common/src/main/java/com/itsaky/androidide/utils/Environment.java
@@ -129,8 +129,7 @@ public final class Environment {
 	public static File getProjectCacheDir(File projectDir) {
 		File current = new File(projectDir, ANDROIDIDE_PROJECT_CACHE_DIR);
 		File legacy = new File(projectDir, SharedEnvironment.LEGACY_PROJECT_CACHE_DIR_NAME);
-		LegacyIdeDataDirMigration.migrateLegacyIdeDataDirIfNeeded(legacy, current);
-		return current;
+		return LegacyIdeDataDirMigration.migrateLegacyIdeDataDirIfNeeded(legacy, current);
 	}
 
 	public static void init(Context context) {
@@ -147,8 +146,9 @@ public final class Environment {
 		HOME = mkdirIfNotExists(new File(ROOT, "home"));
 		File ideHomeCandidate = new File(HOME, SharedEnvironment.PROJECT_CACHE_DIR_NAME);
 		File legacyIdeHome = new File(HOME, SharedEnvironment.LEGACY_PROJECT_CACHE_DIR_NAME);
-		LegacyIdeDataDirMigration.migrateLegacyIdeDataDirIfNeeded(legacyIdeHome, ideHomeCandidate);
-		ANDROIDIDE_HOME = mkdirIfNotExists(ideHomeCandidate);
+		File ideHomeResolved =
+				LegacyIdeDataDirMigration.migrateLegacyIdeDataDirIfNeeded(legacyIdeHome, ideHomeCandidate);
+		ANDROIDIDE_HOME = mkdirIfNotExists(ideHomeResolved);
 		TMP_DIR = mkdirIfNotExists(new File(PREFIX, "tmp"));
 		BIN_DIR = mkdirIfNotExists(new File(PREFIX, "bin"));
 		OPT_DIR = mkdirIfNotExists(new File(PREFIX, "opt"));

--- a/common/src/main/java/com/itsaky/androidide/utils/LegacyIdeDataDirMigration.java
+++ b/common/src/main/java/com/itsaky/androidide/utils/LegacyIdeDataDirMigration.java
@@ -1,0 +1,52 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.itsaky.androidide.utils;
+
+import java.io.File;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * One-time rename of the fork-era {@code .androidide} directory to {@link
+ * SharedEnvironment#PROJECT_CACHE_DIR_NAME}.
+ */
+public final class LegacyIdeDataDirMigration {
+
+	private static final Logger LOG = LoggerFactory.getLogger(LegacyIdeDataDirMigration.class);
+
+	private LegacyIdeDataDirMigration() {}
+
+	/**
+	 * If {@code current} does not exist but {@code legacy} does, renames {@code legacy} to {@code
+	 * current}. If both exist, logs a warning and leaves {@code current} as the source of truth.
+	 */
+	public static void migrateLegacyIdeDataDirIfNeeded(File legacy, File current) {
+		if (current.exists()) {
+			if (legacy.exists()) {
+				LOG.warn(
+						"Both {} and {} exist; using {} only",
+						legacy.getAbsolutePath(),
+						current.getAbsolutePath(),
+						current.getAbsolutePath());
+			}
+			return;
+		}
+		if (legacy.exists() && !legacy.renameTo(current)) {
+			LOG.warn("Failed to rename legacy IDE data dir {} to {}", legacy, current);
+		}
+	}
+}

--- a/common/src/main/java/com/itsaky/androidide/utils/LegacyIdeDataDirMigration.java
+++ b/common/src/main/java/com/itsaky/androidide/utils/LegacyIdeDataDirMigration.java
@@ -38,14 +38,12 @@ public final class LegacyIdeDataDirMigration {
 	 * current} for the caller to create.
 	 */
 	public static File migrateLegacyIdeDataDirIfNeeded(File legacy, File current) {
-		if (current.exists()) {
-			if (legacy.exists()) {
-				LOG.warn(
-						"Both {} and {} exist; using {} only",
-						legacy.getAbsolutePath(),
-						current.getAbsolutePath(),
-						current.getAbsolutePath());
-			}
+		if (current.exists() && legacy.exists()) {
+			LOG.warn(
+				"Both {} and {} exist; using {} only",
+				legacy.getAbsolutePath(),
+				current.getAbsolutePath(),
+				current.getAbsolutePath());
 			return current;
 		}
 		if (legacy.exists()) {

--- a/common/src/main/java/com/itsaky/androidide/utils/LegacyIdeDataDirMigration.java
+++ b/common/src/main/java/com/itsaky/androidide/utils/LegacyIdeDataDirMigration.java
@@ -31,10 +31,13 @@ public final class LegacyIdeDataDirMigration {
 	private LegacyIdeDataDirMigration() {}
 
 	/**
-	 * If {@code current} does not exist but {@code legacy} does, renames {@code legacy} to {@code
-	 * current}. If both exist, logs a warning and leaves {@code current} as the source of truth.
+	 * Resolves which IDE data directory path is in use: prefers {@code current} after a successful
+	 * rename from {@code legacy}. If {@code current} already exists, it wins (both-existing case is
+	 * logged). If only {@code legacy} exists and {@code legacy.renameTo(current)} fails, returns
+	 * {@code legacy} so callers keep using the existing tree. If neither exists, returns {@code
+	 * current} for the caller to create.
 	 */
-	public static void migrateLegacyIdeDataDirIfNeeded(File legacy, File current) {
+	public static File migrateLegacyIdeDataDirIfNeeded(File legacy, File current) {
 		if (current.exists()) {
 			if (legacy.exists()) {
 				LOG.warn(
@@ -43,10 +46,15 @@ public final class LegacyIdeDataDirMigration {
 						current.getAbsolutePath(),
 						current.getAbsolutePath());
 			}
-			return;
+			return current;
 		}
-		if (legacy.exists() && !legacy.renameTo(current)) {
+		if (legacy.exists()) {
+			if (legacy.renameTo(current)) {
+				return current;
+			}
 			LOG.warn("Failed to rename legacy IDE data dir {} to {}", legacy, current);
+			return legacy;
 		}
+		return current;
 	}
 }

--- a/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
+++ b/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
@@ -34,9 +34,12 @@ const val ANDROID_SDK_ZIP = "android-sdk.zip"
 const val GRADLE_DISTRIBUTION_NAME = "gradle-$GRADLE_DISTRIBUTION_VERSION"
 const val GRADLE_DISTRIBUTION_ARCHIVE_NAME = "$GRADLE_DISTRIBUTION_NAME-bin.zip"
 
-// .androidide folder
+// App-internal IDE data under files/home/ (matches SharedEnvironment.PROJECT_CACHE_DIR_NAME)
 @Suppress("SdCardPath")
-const val ANDROIDIDE_HOME = "/data/data/com.itsaky.androidide/files/home/.androidide"
+const val IDE_DATA_DIR_NAME = ".cg"
+
+@Suppress("SdCardPath")
+const val ANDROIDIDE_HOME = "/data/data/com.itsaky.androidide/files/home/$IDE_DATA_DIR_NAME"
 
 // Code On the Go gradle plugin
 const val COGO_GRADLE_PLUGIN_NAME = "cogo-plugin"

--- a/gradle-plugin/src/test/java/com/itsaky/androidide/gradle/utils.kt
+++ b/gradle-plugin/src/test/java/com/itsaky/androidide/gradle/utils.kt
@@ -19,6 +19,7 @@ package com.itsaky.androidide.gradle
 
 import com.itsaky.androidide.buildinfo.BuildInfo
 import com.itsaky.androidide.utils.FileProvider
+import com.itsaky.androidide.utils.SharedEnvironment
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
@@ -35,7 +36,8 @@ internal fun buildProject(
   vararg plugins: String
 ): BuildResult {
   val projectRoot = openProject(agpVersion, useApplyPluginGroovySyntax, *plugins)
-  val initScript = FileProvider.testHomeDir().resolve(".androidide/init/androidide.init.gradle")
+  val initScript = FileProvider.testHomeDir()
+    .resolve("${SharedEnvironment.PROJECT_CACHE_DIR_NAME}/init/androidide.init.gradle")
   val mavenLocal = FileProvider.projectRoot().resolve("gradle-plugin/build/maven-local/repos.txt").toFile()
 
   if (!(mavenLocal.exists() && mavenLocal.isFile)) {

--- a/layouteditor/.gitignore
+++ b/layouteditor/.gitignore
@@ -85,4 +85,4 @@ lint/tmp/
 # lint/reports/
 
 
-.androidide/
+.cg/

--- a/resources/src/main/res/values-ar-rSA/strings.xml
+++ b/resources/src/main/res/values-ar-rSA/strings.xml
@@ -282,7 +282,7 @@
   <string name="xml_formatting_options">خيارات تنسيق XML</string>
   <string name="xml_formatting_options_summary">تهيئة تنسيق XML</string>
   <string name="idepref_customFont_title">استخدام خط مخصص</string>
-  <string name="idepref_customFont_summary">في حالة التمكين، سيتم استخدام الملف الموجود على \"/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" كخط محرر.</string>
+  <string name="idepref_customFont_summary">في حالة التمكين، سيتم استخدام الملف الموجود على \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" كخط محرر.</string>
   <string name="msg_installing_apk">تثبيت APK...</string>
   <string name="msg_action_open_application">هل تريد فتح التطبيق؟</string>
   <string name="title_gradle_service_notification_channel">خدمة بناء Code on the Go</string>
@@ -399,7 +399,7 @@
   <string name="idepref_devOptions_summary">خيارات تجريبية/تصحيح أخطاء Code on the Go</string>
   <string name="idepref_group_debugging">تصحيح الأخطاء</string>
   <string name="idepref_devOptions_dumpLogs_title">تفريغ السجلات</string>
-  <string name="idepref_devOptions_dumpLogs_summary">تفريغ سجلات Code on the Go إلى $HOME/.androidide/logs</string>
+  <string name="idepref_devOptions_dumpLogs_summary">تفريغ سجلات Code on the Go إلى $HOME/.cg/logs</string>
   <string name="msg_emptyview_applogs">قم بتشغيل النسخة التصحيحية (debug) من تطبيقك لعرض السجلات هنا.</string>
   <string name="msg_logsender_disabled">تم تعطيل إرسال السجل. يمكنك تمكينه في الخيارات.</string>
   <string name="msg_emptyview_idelogs">تظهر سجلات من بيئة التطوير المتكاملة هنا.</string>

--- a/resources/src/main/res/values-bn-rIN/strings.xml
+++ b/resources/src/main/res/values-bn-rIN/strings.xml
@@ -282,7 +282,7 @@
   <string name="xml_formatting_options">XML ফর্ম্যাটিং অপশনগুলি</string>
   <string name="xml_formatting_options_summary">XML ফর্ম্যাটার কনফিগার করুন</string>
   <string name="idepref_customFont_title">কাস্টম ফন্ট ব্যবহার করুন</string>
-  <string name="idepref_customFont_summary">সক্রিয় থাকলে, \"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" ফাইলটিকে এডিটর-এর ফন্ট হিসেবে ব্যবহার করা হবে।</string>
+  <string name="idepref_customFont_summary">সক্রিয় থাকলে, \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" ফাইলটিকে এডিটর-এর ফন্ট হিসেবে ব্যবহার করা হবে।</string>
   <string name="msg_installing_apk">APK ইনস্টল করা হচ্ছে...</string>
   <string name="msg_action_open_application">তুমি কি অ্যাপ্লিকেশনটি খুলতে চাও?</string>
   <string name="title_gradle_service_notification_channel">Code on the Go Gradle build পরিষেবা</string>
@@ -399,7 +399,7 @@
   <string name="idepref_devOptions_summary">Code on the Go-এর জন্য পরীক্ষামূলক/ডিবাগিং অপশনগুলি</string>
   <string name="idepref_group_debugging">ডিবাগিং</string>
   <string name="idepref_devOptions_dumpLogs_title">ডাম্প লগ</string>
-  <string name="idepref_devOptions_dumpLogs_summary">Code on the Go লগ ডাম্প করুন $HOME/.androidide/logs এ</string>
+  <string name="idepref_devOptions_dumpLogs_summary">Code on the Go লগ ডাম্প করুন $HOME/.cg/logs এ</string>
   <string name="msg_emptyview_applogs">এখানে লগগুলি দেখার জন্য আপনার অ্যাপ্লিকেশনটির ডিবাগ ভ্যারিয়েন্ট টি রান করুন৷</string>
   <string name="msg_logsender_disabled">LogSender নিষ্ক্রিয় করা হয়েছে। আপনি Preferences-এ গিয়ে এটিকে সক্রিয় করতে পারেন।</string>
   <string name="msg_emptyview_idelogs">IDE লগস্ এখানে দেখানো হয়.</string>

--- a/resources/src/main/res/values-de-rDE/strings.xml
+++ b/resources/src/main/res/values-de-rDE/strings.xml
@@ -281,7 +281,7 @@
   <string name="xml_formatting_options">XML-Formatierungsoptionen</string>
   <string name="xml_formatting_options_summary">XML-Formatierer konfigurieren</string>
   <string name="idepref_customFont_title">Eigene Schriftart verwenden</string>
-  <string name="idepref_customFont_summary">Wenn aktiviert, wird die Datei unter \"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" als Editor Schriftart verwendet.</string>
+  <string name="idepref_customFont_summary">Wenn aktiviert, wird die Datei unter \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" als Editor Schriftart verwendet.</string>
   <string name="msg_installing_apk">Installiere APK...</string>
   <string name="msg_action_open_application">Möchtest du die Applikation öffnen?</string>
   <string name="title_gradle_service_notification_channel">Code on the Go Gradle-Build-Service</string>
@@ -398,7 +398,7 @@
   <string name="idepref_devOptions_summary">Experimentelle/Debugging Optionen für Code on the Go</string>
   <string name="idepref_group_debugging">Debugging</string>
   <string name="idepref_devOptions_dumpLogs_title">Protokolle ausgeben</string>
-  <string name="idepref_devOptions_dumpLogs_summary">Code on the Go-Logs in $HOME/.androidide/logs ausgeben</string>
+  <string name="idepref_devOptions_dumpLogs_summary">Code on the Go-Logs in $HOME/.cg/logs ausgeben</string>
   <string name="msg_emptyview_applogs">Run the debug variant of your application to view its logs here.</string>
   <string name="msg_logsender_disabled">LogSender is disabled. You can enable it in preferences.</string>
   <string name="msg_emptyview_idelogs">Protokolle der IDE werden hier angezeigt.</string>

--- a/resources/src/main/res/values-es-rES/strings.xml
+++ b/resources/src/main/res/values-es-rES/strings.xml
@@ -282,7 +282,7 @@
   <string name="xml_formatting_options">Opciones de formato XML</string>
   <string name="xml_formatting_options_summary">Configura el formato XML</string>
   <string name="idepref_customFont_title">Añadir fuente personalizada</string>
-  <string name="idepref_customFont_summary">Si está habilitado, el archivo en\"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" se utilizará como fuente del editor.</string>
+  <string name="idepref_customFont_summary">Si está habilitado, el archivo en\"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" se utilizará como fuente del editor.</string>
   <string name="msg_installing_apk">Instalando APK...</string>
   <string name="msg_action_open_application">¿Quieres abrir la aplicación?</string>
   <string name="title_gradle_service_notification_channel">Servicio de compilación de Gradle de Code on the Go</string>
@@ -399,7 +399,7 @@
   <string name="idepref_devOptions_summary">Experimental/debugging options for Code on the Go</string>
   <string name="idepref_group_debugging">Debugging</string>
   <string name="idepref_devOptions_dumpLogs_title">Dump logs</string>
-  <string name="idepref_devOptions_dumpLogs_summary">Dump Code on the Go logs to $HOME/.androidide/logs</string>
+  <string name="idepref_devOptions_dumpLogs_summary">Dump Code on the Go logs to $HOME/.cg/logs</string>
   <string name="msg_emptyview_applogs">Run the debug variant of your application to view its logs here.</string>
   <string name="msg_logsender_disabled">LogSender is disabled. You can enable it in preferences.</string>
   <string name="msg_emptyview_idelogs">Logs from the IDE are shown here.</string>

--- a/resources/src/main/res/values-fr-rFR/strings.xml
+++ b/resources/src/main/res/values-fr-rFR/strings.xml
@@ -283,7 +283,7 @@ Dernier projet ouvert : \n%s</string>
   <string name="xml_formatting_options">XML formatting options</string>
   <string name="xml_formatting_options_summary">Configurer le formateur XML</string>
   <string name="idepref_customFont_title">Use custom font</string>
-  <string name="idepref_customFont_summary">Si activé le font : \"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" sera utilisé comme font d\'éditeur par défaut.</string>
+  <string name="idepref_customFont_summary">Si activé le font : \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" sera utilisé comme font d\'éditeur par défaut.</string>
   <string name="msg_installing_apk">Installation de l\'application...</string>
   <string name="msg_action_open_application">Voulez-vous ouvrir l\'application ?</string>
   <string name="title_gradle_service_notification_channel">Gradle Build Service d\'Code on the Go</string>
@@ -400,7 +400,7 @@ Dernier projet ouvert : \n%s</string>
   <string name="idepref_devOptions_summary">Options Expérimental/Débogage d\'Code on the Go</string>
   <string name="idepref_group_debugging">Débogage</string>
   <string name="idepref_devOptions_dumpLogs_title">Vider les logs</string>
-  <string name="idepref_devOptions_dumpLogs_summary">Dump Code on the Go logs to $HOME/.androidide/logs</string>
+  <string name="idepref_devOptions_dumpLogs_summary">Dump Code on the Go logs to $HOME/.cg/logs</string>
   <string name="msg_emptyview_applogs">Run the debug variant of your application to view its logs here.</string>
   <string name="msg_logsender_disabled">LogSender is disabled. You can enable it in preferences.</string>
   <string name="msg_emptyview_idelogs">Logs from the IDE are shown here.</string>

--- a/resources/src/main/res/values-hi-rIN/strings.xml
+++ b/resources/src/main/res/values-hi-rIN/strings.xml
@@ -281,7 +281,7 @@
   <string name="xml_formatting_options">XML फोर्मटिंग विकल्प</string>
   <string name="xml_formatting_options_summary">XML फॉर्मेटर को कॉन्फ़िगर करें |</string>
   <string name="idepref_customFont_title">कस्टम फ़ॉन्ट का प्रयोग करें</string>
-  <string name="idepref_customFont_summary">सक्षम होने पर, \"/data/data/com.itsaky.android/files/home/.androidide/ui/font.ttf\" पर मौजूद फ़ाइल का उपयोग एडिटर फ़ॉन्ट के रूप में किया जाएगा।</string>
+  <string name="idepref_customFont_summary">सक्षम होने पर, \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" पर मौजूद फ़ाइल का उपयोग एडिटर फ़ॉन्ट के रूप में किया जाएगा।</string>
   <string name="msg_installing_apk">APK इंस्टॉल हो रहा है...</string>
   <string name="msg_action_open_application">क्या आप एप्लिकेशन खोलना चाहते हैं?</string>
   <string name="title_gradle_service_notification_channel">Code on the Go ग्रेडल बिल्ड सर्विस</string>
@@ -398,7 +398,7 @@
   <string name="idepref_devOptions_summary">Code on the Go के लिए प्रायोगिक/डिबगिंग विकल्प</string>
   <string name="idepref_group_debugging">डिबगिंग</string>
   <string name="idepref_devOptions_dumpLogs_title">लॉग डंप करें</string>
-  <string name="idepref_devOptions_dumpLogs_summary">Code on the Go लॉग को $HOME/.androidide/logs डायरेक्टरी में डंप करें</string>
+  <string name="idepref_devOptions_dumpLogs_summary">Code on the Go लॉग को $HOME/.cg/logs डायरेक्टरी में डंप करें</string>
   <string name="msg_emptyview_applogs">अपने एप्लिकेशन के लॉग यहां देखने के लिए उसका डिबग संस्करण चलाएँ।</string>
   <string name="msg_logsender_disabled">लॉगसेंडर अक्षम है. आप इसे प्रेफरेन्सेस में सक्षम कर सकते हैं.</string>
   <string name="msg_emptyview_idelogs">आईडीई के लॉग यहां दिखाए जाते हैं।</string>

--- a/resources/src/main/res/values-in-rID/strings.xml
+++ b/resources/src/main/res/values-in-rID/strings.xml
@@ -282,7 +282,7 @@
   <string name="xml_formatting_options">Opsi pemformatan XML</string>
   <string name="xml_formatting_options_summary">Konfigurasikan pemformatan XML</string>
   <string name="idepref_customFont_title">Gunakan custom font</string>
-  <string name="idepref_customFont_summary">Jika diaktifkan, file di \"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" akan digunakan sebagai font Editor.</string>
+  <string name="idepref_customFont_summary">Jika diaktifkan, file di \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" akan digunakan sebagai font Editor.</string>
   <string name="msg_installing_apk">Menginstal APK...</string>
   <string name="msg_action_open_application">Apakah Anda ingin membuka aplikasi?</string>
   <string name="title_gradle_service_notification_channel">Layanan Build Gradle Code on the Go</string>
@@ -399,7 +399,7 @@
   <string name="idepref_devOptions_summary">Opsi eksperimental/debug untuk Code on the Go</string>
   <string name="idepref_group_debugging">Men-debug</string>
   <string name="idepref_devOptions_dumpLogs_title">Dump log</string>
-  <string name="idepref_devOptions_dumpLogs_summary">Dump log Code on the Go ke $HOME/.androidide/logs</string>
+  <string name="idepref_devOptions_dumpLogs_summary">Dump log Code on the Go ke $HOME/.cg/logs</string>
   <string name="msg_emptyview_applogs">Jalankan varian debug aplikasi Anda untuk melihat lognya di sini.</string>
   <string name="msg_logsender_disabled">LogSender dinonaktifkan. Anda dapat mengaktifkannya di preferensi.</string>
   <string name="msg_emptyview_idelogs">Log dari IDE ditampilkan di sini.</string>

--- a/resources/src/main/res/values-pt-rBR/strings.xml
+++ b/resources/src/main/res/values-pt-rBR/strings.xml
@@ -282,7 +282,7 @@
   <string name="xml_formatting_options">Opções de formatação XML</string>
   <string name="xml_formatting_options_summary">Configurar o formatador de XML</string>
   <string name="idepref_customFont_title">Usar fonte personalizada</string>
-  <string name="idepref_customFont_summary">Se ativado, o arquivo em \"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" será usado como fonte do Editor.</string>
+  <string name="idepref_customFont_summary">Se ativado, o arquivo em \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" será usado como fonte do Editor.</string>
   <string name="msg_installing_apk">Instalando APK...</string>
   <string name="msg_action_open_application">Deseja abrir o aplicativo?</string>
   <string name="title_gradle_service_notification_channel">Serviço de compilação Gradle do Code on the Go</string>
@@ -399,7 +399,7 @@
   <string name="idepref_devOptions_summary">Opções experimentais/de depuração para Code on the Go</string>
   <string name="idepref_group_debugging">Depuração</string>
   <string name="idepref_devOptions_dumpLogs_title">Despejar registros</string>
-  <string name="idepref_devOptions_dumpLogs_summary">Despejar registros do Code on the Go para $HOME/.androidide/logs</string>
+  <string name="idepref_devOptions_dumpLogs_summary">Despejar registros do Code on the Go para $HOME/.cg/logs</string>
   <string name="msg_emptyview_applogs">Execute a variante de depuração do seu aplicativo para ver os logs aqui.</string>
   <string name="msg_logsender_disabled">LogSender está desativado. Você pode ativá-lo nas configurações.</string>
   <string name="msg_emptyview_idelogs">Os logs da IDE são exibidos aqui.</string>

--- a/resources/src/main/res/values-ro-rRO/strings.xml
+++ b/resources/src/main/res/values-ro-rRO/strings.xml
@@ -282,7 +282,7 @@
   <string name="xml_formatting_options">XML opțiune de formatares</string>
   <string name="xml_formatting_options_summary">Configurarea formatterului XML</string>
   <string name="idepref_customFont_title">Folosește fontul particularizat</string>
-  <string name="idepref_customFont_summary">Dacă este activat, fișierul din \"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" va fi folosit ca font în Editor.</string>
+  <string name="idepref_customFont_summary">Dacă este activat, fișierul din \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" va fi folosit ca font în Editor.</string>
   <string name="msg_installing_apk">Instalez APK…</string>
   <string name="msg_action_open_application">Doriți să deschideți aplicația?</string>
   <string name="title_gradle_service_notification_channel">Code on the Go Gradle build service</string>
@@ -399,7 +399,7 @@
   <string name="idepref_devOptions_summary">Experimental/debugging options for Code on the Go</string>
   <string name="idepref_group_debugging">Debugging</string>
   <string name="idepref_devOptions_dumpLogs_title">Dump logs</string>
-  <string name="idepref_devOptions_dumpLogs_summary">Dump Code on the Go logs to $HOME/.androidide/logs</string>
+  <string name="idepref_devOptions_dumpLogs_summary">Dump Code on the Go logs to $HOME/.cg/logs</string>
   <string name="msg_emptyview_applogs">Run the debug variant of your application to view its logs here.</string>
   <string name="msg_logsender_disabled">LogSender is disabled. You can enable it in preferences.</string>
   <string name="msg_emptyview_idelogs">Logs from the IDE are shown here.</string>

--- a/resources/src/main/res/values-ru-rRU/strings.xml
+++ b/resources/src/main/res/values-ru-rRU/strings.xml
@@ -281,7 +281,7 @@
   <string name="xml_formatting_options">Настройки форматирования XML</string>
   <string name="xml_formatting_options_summary">Настройте форматтер XML</string>
   <string name="idepref_customFont_title">Использовать сторонний шрифт</string>
-  <string name="idepref_customFont_summary">Если активно, файл \"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" будет использован в качестве шрифта редактора.</string>
+  <string name="idepref_customFont_summary">Если активно, файл \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" будет использован в качестве шрифта редактора.</string>
   <string name="msg_installing_apk">Установка APK...</string>
   <string name="msg_action_open_application">Хотите открыть установленное приложение?</string>
   <string name="title_gradle_service_notification_channel">Служба сборки Code on the Go Gradle</string>
@@ -401,7 +401,7 @@
   <string name="idepref_devOptions_summary">Экспериментальные/отладочные опции для Code on the Go</string>
   <string name="idepref_group_debugging">Отладка</string>
   <string name="idepref_devOptions_dumpLogs_title">Дамп логов</string>
-  <string name="idepref_devOptions_dumpLogs_summary">Дамп логов Code on the Go в $HOME/.androidide/logs</string>
+  <string name="idepref_devOptions_dumpLogs_summary">Дамп логов Code on the Go в $HOME/.cg/logs</string>
   <string name="msg_emptyview_applogs">Запустите отладочный вариант вашего приложения, чтобы увидеть его логи здесь.</string>
   <string name="msg_logsender_disabled">LogSender отключен. Вы можете включить его в настройках.</string>
   <string name="msg_emptyview_idelogs">Логи IDE отображаются здесь.</string>

--- a/resources/src/main/res/values-tr-rTR/strings.xml
+++ b/resources/src/main/res/values-tr-rTR/strings.xml
@@ -282,7 +282,7 @@
   <string name="xml_formatting_options">XML biçimlendirme seçenekleri</string>
   <string name="xml_formatting_options_summary">XML biçimlendiriciyi yapılandır</string>
   <string name="idepref_customFont_title">Kişisel yazı tipi kullan</string>
-  <string name="idepref_customFont_summary">Eğer etkinleştirilmişse \"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" konumundaki dosya Düzenleyici yazı tipi olarak kullanılacak.</string>
+  <string name="idepref_customFont_summary">Eğer etkinleştirilmişse \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" konumundaki dosya Düzenleyici yazı tipi olarak kullanılacak.</string>
   <string name="msg_installing_apk">APK kuruluyor...</string>
   <string name="msg_action_open_application">Uygulamayı açmak ister misiniz?</string>
   <string name="title_gradle_service_notification_channel">Code on the Go Gradle inşa servisi</string>
@@ -399,7 +399,7 @@
   <string name="idepref_devOptions_summary">Code on the Go için deneysel/hata ayıklama seçenekleri</string>
   <string name="idepref_group_debugging">Hata ayıklama</string>
   <string name="idepref_devOptions_dumpLogs_title">Günlükleri kaydet</string>
-  <string name="idepref_devOptions_dumpLogs_summary">$HOME/.androidide/logs içine Code on the Go günlüklerini kaydet</string>
+  <string name="idepref_devOptions_dumpLogs_summary">$HOME/.cg/logs içine Code on the Go günlüklerini kaydet</string>
   <string name="msg_emptyview_applogs">Uygulamanızın günlüklerini burada görüntülemek için debug varyantını çalıştırın.</string>
   <string name="msg_logsender_disabled">LogSender devre dışı. Ayarlardan etkinleştirebilirsiniz.</string>
   <string name="msg_emptyview_idelogs">IDE\'den günlükler burada görünür.</string>

--- a/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/resources/src/main/res/values-zh-rCN/strings.xml
@@ -281,7 +281,7 @@
   <string name="xml_formatting_options">XML 格式化选项</string>
   <string name="xml_formatting_options_summary">配置 XML 格式化程序</string>
   <string name="idepref_customFont_title">使用自定义字体</string>
-  <string name="idepref_customFont_summary">如果启用，文件“/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf”将用作编辑器字体。</string>
+  <string name="idepref_customFont_summary">如果启用，文件“/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf”将用作编辑器字体。</string>
   <string name="msg_installing_apk">正在安装 APK …</string>
   <string name="msg_action_open_application">您想打开该应用吗？</string>
   <string name="title_gradle_service_notification_channel">Code on the Go Gradle 构建服务</string>
@@ -398,7 +398,7 @@
   <string name="idepref_devOptions_summary">Code on the Go 的实验和调试选项</string>
   <string name="idepref_group_debugging">调试</string>
   <string name="idepref_devOptions_dumpLogs_title">转储日志</string>
-  <string name="idepref_devOptions_dumpLogs_summary">将 Code on the Go 日志转储到 $HOME/.androidide/logs</string>
+  <string name="idepref_devOptions_dumpLogs_summary">将 Code on the Go 日志转储到 $HOME/.cg/logs</string>
   <string name="msg_emptyview_applogs">运行应用的 debug 变体以在此处查看其日志。</string>
   <string name="msg_logsender_disabled">LogSender 已禁用。您可以在首选项中启用它。</string>
   <string name="msg_emptyview_idelogs">IDE 中的日志显示在这里。</string>

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -482,7 +482,7 @@
 	<string name="xml_formatting_options">XML formatting options</string>
 	<string name="xml_formatting_options_summary">Set formatting preferences for XML files.</string>
 	<string name="idepref_customFont_title">Use custom font</string>
-	<string name="idepref_customFont_summary">If enabled, the file at \"/data/data/com.itsaky.androidide/files/home/.androidide/ui/font.ttf\" will be used as Editor font.</string>
+	<string name="idepref_customFont_summary">If enabled, the file at \"/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf\" will be used as Editor font.</string>
 	<string name="msg_installing_apk">Installing APK…</string>
 	<string name="msg_action_open_application">Your app is installed. Do you want to launch the app?</string>
 	<string name="msg_action_open_title_application">App installed</string>
@@ -663,7 +663,7 @@
 	<string name="idepref_devOptions_summary">Experimental/debugging options for Code on the Go</string>
 	<string name="idepref_group_debugging">Debugging</string>
 	<string name="idepref_devOptions_dumpLogs_title">Dump logs</string>
-	<string name="idepref_devOptions_dumpLogs_summary">Dump Code on the Go logs to $HOME/.androidide/logs</string>
+	<string name="idepref_devOptions_dumpLogs_summary">Dump Code on the Go logs to $HOME/.cg/logs</string>
 	<string name="msg_emptyview_applogs">Run the debug variant of your application to view its logs here.</string>
 	<string name="msg_logsender_disabled">LogSender is disabled. You can enable it in preferences.</string>
 	<string name="msg_emptyview_idelogs">Logs from the IDE are shown here.</string>

--- a/shared/src/main/java/com/itsaky/androidide/utils/SharedEnvironment.kt
+++ b/shared/src/main/java/com/itsaky/androidide/utils/SharedEnvironment.kt
@@ -7,9 +7,14 @@ package com.itsaky.androidide.utils
  */
 object SharedEnvironment {
 	/**
-	 * The name of the per-project cache directory.
+	 * The name of the per-project cache directory and app-internal IDE data under `files/home/`.
 	 */
-	const val PROJECT_CACHE_DIR_NAME = ".androidide"
+	const val PROJECT_CACHE_DIR_NAME = ".cg"
+
+	/**
+	 * Previous cache directory name (fork branding); migrated on first access.
+	 */
+	const val LEGACY_PROJECT_CACHE_DIR_NAME = ".androidide"
 
 	/**
 	 * The name of the gradle sync cache directory.

--- a/subprojects/tooling-api-model/build.gradle.kts
+++ b/subprojects/tooling-api-model/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
 tasks.register<Copy>("copyToTestDir") {
 	from(project.layout.buildDirectory.file("libs/tooling-api-model.jar"))
-	into(project.rootProject.mkdir("tests/test-home/.androidide/init"))
+	into(project.rootProject.mkdir("tests/test-home/.cg/init"))
 	rename { "model.jar" }
 
 	outputs.upToDateWhen { false }


### PR DESCRIPTION
**Runtime and shared constants**
[SharedEnvironment.kt](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/shared/src/main/java/com/itsaky/androidide/utils/SharedEnvironment.kt): PROJECT_CACHE_DIR_NAME = ".cg", LEGACY_PROJECT_CACHE_DIR_NAME = ".androidide". All derived paths (e.g. PROJECT_SYNC_CACHE_DIR) now use .cg.
[LegacyIdeDataDir.kt](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/shared/src/main/java/com/itsaky/androidide/utils/LegacyIdeDataDir.kt): migrateLegacyIdeDataDirIfNeeded(legacy, current) — renames legacy → current when only legacy exists; if both exist, logs a warning and keeps the new dir.
[Environment.java](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/common/src/main/java/com/itsaky/androidide/utils/Environment.java): Runs migration on files/home/ before creating ANDROIDIDE_HOME, uses SharedEnvironment.PROJECT_CACHE_DIR_NAME (no hardcoded .androidide). getProjectCacheDir runs the same migration per project.

**Build constants**
[constants.kt](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt): IDE_DATA_DIR_NAME = ".cg" and ANDROIDIDE_HOME built from it so plugin paths stay aligned with the app.

**Host tooling / ignores**
[subprojects/tooling-api-model/build.gradle.kts](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/subprojects/tooling-api-model/build.gradle.kts): copy target tests/test-home/.cg/init.
[gradle-plugin/.../utils.kt](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/gradle-plugin/src/test/java/com/itsaky/androidide/gradle/utils.kt): init script path uses SharedEnvironment.PROJECT_CACHE_DIR_NAME.
[.gitignore](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/.gitignore): tests/**/.cg/init/model.jar.
[layouteditor/.gitignore](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/layouteditor/.gitignore): .cg/.

**Strings**
All values / values-* strings.xml: /home/.androidide → /home/.cg, $HOME/.androidide → $HOME/.cg.
Hindi: fixed package typo com.itsaky.android → com.itsaky.androidide.
Arabic: fixed font path prefix to /data/data/com.itsaky.androidide/....
