### PR TITLE
ADFA-3757 | Fix fuzzy attribute parsing and OCR text assembly

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParser.kt
@@ -26,8 +26,8 @@ object FuzzyAttributeParser {
         TEXT("android:text", listOf("text")),
         HINT("android:hint", listOf("hint")),
         BACKGROUND("android:background", listOf("background", "bg"), ValueType.COLOR),
-        BACKGROUND_TINT("app:backgroundTint", listOf("backgroundtint", "background_tint"), ValueType.COLOR),
-        SRC("android:src", listOf("src", "scr", "sre"), ValueType.DRAWABLE),
+        BACKGROUND_TINT("app:backgroundTint", listOf("backgroundtint", "background_tint", "bg_tint"), ValueType.COLOR),
+        SRC("android:src", listOf("src", "scr", "sre", "5rc"), ValueType.DRAWABLE),
         CONTENT_DESCRIPTION("android:contentDescription", listOf("contentdescription", "content_description")),
 
         TEXT_SIZE("android:textSize", listOf("textsize", "text_size"), ValueType.SP_DIMENSION),
@@ -150,6 +150,7 @@ object FuzzyAttributeParser {
     private val ocrLetterZToTwoRegex = Regex("[zZ]")
     private val ocrLetterSToFiveRegex = Regex("[sS]")
     private val ocrLetterBToSixRegex = Regex("[bB]")
+    private val ocrDenoiseRegex = Regex("inm|rn|wm|nm")
 
     private val matchKeywords = setOf("match", "parent")
     private val wrapKeywords = setOf("wrap", "content", "wrapcan")
@@ -464,11 +465,14 @@ object FuzzyAttributeParser {
             .trimStart('_')
     }
 
-    private fun denoiseOcrIdentifier(value: String): String =
-        value.replace("rn", "m")
-            .replace("wm", "m")
-            .replace("nm", "m")
-            .replace("inm", "im")
+    private fun denoiseOcrIdentifier(value: String): String {
+        return value.replace(ocrDenoiseRegex) { matchResult ->
+            when (matchResult.value) {
+                "inm" -> "im"
+                else -> "m"
+            }
+        }
+    }
 
     private fun cleanDrawable(value: String): String {
         if (value.startsWith("@drawable/")) return value

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParser.kt
@@ -27,7 +27,7 @@ object FuzzyAttributeParser {
         HINT("android:hint", listOf("hint")),
         BACKGROUND("android:background", listOf("background", "bg"), ValueType.COLOR),
         BACKGROUND_TINT("app:backgroundTint", listOf("backgroundtint", "background_tint"), ValueType.COLOR),
-        SRC("android:src", listOf("src", "scr"), ValueType.DRAWABLE),
+        SRC("android:src", listOf("src", "scr", "sre"), ValueType.DRAWABLE),
         CONTENT_DESCRIPTION("android:contentDescription", listOf("contentdescription", "content_description")),
 
         TEXT_SIZE("android:textSize", listOf("textsize", "text_size"), ValueType.SP_DIMENSION),
@@ -74,7 +74,7 @@ object FuzzyAttributeParser {
         LAYOUT_MARGIN_RIGHT("android:layout_marginRight", listOf("layout_marginright", "layout_margin_right", "margin_right"), ValueType.DIMENSION),
 
         LAYOUT_WEIGHT("android:layout_weight", listOf("layout_weight", "weight"), ValueType.FLOAT),
-        LAYOUT_GRAVITY("android:layout_gravity", listOf("layout_gravity")),
+        LAYOUT_GRAVITY("android:layout_gravity", listOf("layout_gravity", "layaut_gravity")),
         GRAVITY("android:gravity", listOf("gravity")),
         ORIENTATION("android:orientation", listOf("orientation")),
 
@@ -419,7 +419,7 @@ object FuzzyAttributeParser {
             .replace(Regex("op$"), "dp")
             .replace(Regex("olp$"), "dp")
 
-        val numericString = fixedUnit.replace(Regex("[a-z]+$"), "")
+        val numericString = fixedUnit.replace("_", "")
         val numericPart = extractOcrNumber(numericString)
 
         if (numericPart != null) return "${numericPart}dp"
@@ -432,7 +432,7 @@ object FuzzyAttributeParser {
             .replace(" ", "")
             .replace(Regex("5p$"), "sp")
 
-        val numericString = fixedUnit.replace(Regex("[a-z]+$"), "")
+        val numericString = fixedUnit.replace("_", "")
         val numericPart = extractOcrNumber(numericString)
 
         if (numericPart != null) return "${numericPart}sp"
@@ -457,7 +457,7 @@ object FuzzyAttributeParser {
     }
 
     private fun cleanId(value: String): String {
-        return value.lowercase()
+        return denoiseOcrIdentifier(value.lowercase())
             .replace(nonAlphanumericRegex, "_")
             .replace(multipleUnderscoresRegex, "_")
             .trimEnd('_')
@@ -467,12 +467,17 @@ object FuzzyAttributeParser {
     private fun denoiseOcrIdentifier(value: String): String =
         value.replace("rn", "m")
             .replace("wm", "m")
+            .replace("nm", "m")
+            .replace("inm", "im")
 
     private fun cleanDrawable(value: String): String {
         if (value.startsWith("@drawable/")) return value
-        val cleaned = value.replace(Regex("[^a-zA-Z0-9_.]"), "")
-            .substringBeforeLast('.')
-            .lowercase()
+
+        var cleaned = value.lowercase()
+            .replace(Regex("\\.(png|jpg|jpeg|webp|xml|svg)$"), "")
+
+        cleaned = cleaned.replace(Regex("[^a-z0-9_]"), "")
+
         return "@drawable/${denoiseOcrIdentifier(cleaned)}"
     }
 

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/RegionOcrProcessor.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/RegionOcrProcessor.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.coroutineScope
 import org.appdevforall.codeonthego.computervision.data.source.OcrSource
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
 import org.appdevforall.codeonthego.computervision.utils.BitmapUtils
+import org.appdevforall.codeonthego.computervision.utils.OcrTextAssembler
 
 class RegionOcrProcessor(
     private val ocrSource: OcrSource,
@@ -69,12 +70,8 @@ class RegionOcrProcessor(
                 try {
                     crop = BitmapUtils.cropRegion(bitmap, component.boundingBox, componentPadding)
                     preprocessed = BitmapUtils.preprocessForOcr(crop)
-                    val text = ocrSource.recognizeText(preprocessed)
-                        .getOrNull()
-                        ?.joinToString(" ") { it.text }
-                        ?.replace("\n", " ")
-                        ?.trim()
-                        ?: ""
+                    val textBlocks = ocrSource.recognizeText(preprocessed).getOrNull()
+                    val text = textBlocks?.let { OcrTextAssembler.extractTextWithTolerance(it) } ?: ""
                     component.copy(text = text)
                 } finally {
                     preprocessed?.recycle()
@@ -124,7 +121,7 @@ class RegionOcrProcessor(
                             ),
                             label = "text",
                             score = 0.99f,
-                            text = line.text.trim(),
+                            text = OcrTextAssembler.joinElementsWithTolerance(line),
                             isYolo = false
                         )
                     }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/OcrTextAssembler.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/OcrTextAssembler.kt
@@ -1,0 +1,44 @@
+package org.appdevforall.codeonthego.computervision.utils
+
+import com.google.mlkit.vision.text.Text
+
+object OcrTextAssembler {
+    const val DEFAULT_SPACE_GAP_TOLERANCE_PX = 15f
+
+    fun extractTextWithTolerance(
+        textBlocks: List<Text.TextBlock>,
+        maxSpaceGap: Float = DEFAULT_SPACE_GAP_TOLERANCE_PX
+    ): String {
+        return textBlocks.joinToString(" ") { block ->
+            block.lines.joinToString(" ") { line ->
+                joinElementsWithTolerance(line, maxSpaceGap)
+            }
+        }.trim()
+    }
+
+    fun joinElementsWithTolerance(line: Text.Line, maxSpaceGap: Float = DEFAULT_SPACE_GAP_TOLERANCE_PX): String {
+        val elements = line.elements.sortedBy { it.boundingBox?.left ?: 0 }
+        if (elements.isEmpty()) return ""
+
+        val builder = StringBuilder()
+        var prevRight = elements.first().boundingBox?.right ?: 0
+        builder.append(elements.first().text)
+
+        for (i in 1 until elements.size) {
+            val current = elements[i]
+            val currentBox = current.boundingBox
+
+            if (currentBox != null) {
+                val gap = currentBox.left - prevRight
+                if (gap > maxSpaceGap) {
+                    builder.append(" ")
+                }
+                prevRight = currentBox.right
+            } else {
+                builder.append(" ")
+            }
+            builder.append(current.text)
+        }
+        return builder.toString().trim()
+    }
+}


### PR DESCRIPTION
## Description

This PR addresses the issue where image placeholder attributes were being incorrectly parsed and concatenated (e.g., `android:src="@drawable/imagelagautgratystart"` and `1dp` instead of `150dp`). The core problem was a combination of overly aggressive text-cleaning regexes and ML Kit misinterpreting handwritten spacing.

To fix this, the `FuzzyAttributeParser` was refined to safely clean dimensions without dropping misread numbers, correctly strip image extensions for drawables, and apply denoise rules to IDs. Additionally, we introduced a custom `OcrTextAssembler` to manually join OCR text elements based on a 15px distance tolerance, preventing the system from merging distinct attributes or splitting single words inappropriately.

## Details

* **Fixed Dimension Parsing:** Removed the aggressive regex in `cleanDimension` and `cleanSpDimension` that truncated numbers if the OCR read a number as a letter (e.g., reading `150dp` as `1sodp` no longer results in `1dp`).
* **Fixed Drawable Parsing:** `cleanDrawable` now explicitly targets known image extensions (`.png`, `.jpg`, etc.) rather than truncating at the last period, preventing issues where OCR hallucinated punctuation destroys the string.
* **Improved Fuzzy Matching:** Added new aliases for `SRC` (`sre`) and `LAYOUT_GRAVITY` (`layaut_gravity`) to handle common OCR misreadings.
* **Enhanced Denoising:** Added `nm` -> `m` and `inm` -> `im` to `denoiseOcrIdentifier`, and applied this denoising to IDs.
* **Text Assembly Tolerance:** Implemented `OcrTextAssembler` to replace ML Kit's default text joining. It calculates the bounding box gap between text elements and only inserts a space if the gap exceeds 15px, preventing run-on strings like `imagelagautgratystart`.


https://github.com/user-attachments/assets/8ee53030-c413-4dff-a0ce-a7b59950bbaa


## Ticket

[ADFA-3757](https://appdevforall.atlassian.net/browse/ADFA-3757)

[ADFA-3757]: https://appdevforall.atlassian.net/browse/ADFA-3757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ