### PR TITLE
fix/ADFA-3234 test harness for offline mode

### DIFF
--- a/preferences/src/main/java/com/itsaky/androidide/preferences/internal/BuildPreferences.kt
+++ b/preferences/src/main/java/com/itsaky/androidide/preferences/internal/BuildPreferences.kt
@@ -67,7 +67,7 @@ object BuildPreferences {
 
 	/** Switch for Gradle `--offline` option. */
 	var isOfflineEnabled: Boolean
-		get() = prefManager.getBoolean(OFFLINE_MODE, false)
+		get() = prefManager.getBoolean(OFFLINE_MODE, true)
 		set(enabled) {
 			prefManager.putBoolean(OFFLINE_MODE, enabled)
 		}


### PR DESCRIPTION
Testing debug apk with offline mode enabled by default for testing whether the 9 out of 10 templates  (except plugin) build offline.