### PR TITLE
ADFA-2738 connectedV8DebugAndroidTest Part 3 of 3: iterate over 1st three templates

### DIFF
--- a/app/src/androidTest/kotlin/com/itsaky/androidide/EndToEndTest.kt
+++ b/app/src/androidTest/kotlin/com/itsaky/androidide/EndToEndTest.kt
@@ -8,10 +8,16 @@ import androidx.test.uiautomator.UiSelector
 import com.itsaky.androidide.activities.SplashActivity
 import com.itsaky.androidide.helper.advancePastWelcomeScreen
 import com.itsaky.androidide.helper.clickFirstAccessibilityNodeByText
+import com.itsaky.androidide.helper.ensureOnHomeScreenBeforeCreateProject
 import com.itsaky.androidide.helper.grantAllRequiredPermissionsThroughOnboardingUi
+import com.itsaky.androidide.helper.initializeProjectAndCancelBuild
+import com.itsaky.androidide.helper.selectProjectTemplate
 import com.itsaky.androidide.helper.waitForMainHomeOrEditorUi
 import com.itsaky.androidide.resources.R as ResourcesR
+import com.itsaky.androidide.screens.HomeScreen.clickCreateProjectHomeScreen
 import com.itsaky.androidide.screens.OnboardingScreen
+import com.itsaky.androidide.screens.ProjectSettingsScreen.clickCreateProjectProjectSettings
+import com.itsaky.androidide.screens.ProjectSettingsScreen.setProjectName
 import com.itsaky.androidide.screens.PermissionScreen
 import com.itsaky.androidide.screens.PermissionsInfoScreen
 import com.itsaky.androidide.utils.PermissionsHelper
@@ -195,6 +201,36 @@ class EndToEndTest : TestCase() {
             )
         }
 
-        // ── Future phases (project creation, builds, preferences) go here ──
+        // ── Phase 2: Project creation + build for first 3 templates ──
+
+        ensureOnHomeScreenBeforeCreateProject()
+
+        data class TemplateConfig(
+            val label: String,
+            val templateResId: Int,
+            val projectName: String,
+        )
+
+        val templates = listOf(
+            TemplateConfig("No Activity", R.string.template_no_activity, "TestNoActivity"),
+            TemplateConfig("Empty Activity", R.string.template_empty, "TestEmptyActivity"),
+            TemplateConfig("Basic Activity", R.string.template_basic, "TestBasicActivity"),
+        )
+
+        for ((index, config) in templates.withIndex()) {
+            step("Create+build template ${index + 1}/${templates.size}: ${config.label}") {
+                clickCreateProjectHomeScreen()
+            }
+            selectProjectTemplate("Select ${config.label} template", config.templateResId)
+            setProjectName(config.projectName)
+            clickCreateProjectProjectSettings()
+            initializeProjectAndCancelBuild()
+
+            if (index < templates.lastIndex) {
+                ensureOnHomeScreenBeforeCreateProject()
+            }
+        }
+
+        // ── Future phases (preferences, more templates, etc.) go here ──
     }
 }

--- a/app/src/androidTest/kotlin/com/itsaky/androidide/helper/DevicePermissionGrantUiHelper.kt
+++ b/app/src/androidTest/kotlin/com/itsaky/androidide/helper/DevicePermissionGrantUiHelper.kt
@@ -76,6 +76,108 @@ fun clickFirstAccessibilityNodeByText(
     }
 }
 
+/**
+ * Clicks a node found by [searchText] matching on [contentDescription] rather than text.
+ * Useful for toolbar ImageButtons that have no text label.
+ */
+fun clickFirstAccessibilityNodeByDescription(
+    searchText: String,
+    errorLabel: String = searchText,
+) {
+    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
+    val root = uiAutomation.rootInActiveWindow
+        ?: throw AssertionError("No active window for accessibility")
+
+    val nodes = root.findAccessibilityNodeInfosByText(searchText)
+    var clicked = false
+    try {
+        for (node in nodes) {
+            val desc = node.contentDescription?.toString() ?: ""
+            if (!clicked && desc.contains(searchText, ignoreCase = true) && node.isClickable) {
+                clicked = node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+            }
+            node.recycle()
+        }
+    } finally {
+        root.recycle()
+    }
+
+    if (!clicked) {
+        throw AssertionError("No '$errorLabel' button found via accessibility (by description)")
+    }
+}
+
+/**
+ * Finds a node by [searchText], walks up to its nearest clickable ancestor, and clicks it.
+ * Useful when the click handler is on a parent container (e.g., RecyclerView item roots).
+ */
+fun clickFirstAccessibilityNodeParentByText(
+    searchText: String,
+    errorLabel: String = searchText,
+) {
+    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
+    val root = uiAutomation.rootInActiveWindow
+        ?: throw AssertionError("No active window for accessibility")
+
+    val nodes = root.findAccessibilityNodeInfosByText(searchText)
+    var clicked = false
+    try {
+        for (node in nodes) {
+            if (clicked) { node.recycle(); continue }
+            var current: AccessibilityNodeInfo? = node
+            while (current != null) {
+                if (current.isClickable) {
+                    clicked = current.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+                    break
+                }
+                current = current.parent
+            }
+            node.recycle()
+        }
+    } finally {
+        root.recycle()
+    }
+
+    if (!clicked) {
+        throw AssertionError("No clickable parent found for '$errorLabel' via accessibility")
+    }
+}
+
+/**
+ * Sets the text of an EditText found by [searchText] to [newText] using accessibility
+ * ACTION_SET_TEXT. Avoids the clear-then-retype pattern which can lose the selector.
+ */
+fun setAccessibilityEditText(
+    searchText: String,
+    newText: String,
+    errorLabel: String = searchText,
+) {
+    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
+    val root = uiAutomation.rootInActiveWindow
+        ?: throw AssertionError("No active window for accessibility")
+
+    val nodes = root.findAccessibilityNodeInfosByText(searchText)
+    var set = false
+    try {
+        for (node in nodes) {
+            if (!set && node.className?.toString() == "android.widget.EditText") {
+                val args = android.os.Bundle()
+                args.putCharSequence(
+                    AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, newText
+                )
+                set = node.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
+            }
+            node.recycle()
+        }
+    } finally {
+        root.recycle()
+    }
+
+    if (!set) {
+        throw AssertionError("Failed to set text on '$errorLabel' via accessibility")
+    }
+}
+
 /** Appops that are granted via [grantViaAppOpsAndBack] and must be explicitly revoked in cleanup. */
 private val APPOPS_PERMISSIONS = listOf(
     "MANAGE_EXTERNAL_STORAGE",

--- a/app/src/androidTest/kotlin/com/itsaky/androidide/helper/DevicePermissionGrantUiHelper.kt
+++ b/app/src/androidTest/kotlin/com/itsaky/androidide/helper/DevicePermissionGrantUiHelper.kt
@@ -54,26 +54,10 @@ fun clickFirstAccessibilityNodeByText(
             && node.isVisibleToUser
     },
 ) {
-    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
-    val root = uiAutomation.rootInActiveWindow
-        ?: throw AssertionError("No active window for accessibility")
-
-    val nodes = root.findAccessibilityNodeInfosByText(searchText)
-    var clicked = false
-    try {
-        for (node in nodes) {
-            if (!clicked && matchBy(node)) {
-                clicked = node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
-            }
-            node.recycle()
-        }
-    } finally {
-        root.recycle()
+    val success = findAndActOnAccessibilityNode(searchText) { node ->
+        if (matchBy(node)) node.performAction(AccessibilityNodeInfo.ACTION_CLICK) else false
     }
-
-    if (!clicked) {
-        throw AssertionError("No '$errorLabel' button found via accessibility")
-    }
+    check(success) { "No '$errorLabel' button found via accessibility" }
 }
 
 /**
@@ -84,27 +68,13 @@ fun clickFirstAccessibilityNodeByDescription(
     searchText: String,
     errorLabel: String = searchText,
 ) {
-    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
-    val root = uiAutomation.rootInActiveWindow
-        ?: throw AssertionError("No active window for accessibility")
-
-    val nodes = root.findAccessibilityNodeInfosByText(searchText)
-    var clicked = false
-    try {
-        for (node in nodes) {
-            val desc = node.contentDescription?.toString() ?: ""
-            if (!clicked && desc.contains(searchText, ignoreCase = true) && node.isClickable) {
-                clicked = node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
-            }
-            node.recycle()
-        }
-    } finally {
-        root.recycle()
+    val success = findAndActOnAccessibilityNode(searchText) { node ->
+        val desc = node.contentDescription?.toString() ?: ""
+        if (desc.contains(searchText, ignoreCase = true) && node.isClickable) {
+            node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+        } else false
     }
-
-    if (!clicked) {
-        throw AssertionError("No '$errorLabel' button found via accessibility (by description)")
-    }
+    check(success) { "No '$errorLabel' button found via accessibility (by description)" }
 }
 
 /**
@@ -115,32 +85,18 @@ fun clickFirstAccessibilityNodeParentByText(
     searchText: String,
     errorLabel: String = searchText,
 ) {
-    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
-    val root = uiAutomation.rootInActiveWindow
-        ?: throw AssertionError("No active window for accessibility")
-
-    val nodes = root.findAccessibilityNodeInfosByText(searchText)
-    var clicked = false
-    try {
-        for (node in nodes) {
-            if (clicked) { node.recycle(); continue }
-            var current: AccessibilityNodeInfo? = node
-            while (current != null) {
-                if (current.isClickable) {
-                    clicked = current.performAction(AccessibilityNodeInfo.ACTION_CLICK)
-                    break
-                }
-                current = current.parent
+    val success = findAndActOnAccessibilityNode(searchText) { node ->
+        var current: AccessibilityNodeInfo? = node
+        var clicked = false
+        while (current != null && !clicked) {
+            if (current.isClickable) {
+                clicked = current.performAction(AccessibilityNodeInfo.ACTION_CLICK)
             }
-            node.recycle()
+            current = current.parent
         }
-    } finally {
-        root.recycle()
+        clicked
     }
-
-    if (!clicked) {
-        throw AssertionError("No clickable parent found for '$errorLabel' via accessibility")
-    }
+    check(success) { "No clickable parent found for '$errorLabel' via accessibility" }
 }
 
 /**
@@ -152,30 +108,44 @@ fun setAccessibilityEditText(
     newText: String,
     errorLabel: String = searchText,
 ) {
+    val args = android.os.Bundle().apply {
+        putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, newText)
+    }
+    val success = findAndActOnAccessibilityNode(searchText) { node ->
+        if (node.className?.toString() == "android.widget.EditText") {
+            node.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
+        } else false
+    }
+    check(success) { "Failed to set text on '$errorLabel' via accessibility" }
+}
+
+/**
+ * Searches the accessibility tree for nodes matching [searchText], applies [action] to each
+ * until one returns true. Handles root-window acquisition, node iteration, and recycling.
+ *
+ * @return true if [action] returned true for any node.
+ */
+private fun findAndActOnAccessibilityNode(
+    searchText: String,
+    action: (AccessibilityNodeInfo) -> Boolean,
+): Boolean {
     val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
     val root = uiAutomation.rootInActiveWindow
         ?: throw AssertionError("No active window for accessibility")
 
     val nodes = root.findAccessibilityNodeInfosByText(searchText)
-    var set = false
+    var success = false
     try {
         for (node in nodes) {
-            if (!set && node.className?.toString() == "android.widget.EditText") {
-                val args = android.os.Bundle()
-                args.putCharSequence(
-                    AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, newText
-                )
-                set = node.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
+            if (!success) {
+                success = action(node)
             }
             node.recycle()
         }
     } finally {
         root.recycle()
     }
-
-    if (!set) {
-        throw AssertionError("Failed to set text on '$errorLabel' via accessibility")
-    }
+    return success
 }
 
 /** Appops that are granted via [grantViaAppOpsAndBack] and must be explicitly revoked in cleanup. */

--- a/app/src/androidTest/kotlin/com/itsaky/androidide/helper/DevicePermissionGrantUiHelper.kt
+++ b/app/src/androidTest/kotlin/com/itsaky/androidide/helper/DevicePermissionGrantUiHelper.kt
@@ -41,8 +41,8 @@ fun Device.grantDisplayOverOtherAppsUi() {
 /**
  * Finds accessibility nodes matching [searchText] and clicks the first one accepted by [matchBy].
  *
- * Handles root-window acquisition, node iteration, recycling, and throws
- * [AssertionError] if no matching node was clicked.
+ * Handles root-window acquisition, node iteration, and recycling.
+ * @throws IllegalStateException if no matching node was clicked.
  */
 fun clickFirstAccessibilityNodeByText(
     searchText: String,

--- a/app/src/androidTest/kotlin/com/itsaky/androidide/scenarios/InitializationProjectAndCancelingBuildScenario.kt
+++ b/app/src/androidTest/kotlin/com/itsaky/androidide/scenarios/InitializationProjectAndCancelingBuildScenario.kt
@@ -1,113 +1,82 @@
 package com.itsaky.androidide.scenarios
 
 import androidx.test.uiautomator.UiSelector
-import com.itsaky.androidide.R
-import com.itsaky.androidide.screens.EditorScreen
+import com.itsaky.androidide.helper.clickFirstAccessibilityNodeByDescription
+import com.itsaky.androidide.helper.clickFirstAccessibilityNodeByText
 import com.kaspersky.kaspresso.testcases.api.scenario.Scenario
 import com.kaspersky.kaspresso.testcases.core.testcontext.TestContext
-import io.github.kakaocup.kakao.common.views.KView
-import io.github.kakaocup.kakao.toolbar.KToolbar
 
 class InitializationProjectAndCancelingBuildScenario : Scenario() {
 
+    private fun TestContext<Unit>.clickToolbarButton(description: String, waitMs: Long = 10_000) {
+        val d = device.uiDevice
+        val btn = d.findObject(UiSelector().descriptionContains(description))
+        check(btn.waitForExists(waitMs)) { "Toolbar button '$description' not found" }
+        clickFirstAccessibilityNodeByDescription(description)
+        d.waitForIdle()
+    }
+
     override val steps: TestContext<Unit>.() -> Unit = {
-        step("Close the first build dialog") {
-            flakySafely(180000) {
-                try {
-                    EditorScreen {
-                        firstBuildDialog {
-                            isDisplayed()
-                            title {
-                                hasText(R.string.title_first_build)
-                            }
-                            message {
-                                hasText(R.string.msg_first_build)
-                            }
-                            positiveButton {
-                                click()
-                            }
-                        }
-                    }
-                } catch (e: Exception) {
-                    println("First build dialog was not visible or was auto-dismissed: ${e.message}")
-                }
+        step("Dismiss first build notice and start init") {
+            val d = device.uiDevice
+            val okBtn = d.findObject(UiSelector().text("OK").className("android.widget.Button"))
+            if (okBtn.waitForExists(3_000)) {
+                clickFirstAccessibilityNodeByText("OK")
+                d.waitForIdle()
             }
+            // Wait for the editor UI to settle after dialog dismiss
+            // before clicking the quick-run button
+            val toolbar = d.findObject(
+                UiSelector().resourceIdMatches(".*:id/editor_appBarLayout")
+            )
+            check(toolbar.waitForExists(3_000)) { "Editor toolbar not found" }
+            d.waitForIdle()
+            // The button may be "Sync project" or "Quick run" depending on state
+            clickToolbarButton("Sync project")
         }
-        step("Wait for the green button") {
-            flakySafely(600000) { // Increased timeout to 10 minutes
-                try {
-                    // Wait for project initialization with increased timeout
-                    val projectInitializedText =
-                        device.uiDevice.findObject(UiSelector().text("Project initialized"))
-                    if (!projectInitializedText.waitForExists(540000)) { // 9 minutes
-                        // If we can't find the text, let's wait a bit more before proceeding
-                        println("Project initialized text not found, waiting additional time...")
-                        Thread.sleep(10000)
-                    } else {
-                        println("Project initialized text found")
-                    }
 
-                    // Wait after project is initialized to ensure UI is stable
-                    Thread.sleep(5000)
-
-                    // Try to find and click the build button with retries
-                    var attempts = 0
-                    var success = false
-                    while (attempts < 3 && !success) {
-                        try {
-                            flakySafely(10000) {
-                                KView {
-                                    withParent {
-                                        KToolbar {
-                                            withId(R.id.editor_appBarLayout)
-                                        }
-                                    }
-                                    withId("ide.editor.build.quickRun".hashCode())
-                                }.click()
-                            }
-                            success = true
-                            println("Successfully clicked build button on attempt ${attempts + 1}")
-                        } catch (e: Exception) {
-                            attempts++
-                            println("Failed to find or click build button on attempt $attempts: ${e.message}")
-                            if (attempts < 3) Thread.sleep(5000)
-                        }
-                    }
-                } catch (e: Exception) {
-                    println("Error waiting for project initialization: ${e.message}")
-                }
-            }
+        step("Wait for project initialized") {
+            val d = device.uiDevice
+            val status = d.findObject(UiSelector().text("Project initialized"))
+            check(status.waitForExists(120_000)) { "Project never initialized" }
+            println("Project initialized")
+            d.waitForIdle()
         }
-        step("Click back and confirm that the Close Project dialog appears") {
-            // Wait before pressing back
-            Thread.sleep(3000)
-            device.uiDevice.pressBack()
 
-            flakySafely(20000) { // Increased timeout for dialog
-                try {
-                    EditorScreen {
-                        closeProjectDialog {
-                            positiveButton {
-                                hasText("Save files and close project")
-                                click()
-                            }
-                        }
-                    }
-                } catch (e: Exception) {
-                    println("Failed to find or click close project dialog: ${e.message}")
-                    // Try one more time
-                    Thread.sleep(2000)
-                    device.uiDevice.pressBack()
-                    EditorScreen {
-                        closeProjectDialog {
-                            positiveButton {
-                                hasText("Save files and close project")
-                                click()
-                            }
-                        }
-                    }
-                }
+        step("Click quick-run to build APK") {
+            clickToolbarButton("Quick run")
+        }
+
+        step("Wait for APK install offer") {
+            // After a successful build, the system package installer appears.
+            // If it never appears, the build failed.
+            val d = device.uiDevice
+            val installer = d.findObject(
+                UiSelector().packageNameMatches(".*packageinstaller.*|.*permissioncontroller.*")
+            )
+            check(installer.waitForExists(120_000)) {
+                "APK install offer never appeared — build may have failed"
             }
+            println("APK install offer appeared — build succeeded")
+            // Dismiss it — we don't need to install
+            d.pressBack()
+            d.waitForIdle()
+        }
+
+        step("Close project") {
+            val d = device.uiDevice
+            d.pressBack()
+            d.waitForIdle()
+
+            val saveBtn = d.findObject(UiSelector().text("Save files and close project"))
+            if (!saveBtn.waitForExists(3_000)) {
+                // Maybe need another back press
+                d.pressBack()
+                d.waitForIdle()
+                check(saveBtn.waitForExists(3_000)) { "Close project dialog not found" }
+            }
+            clickFirstAccessibilityNodeByText("Save files and close project")
+            d.waitForIdle()
         }
     }
 }

--- a/app/src/androidTest/kotlin/com/itsaky/androidide/scenarios/InitializationProjectAndCancelingBuildScenario.kt
+++ b/app/src/androidTest/kotlin/com/itsaky/androidide/scenarios/InitializationProjectAndCancelingBuildScenario.kt
@@ -68,12 +68,13 @@ class InitializationProjectAndCancelingBuildScenario : Scenario() {
             d.pressBack()
             d.waitForIdle()
 
-            val saveBtn = d.findObject(UiSelector().text("Save files and close project"))
-            if (!saveBtn.waitForExists(3_000)) {
-                // Maybe need another back press
+            val selector = UiSelector().text("Save files and close project")
+            if (!d.findObject(selector).waitForExists(3_000)) {
                 d.pressBack()
                 d.waitForIdle()
-                check(saveBtn.waitForExists(3_000)) { "Close project dialog not found" }
+                check(d.findObject(selector).waitForExists(3_000)) {
+                    "Close project dialog not found"
+                }
             }
             clickFirstAccessibilityNodeByText("Save files and close project")
             d.waitForIdle()

--- a/app/src/androidTest/kotlin/com/itsaky/androidide/screens/HomeScreen.kt
+++ b/app/src/androidTest/kotlin/com/itsaky/androidide/screens/HomeScreen.kt
@@ -1,8 +1,8 @@
 package com.itsaky.androidide.screens
 
 import android.view.View
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.itsaky.androidide.R
+import com.itsaky.androidide.helper.clickFirstAccessibilityNodeByText
 import com.kaspersky.kaspresso.screens.KScreen
 import com.kaspersky.kaspresso.testcases.core.testcontext.TestContext
 import io.github.kakaocup.kakao.recycler.KRecyclerItem
@@ -10,7 +10,6 @@ import io.github.kakaocup.kakao.recycler.KRecyclerView
 import io.github.kakaocup.kakao.text.KButton
 import io.github.kakaocup.kakao.text.KTextView
 import org.hamcrest.Matcher
-import org.hamcrest.Matchers
 
 object HomeScreen : KScreen<HomeScreen>() {
 
@@ -32,41 +31,11 @@ object HomeScreen : KScreen<HomeScreen>() {
     }
 
     fun TestContext<Unit>.clickCreateProjectHomeScreen() {
-
-        val createProjectLabel = "Create Project"
-        val getStartedLabel = "Get started"
-
         step("Click create project") {
-            flakySafely(60000) {
-                HomeScreen {
-                    try {
-                        title {
-                            isVisible()
-                            withText(
-                                Matchers.equalToIgnoringCase(
-                                    getStartedLabel
-                                )
-                            )
-                        }
-                    } catch (e: Exception) {
-                        println("Get Started title not visible: ${e.message}")
-                    }
-
-                    rvActions {
-                        scrollTo(0)
-                        childWith<ActionItem> {
-                            withText(
-                                Matchers.equalToIgnoringCase(
-                                    createProjectLabel
-                                )
-                            )
-                        } perform {
-                            isDisplayed()
-                            click()
-                        }
-                    }
-                }
-            }
+            // Use ACTION_CLICK via accessibility — the IDETooltip WebView overlay
+            // can intercept coordinate-based clicks from both Espresso and UiAutomator.
+            clickFirstAccessibilityNodeByText("Create project")
+            device.uiDevice.waitForIdle()
         }
     }
 }

--- a/app/src/androidTest/kotlin/com/itsaky/androidide/screens/ProjectSettingsScreen.kt
+++ b/app/src/androidTest/kotlin/com/itsaky/androidide/screens/ProjectSettingsScreen.kt
@@ -2,6 +2,8 @@ package com.itsaky.androidide.screens
 
 import androidx.test.uiautomator.UiSelector
 import com.itsaky.androidide.R
+import com.itsaky.androidide.helper.clickFirstAccessibilityNodeByText
+import com.itsaky.androidide.helper.setAccessibilityEditText
 import com.kaspersky.kaspresso.screens.KScreen
 import com.kaspersky.kaspresso.testcases.core.testcontext.TestContext
 import io.github.kakaocup.kakao.check.KCheckBox
@@ -105,10 +107,19 @@ object ProjectSettingsScreen : KScreen<ProjectSettingsScreen>() {
 
     fun TestContext<Unit>.clickCreateProjectProjectSettings() {
         step("Click create project on the Settings Page") {
-            createProjectButton {
-                isVisible()
-                click()
-            }
+            val createText = device.targetContext.getString(R.string.create_project)
+            clickFirstAccessibilityNodeByText(createText)
+            device.uiDevice.waitForIdle()
+        }
+    }
+
+    fun TestContext<Unit>.setProjectName(name: String) {
+        step("Set project name to '$name'") {
+            val d = device.uiDevice
+            val byText = d.findObject(UiSelector().textStartsWith("My Application"))
+            check(byText.waitForExists(3_000)) { "Project name field not found" }
+            setAccessibilityEditText("My Application", name, "project name")
+            d.waitForIdle()
         }
     }
 

--- a/app/src/androidTest/kotlin/com/itsaky/androidide/screens/TemplateScreen.kt
+++ b/app/src/androidTest/kotlin/com/itsaky/androidide/screens/TemplateScreen.kt
@@ -1,48 +1,22 @@
 package com.itsaky.androidide.screens
 
-import android.view.View
-import com.itsaky.androidide.R
-import com.itsaky.androidide.screens.HomeScreen.ActionItem
-import com.kaspersky.kaspresso.screens.KScreen
+import androidx.test.uiautomator.UiSelector
+import com.itsaky.androidide.helper.clickFirstAccessibilityNodeParentByText
 import com.kaspersky.kaspresso.testcases.core.testcontext.TestContext
-import io.github.kakaocup.kakao.recycler.KRecyclerItem
-import io.github.kakaocup.kakao.recycler.KRecyclerView
-import io.github.kakaocup.kakao.text.KTextView
-import org.hamcrest.Matcher
-import org.hamcrest.Matchers
 
-object TemplateScreen : KScreen<TemplateScreen>() {
-
-    override val layoutId: Int? = null
-
-    override val viewClass: Class<*>? = null
-
-    val rvTemplates = KRecyclerView(
-        builder = { withId(R.id.list) },
-        itemTypeBuilder = { itemType(::TemplateItem) }
-    )
-
-    class TemplateItem(matcher: Matcher<View>) : KRecyclerItem<TemplateItem>(matcher) {
-        // Using this property in withDescendant matcher to find the template by name
-        val nameTemplate = KTextView(matcher) { withId(R.id.template_name) }
-    }
+object TemplateScreen {
 
     fun TestContext<Unit>.selectTemplate(templateResId: Int) {
         val templateText = device.targetContext.getString(templateResId)
-        println("Selecting template with id: $templateResId $templateText")
 
-        flakySafely(10000) {
-            TemplateScreen {
-                rvTemplates {
-                    scrollTo(0)
-                    childWith<TemplateItem> {
-                        withDescendant { withText(Matchers.equalToIgnoringCase(templateText)) }
-                    } perform {
-                        isDisplayed()
-                        click()
-                    }
-                }
-            }
+        val d = device.uiDevice
+        val templateItem = d.findObject(
+            UiSelector().resourceIdMatches(".*:id/template_name").text(templateText)
+        )
+        check(templateItem.waitForExists(3_000)) {
+            "Template '$templateText' not found in template list"
         }
+        clickFirstAccessibilityNodeParentByText(templateText, "template '$templateText'")
+        d.waitForIdle()
     }
 }


### PR DESCRIPTION
Extend the end2end test to iterate over the 1st three project templates

It's tricky getting the tests to not get blocked by the universal tooltips 

Added a template loop to EndToEndTest that iterates over three templates (No Activity, Empty Activity, Basic Activity), and for each one: clicks "Create project" on the home screen, selects the template from the list, sets a meaningful project name, clicks "Create project" on the settings page, then runs the InitializationProjectAndCancelingBuildScenario which dismisses the first-build notice, clicks "Sync project" to trigger Gradle initialization, waits for "Project initialized", clicks "Quick run" to build the APK, waits for the system package installer to appear (confirming the APK was built successfully), dismisses it, and closes the project back to the home screen before the next iteration. The key technical challenge was that the IDETooltipWebviewFragment creates a transparent WebView overlay that intercepts all coordinate-based clicks (both Espresso and UiAutomator), so had to use accessibility ACTION_CLICK via clickFirstAccessibilityNodeByText and related helpers throughout. Extracted three new shared helpers (clickFirstAccessibilityNodeByDescription, clickFirstAccessibilityNodeParentByText, and setAccessibilityEditText) into DevicePermissionGrantUiHelper to eliminate duplicated accessibility tree traversal code across the screen objects and scenario.