### PR TITLE
ADFA-3645 | Open terminal in adjacent window on large screens

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/main/OpenTerminalAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/main/OpenTerminalAction.kt
@@ -10,6 +10,7 @@ import com.itsaky.androidide.actions.ActionItem
 import com.itsaky.androidide.actions.markInvisible
 import com.itsaky.androidide.activities.TerminalActivity
 import com.itsaky.androidide.idetooltips.TooltipTag
+import com.itsaky.androidide.utils.applyMultiWindowFlags
 
 class OpenTerminalAction(context: Context) : ActionItem {
 
@@ -38,7 +39,9 @@ class OpenTerminalAction(context: Context) : ActionItem {
 
     override suspend fun execAction(data: ActionData): Any {
         val context = data.get(Context::class.java) ?: return false
-        context.startActivity(Intent(context, TerminalActivity::class.java))
+        val intent = Intent(context, TerminalActivity::class.java)
+            .applyMultiWindowFlags(context)
+        context.startActivity(intent)
         return true
     }
 }

--- a/app/src/main/java/com/itsaky/androidide/actions/sidebar/TerminalSidebarAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/sidebar/TerminalSidebarAction.kt
@@ -27,6 +27,7 @@ import com.itsaky.androidide.actions.requireContext
 import com.itsaky.androidide.activities.TerminalActivity
 import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.projects.IProjectManager
+import com.itsaky.androidide.utils.applyMultiWindowFlags
 import com.termux.shared.termux.TermuxConstants.TERMUX_APP.TERMUX_ACTIVITY
 import java.util.Objects
 import kotlin.reflect.KClass
@@ -71,7 +72,7 @@ class TerminalSidebarAction(
 							?.name,
 					)
 					putExtra(TERMUX_ACTIVITY.EXTRA_FAILSAFE_SESSION, isFailsafe)
-				}
+			}.applyMultiWindowFlags(context)
 			context.startActivity(intent)
 		}
 	}

--- a/common/src/main/java/com/itsaky/androidide/activities/editor/HelpActivity.kt
+++ b/common/src/main/java/com/itsaky/androidide/activities/editor/HelpActivity.kt
@@ -33,6 +33,7 @@ import com.itsaky.androidide.common.databinding.ActivityHelpBinding
 import com.itsaky.androidide.utils.DeviceFormFactorUtils
 import com.itsaky.androidide.utils.isSystemInDarkMode
 import com.itsaky.androidide.utils.UrlManager
+import com.itsaky.androidide.utils.applyMultiWindowFlags
 import org.adfa.constants.CONTENT_TITLE_KEY
 
 class HelpActivity : BaseIDEActivity() {
@@ -46,20 +47,10 @@ class HelpActivity : BaseIDEActivity() {
                 putExtra(CONTENT_KEY, url)
                 putExtra(CONTENT_TITLE_KEY, title)
 
-                val formFactor = DeviceFormFactorUtils.getCurrent(context)
-
-                if (formFactor.isLargeScreenLike) {
-                    addFlags(
-                        Intent.FLAG_ACTIVITY_NEW_TASK or
-                        Intent.FLAG_ACTIVITY_NEW_DOCUMENT or
-                        Intent.FLAG_ACTIVITY_SINGLE_TOP or
-                        Intent.FLAG_ACTIVITY_LAUNCH_ADJACENT
-                    )
+                if (DeviceFormFactorUtils.getCurrent(context).isLargeScreenLike) {
                     data = MULTI_WINDOW_URI.toUri()
-                } else if (context !is Activity) {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 }
-            }
+            }.applyMultiWindowFlags(context)
             context.startActivity(intent)
         }
     }

--- a/common/src/main/java/com/itsaky/androidide/utils/IntentExtensions.kt
+++ b/common/src/main/java/com/itsaky/androidide/utils/IntentExtensions.kt
@@ -1,0 +1,21 @@
+package com.itsaky.androidide.utils
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+
+
+fun Intent.applyMultiWindowFlags(context: Context): Intent = apply {
+    val formFactor = DeviceFormFactorUtils.getCurrent(context)
+
+    if (formFactor.isLargeScreenLike) {
+        addFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK or
+            Intent.FLAG_ACTIVITY_NEW_DOCUMENT or
+            Intent.FLAG_ACTIVITY_SINGLE_TOP or
+            Intent.FLAG_ACTIVITY_LAUNCH_ADJACENT
+        )
+    } else if (context !is Activity) {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+}

--- a/termux/termux-app/src/main/java/com/itsaky/androidide/activities/TerminalActivity.kt
+++ b/termux/termux-app/src/main/java/com/itsaky/androidide/activities/TerminalActivity.kt
@@ -18,6 +18,7 @@
 package com.itsaky.androidide.activities
 
 import android.content.ComponentName
+import android.content.Intent
 import android.os.Bundle
 import android.os.IBinder
 import androidx.core.content.ContextCompat
@@ -25,6 +26,7 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import com.itsaky.androidide.utils.Environment
 import com.termux.app.TermuxActivity
+import com.termux.shared.termux.TermuxConstants
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -52,4 +54,30 @@ class TerminalActivity : TermuxActivity() {
       Environment.mkdirIfNotExists(Environment.TMP_DIR)
     }
   }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        if (intent == null) return
+
+        val newWorkingDir = intent.getStringExtra(TermuxConstants.TERMUX_APP.TERMUX_ACTIVITY.EXTRA_SESSION_WORKING_DIR)
+        val newSessionName = intent.getStringExtra(TermuxConstants.TERMUX_APP.TERMUX_ACTIVITY.EXTRA_SESSION_NAME)
+        val isFailsafe = intent.getBooleanExtra(TermuxConstants.TERMUX_APP.TERMUX_ACTIVITY.EXTRA_FAILSAFE_SESSION, false)
+
+        val service = mTermuxService
+        if (service != null) {
+            val newSession = service.createTermuxSession(
+                null,
+                null,
+                null,
+                newWorkingDir,
+                isFailsafe,
+                newSessionName
+            )
+
+            if (newSession != null) {
+                mTermuxTerminalSessionActivityClient.setCurrentSession(newSession.terminalSession)
+            }
+        }
+    }
 }

--- a/termux/termux-app/src/main/java/com/itsaky/androidide/activities/TerminalActivity.kt
+++ b/termux/termux-app/src/main/java/com/itsaky/androidide/activities/TerminalActivity.kt
@@ -26,6 +26,7 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import com.itsaky.androidide.utils.Environment
 import com.termux.app.TermuxActivity
+import com.termux.app.TermuxService
 import com.termux.shared.termux.TermuxConstants
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -34,26 +35,37 @@ import kotlinx.coroutines.launch
  * @author Akash Yadav
  */
 class TerminalActivity : TermuxActivity() {
+    private var pendingWorkingDir: String? = null
+    private var pendingSessionName: String? = null
+    private var pendingIsFailsafe: Boolean = false
 
-  override val navigationBarColor: Int
-    get() = ContextCompat.getColor(this, android.R.color.black)
-  override val statusBarColor: Int
-    get() = ContextCompat.getColor(this, android.R.color.black)
+    override val navigationBarColor: Int
+        get() = ContextCompat.getColor(this, android.R.color.black)
+    override val statusBarColor: Int
+        get() = ContextCompat.getColor(this, android.R.color.black)
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    val controller = WindowCompat.getInsetsController(
-      window, window.decorView)
-    controller.isAppearanceLightNavigationBars = false
-    controller.isAppearanceLightStatusBars = false
-    super.onCreate(savedInstanceState)
-  }
-
-  override fun onServiceConnected(componentName: ComponentName?, service: IBinder?) {
-    super.onServiceConnected(componentName, service)
-    lifecycleScope.launch(Dispatchers.IO) {
-      Environment.mkdirIfNotExists(Environment.TMP_DIR)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        val controller = WindowCompat.getInsetsController(window, window.decorView)
+        controller.isAppearanceLightNavigationBars = false
+        controller.isAppearanceLightStatusBars = false
+        super.onCreate(savedInstanceState)
     }
-  }
+
+    override fun onServiceConnected(componentName: ComponentName?, service: IBinder?) {
+        super.onServiceConnected(componentName, service)
+        lifecycleScope.launch(Dispatchers.IO) {
+            Environment.mkdirIfNotExists(Environment.TMP_DIR)
+        }
+
+        val termuxService = mTermuxService
+        if (termuxService != null && (pendingWorkingDir != null || pendingSessionName != null)) {
+            createAndSetSession(termuxService, pendingWorkingDir, pendingSessionName, pendingIsFailsafe)
+
+            pendingWorkingDir = null
+            pendingSessionName = null
+            pendingIsFailsafe = false
+        }
+    }
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
@@ -66,18 +78,31 @@ class TerminalActivity : TermuxActivity() {
 
         val service = mTermuxService
         if (service != null) {
-            val newSession = service.createTermuxSession(
-                null,
-                null,
-                null,
-                newWorkingDir,
-                isFailsafe,
-                newSessionName
-            )
+            createAndSetSession(service, newWorkingDir, newSessionName, isFailsafe)
+        } else {
+            pendingWorkingDir = newWorkingDir
+            pendingSessionName = newSessionName
+            pendingIsFailsafe = isFailsafe
+        }
+    }
 
-            if (newSession != null) {
-                mTermuxTerminalSessionActivityClient.setCurrentSession(newSession.terminalSession)
-            }
+    private fun createAndSetSession(
+        service: TermuxService,
+        workingDir: String?,
+        sessionName: String?,
+        isFailsafe: Boolean
+    ) {
+        val newSession = service.createTermuxSession(
+            null,
+            null,
+            null,
+            workingDir,
+            isFailsafe,
+            sessionName
+        )
+
+        if (newSession != null) {
+            mTermuxTerminalSessionActivityClient.setCurrentSession(newSession.terminalSession)
         }
     }
 }


### PR DESCRIPTION
## Description

Added support for launching the terminal in a secondary adjacent window (split-screen) when users are on a tablet or DeX device. This allows users to read their code in the editor and interact with the terminal at the same time. The multi-window intent flags were extracted into a reusable `Intent.applyMultiWindowFlags()` extension function, which is now applied to terminal actions. Additionally, `TerminalActivity` was updated to handle `onNewIntent` so that new terminal sessions are created correctly when the activity is already open. 

## Details

- Created `IntentExtensions.kt` to centralize large screen / multi-window intent flag configurations.
- Applied multi-window flags to `OpenTerminalAction` and `TerminalSidebarAction`.
- Overrode `onNewIntent` in `TerminalActivity` to instantiate a `newTermuxSession` when the activity is launched again.


https://github.com/user-attachments/assets/c49355ab-a5fc-424e-af6d-405792dd749f


## Ticket

[ADFA-3645](https://appdevforall.atlassian.net/browse/ADFA-3645)

## Observation

Because the multi-window launch uses `Intent.FLAG_ACTIVITY_SINGLE_TOP`, `TerminalActivity` requires the `onNewIntent` implementation to ensure subsequent terminal open actions correctly initialize new sessions with the provided working directory and session name, rather than just bringing the existing window into focus silently.

[ADFA-3645]: https://appdevforall.atlassian.net/browse/ADFA-3645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ