### PR TITLE
ADFA-3612 | Refactor generic box resolution to domain layer

### DIFF
--- a/cv-image-to-xml/src/main/assets/labels.txt
+++ b/cv-image-to-xml/src/main/assets/labels.txt
@@ -1,11 +1,11 @@
-dropdown
+generic_box
+dropdown_symbol
 image_placeholder
 button
 checkbox_checked
+checkbox_unchecked
 radio_button_unchecked
 radio_button_checked
-text_entry_box
-checkbox_unchecked
 slider
 switch_off
 switch_on

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/data/repository/ComputerVisionRepositoryImpl.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/data/repository/ComputerVisionRepositoryImpl.kt
@@ -10,6 +10,7 @@ import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
 import com.google.mlkit.vision.text.Text
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.appdevforall.codeonthego.computervision.domain.GenericBoxResolver
 
 class ComputerVisionRepositoryImpl(
     private val assetManager: AssetManager,
@@ -26,7 +27,8 @@ class ComputerVisionRepositoryImpl(
     override suspend fun runYoloInference(bitmap: Bitmap): Result<List<DetectionResult>> =
         withContext(Dispatchers.Default) {
             runCatching {
-                yoloModelSource.runInference(bitmap)
+                val rawDetections = yoloModelSource.runInference(bitmap)
+                GenericBoxResolver().resolve(rawDetections)
             }
         }
 

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/GenericBoxResolver.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/GenericBoxResolver.kt
@@ -1,0 +1,37 @@
+package org.appdevforall.codeonthego.computervision.domain
+
+import android.graphics.RectF
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import kotlin.math.hypot
+
+class GenericBoxResolver {
+
+    fun resolve(detections: List<DetectionResult>): List<DetectionResult> {
+        val dropdownSymbols = detections.filter { it.label == "dropdown_symbol" }
+
+        return detections.mapNotNull { det ->
+            when (det.label) {
+                "dropdown_symbol" -> null
+                "generic_box" -> {
+                    val hasSymbolNearby = dropdownSymbols.any { symbol ->
+                        isNearby(det.boundingBox, symbol.boundingBox, 0.8f)
+                    }
+                    det.copy(label = if (hasSymbolNearby) "dropdown" else "text_entry_box")
+                }
+                else -> det
+            }
+        }
+    }
+
+    private fun isNearby(box1: RectF, box2: RectF, thresholdFactor: Float = 1.5f): Boolean {
+        val avgDim1 = (box1.width() + box1.height()) / 2f
+        val distanceThreshold = thresholdFactor * avgDim1
+
+        val distance = hypot(
+            (box1.centerX() - box2.centerX()).toDouble(),
+            (box1.centerY() - box2.centerY()).toDouble()
+        ).toFloat()
+
+        return distance < distanceThreshold
+    }
+}


### PR DESCRIPTION
## Description

Extracted the logic that determines whether a `generic_box` is a dropdown or a text entry box into a new dedicated domain class (`GenericBoxResolver`), and updated the YOLO model labels.

Created the `GenericBoxResolver` class to handle proximity checks between `generic_box` and `dropdown_symbol` using declarative Kotlin functions (`mapNotNull`, `any`). Injected this step into `ComputerVisionRepositoryImpl` immediately after the raw YOLO inference. Updated `labels.txt` to include `generic_box` and `dropdown_symbol`.

## Details

<img width="1280" height="801" alt="image" src="https://github.com/user-attachments/assets/59b290b3-c82a-413f-af4e-2ed22906ef13" />

<img width="1280" height="801" alt="image" src="https://github.com/user-attachments/assets/36dfe3d7-3041-4dda-bf0c-5c7e38e1e93a" />


## Ticket

[ADFA-3612](https://appdevforall.atlassian.net/browse/ADFA-3612)

[ADFA-3612]: https://appdevforall.atlassian.net/browse/ADFA-3612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ