### PR TITLE
ADFA-3761 | Fix Switch widget ID and nearby text assignment

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/LayoutGeometryProcessor.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/LayoutGeometryProcessor.kt
@@ -4,6 +4,7 @@ import android.graphics.Rect
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
 import org.appdevforall.codeonthego.computervision.domain.model.LayoutItem
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -17,6 +18,14 @@ class LayoutGeometryProcessor {
 
     private fun isRadioButton(box: ScaledBox): Boolean =
         box.label == "radio_button_unchecked" || box.label == "radio_button_checked"
+
+    private fun isLabelableWidget(box: ScaledBox): Boolean {
+        return box.label in setOf(
+            "radio_button_unchecked", "radio_button_checked",
+            "checkbox_unchecked", "checkbox_checked",
+            "switch_on", "switch_off"
+        )
+    }
 
     private class LayoutRow(initialBox: ScaledBox) {
         private val _boxes = mutableListOf(initialBox)
@@ -40,7 +49,7 @@ class LayoutGeometryProcessor {
             val verticalOverlap = minOf(box.y + box.h, bottom) - maxOf(box.y, top)
             val minHeight = minOf(box.h, height).coerceAtLeast(1)
             val overlapRatio = verticalOverlap.toFloat() / minHeight.toFloat()
-            val centerDelta = kotlin.math.abs(box.centerY - centerY)
+            val centerDelta = abs(box.centerY - centerY)
             val centerThreshold = max(VERTICAL_ALIGN_THRESHOLD, minHeight / 2)
 
             return overlapRatio >= OVERLAP_THRESHOLD || centerDelta <= centerThreshold
@@ -121,31 +130,6 @@ class LayoutGeometryProcessor {
         )
     }
 
-    private fun mergeRadioLabels(row: List<ScaledBox>): List<ScaledBox> {
-        val merged = mutableListOf<ScaledBox>()
-        var i = 0
-
-        while (i < row.size) {
-            val current = row[i]
-
-            if (isRadioButton(current) && i + 1 < row.size && row[i + 1].label == "text") {
-                val nextText = row[i + 1]
-                merged.add(current.copy(text = nextText.text))
-                i += 2
-            }
-            else if (current.label == "text" && i + 1 < row.size && isRadioButton(row[i + 1])) {
-                val nextRadio = row[i + 1]
-                merged.add(nextRadio.copy(text = current.text))
-                i += 2
-            }
-            else {
-                merged.add(current)
-                i++
-            }
-        }
-        return merged
-    }
-
     internal fun buildLayoutTree(boxes: List<ScaledBox>): List<LayoutItem> {
         val rows = groupIntoRows(boxes)
         val items = mutableListOf<LayoutItem>()
@@ -158,8 +142,7 @@ class LayoutGeometryProcessor {
             }
         }
 
-        rows.forEach { rawRow ->
-            val row = mergeRadioLabels(rawRow)
+        rows.forEach { row ->
             when {
                 row.all { isRadioButton(it) } && row.size == 1 -> verticalRadioRun.add(row.first())
                 row.all { isRadioButton(it) } -> {
@@ -179,5 +162,33 @@ class LayoutGeometryProcessor {
         flushVerticalRadioRun()
 
         return items
+    }
+
+    internal fun assignNearbyTextToWidgets(boxes: List<ScaledBox>, availableTexts: List<ScaledBox>): List<ScaledBox> {
+        val consumedTexts = mutableSetOf<ScaledBox>()
+        val updatedWidgets = mutableMapOf<ScaledBox, ScaledBox>()
+
+        val labelableWidgets = boxes.filter { isLabelableWidget(it) }
+
+        for (widget in labelableWidgets) {
+            val nearbyText = availableTexts.firstOrNull { text ->
+                !consumedTexts.contains(text) &&
+                abs(text.centerY - widget.centerY) < widget.h * 3 &&
+                abs(text.centerX - widget.centerX) < widget.w * 3
+            }
+
+            if (nearbyText != null) {
+                updatedWidgets[widget] = widget.copy(text = nearbyText.text)
+                consumedTexts.add(nearbyText)
+            }
+        }
+
+        return boxes.mapNotNull { box ->
+            when {
+                consumedTexts.contains(box) -> null
+                updatedWidgets.containsKey(box) -> updatedWidgets[box]
+                else -> box
+            }
+        }
     }
 }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/LayoutGeometryProcessor.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/LayoutGeometryProcessor.kt
@@ -171,11 +171,20 @@ class LayoutGeometryProcessor {
         val labelableWidgets = boxes.filter { isLabelableWidget(it) }
 
         for (widget in labelableWidgets) {
-            val nearbyText = availableTexts.firstOrNull { text ->
-                !consumedTexts.contains(text) &&
-                abs(text.centerY - widget.centerY) < widget.h * 3 &&
-                abs(text.centerX - widget.centerX) < widget.w * 3
-            }
+            val nearbyText = availableTexts
+                .asSequence()
+                .filter { !consumedTexts.contains(it) }
+                .filter { text ->
+                    val dx = maxOf(0, widget.rect.left - text.rect.right, text.rect.left - widget.rect.right)
+                    val dy = maxOf(0, widget.rect.top - text.rect.bottom, text.rect.top - widget.rect.bottom)
+
+                    dx < widget.w * 2 && dy < widget.h * 2
+                }
+                .minByOrNull { text ->
+                    val dx = maxOf(0, widget.rect.left - text.rect.right, text.rect.left - widget.rect.right).toDouble()
+                    val dy = maxOf(0, widget.rect.top - text.rect.bottom, text.rect.top - widget.rect.bottom).toDouble()
+                    (dx * dx) + (dy * dy)
+                }
 
             if (nearbyText != null) {
                 updatedWidgets[widget] = widget.copy(text = nearbyText.text)

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverter.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverter.kt
@@ -19,8 +19,8 @@ class YoloToXmlConverter(
         targetDpHeight: Int,
         wrapInScroll: Boolean = true
     ): String {
-        val widgets = detections
-            .filter { it.isYolo && it.label != "widget_tag" }
+        val uiCandidates = detections
+            .filter { (it.isYolo || it.label == "text") && it.label != "widget_tag" }
             .distinctBy {
                 if (it.label.startsWith("switch")) {
                     "${((it.boundingBox.top + it.boundingBox.bottom) / 2f).toInt() / 50}"
@@ -29,12 +29,14 @@ class YoloToXmlConverter(
                 }
             }
 
-        var scaledBoxes = widgets.map { geometryProcessor.scaleDetection(it, sourceImageWidth, sourceImageHeight, targetDpWidth, targetDpHeight) }
+        var scaledBoxes = uiCandidates.map { geometryProcessor.scaleDetection(it, sourceImageWidth, sourceImageHeight, targetDpWidth, targetDpHeight) }
 
         val parents = scaledBoxes.filter { it.label != "text" && !annotationMatcher.isTag(it.text) }
-        val texts = scaledBoxes.filter { it.label == "text" && !annotationMatcher.isTag(it.text) }
+        var texts = scaledBoxes.filter { it.label == "text" && !annotationMatcher.isTag(it.text) }
 
         scaledBoxes = geometryProcessor.assignTextToParents(parents, texts, scaledBoxes)
+        texts = scaledBoxes.filter { it.label == "text" && !annotationMatcher.isTag(it.text) }
+        scaledBoxes = geometryProcessor.assignNearbyTextToWidgets(scaledBoxes, texts)
 
         val uiElements = scaledBoxes.filter { !annotationMatcher.isTag(it.text) }
         val widgetTags = detections.filter { it.label == "widget_tag" || (!it.isYolo && annotationMatcher.isTag(it.text)) }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidWidget.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidWidget.kt
@@ -9,6 +9,8 @@ sealed class AndroidWidget(
 ) {
     abstract val tag: String
 
+    protected open fun fallbackIdLabel(): String = box.label
+
     protected abstract fun specificAttributes(): Map<String, String>
 
     fun render(
@@ -18,7 +20,7 @@ sealed class AndroidWidget(
         idOverride: String? = null
     ) {
         val requestedId = idOverride ?: parsedAttrs["android:id"]?.substringAfterLast('/')
-        val id = context.resolveId(requestedId, box.label)
+        val id = context.resolveId(requestedId, fallbackIdLabel())
         val width = parsedAttrs["android:layout_width"] ?: extraAttrs["android:layout_width"] ?: "wrap_content"
         val height = parsedAttrs["android:layout_height"] ?: extraAttrs["android:layout_height"] ?: "wrap_content"
 
@@ -45,8 +47,9 @@ sealed class AndroidWidget(
         fun create(box: ScaledBox, parsedAttrs: Map<String, String>): AndroidWidget {
             return when (box.label) {
                 "text", "button", "checkbox_unchecked", "checkbox_checked",
-                "radio_button_unchecked", "radio_button_checked", "switch_off", "switch_on" ->
+                "radio_button_unchecked", "radio_button_checked" ->
                     TextBasedWidget(box, parsedAttrs, getTagFor(box.label))
+                "switch_off", "switch_on" -> SwitchWidget(box, parsedAttrs)
                 "text_entry_box" -> InputWidget(box, parsedAttrs)
                 "image_placeholder", "icon" -> ImageWidget(box, parsedAttrs)
                 else -> GenericWidget(box, parsedAttrs, getTagFor(box.label))
@@ -88,6 +91,29 @@ class TextBasedWidget(
         if (box.label.contains("_checked") || box.label.contains("_on")) {
             attrs["android:checked"] = parsedAttrs["android:checked"] ?: "true"
         }
+        return attrs
+    }
+}
+
+class SwitchWidget(
+    box: ScaledBox,
+    parsedAttrs: Map<String, String>
+) : AndroidWidget(box, parsedAttrs) {
+    override val tag = "Switch"
+
+    override fun fallbackIdLabel(): String = "switch"
+
+    override fun specificAttributes(): Map<String, String> {
+        val attrs = mutableMapOf<String, String>()
+        val switchText = parsedAttrs["android:text"] ?: box.text.trim().takeIf { it.isNotEmpty() && it != box.label } ?: "Switch"
+
+        attrs["android:text"] = switchText
+        attrs["tools:ignore"] = "HardcodedText"
+
+        if (box.label.contains("_on")) {
+            attrs["android:checked"] = parsedAttrs["android:checked"] ?: "true"
+        }
+
         return attrs
     }
 }


### PR DESCRIPTION
## Description

Fixed an issue where the generated Switch ID incorrectly contained its state ("on" or "off"). Created a dedicated `SwitchWidget` class that overrides the fallback ID label to simply be "switch". Furthermore, replaced the radio-specific text merging logic with a generic `assignNearbyTextToWidgets` processor to accurately assign surrounding text to switches, checkboxes, and radio buttons based on the original sketch.

## Details

- Added `SwitchWidget` to handle specific switch attributes (like `android:checked` and `android:text`).
- Introduced `isLabelableWidget` and `assignNearbyTextToWidgets` in `LayoutGeometryProcessor` for improved proximity-based text resolution.
- Updated `YoloToXmlConverter` to map nearby text detections to UI candidates before final XML generation.


https://github.com/user-attachments/assets/bf20c5a4-c92a-40b1-8260-30e22ad7d742


## Ticket

[ADFA-3761](https://appdevforall.atlassian.net/browse/ADFA-3761)

## Observation

The new text assignment logic scales better, as it now handles multiple labelable widgets (switches, checkboxes, radios) rather than relying on hardcoded logic solely for radio buttons.

[ADFA-3761]: https://appdevforall.atlassian.net/browse/ADFA-3761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ