### PR TITLE
ADFA-3755 | Fix Spinner entries OCR parsing and validation

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/AttributeValidator.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/AttributeValidator.kt
@@ -60,7 +60,18 @@ object EntriesValidator : AttributeValidator {
         val hasBrackets = isEnclosedInBrackets(trimmed)
         val content = trimmed.removeSurrounding("[", "]")
 
-        val cleanedItems = content.split(",").map { processItem(it) }
+        val rawItems = content.split(",")
+
+        val isNumericArray = isEntireArrayLikelyNumeric(rawItems)
+
+        val cleanedItems = rawItems.map { item ->
+            val cleanItem = item.trim()
+            if (isNumericArray) {
+                cleanNumberArtifacts(cleanItem)
+            } else {
+                cleanTextArtifacts(cleanItem)
+            }
+        }
 
         val finalString = cleanedItems.joinToString(", ")
         return if (hasBrackets) "[$finalString]" else finalString
@@ -70,20 +81,23 @@ object EntriesValidator : AttributeValidator {
         return text.startsWith("[") && text.endsWith("]")
     }
 
-    private fun processItem(item: String): String {
-        val cleanItem = item.trim()
-        return if (isOcrGarbledNumber(cleanItem)) {
-            cleanNumberArtifacts(cleanItem)
-        } else {
-            cleanTextArtifacts(cleanItem)
+    private fun isEntireArrayLikelyNumeric(items: List<String>): Boolean {
+        if (items.isEmpty()) return false
+        var hasAtLeastOneDigit = false
+
+        for (item in items) {
+            val cleanItem = item.trim()
+            if (cleanItem.isEmpty()) continue
+
+            if (!cleanItem.matches(Regex("^[0-9oOlIzZsSbB\\s]+$"))) {
+                return false
+            }
+            if (cleanItem.any { it.isDigit() }) {
+                hasAtLeastOneDigit = true
+            }
         }
-    }
 
-    private fun isOcrGarbledNumber(text: String): Boolean {
-        val hasDigit = text.any { it.isDigit() }
-        val onlyContainsNumbersAndCommonOcrNoise = text.matches(Regex("^[0-9oOlIzZsSbB\\s]+$"))
-
-        return hasDigit && onlyContainsNumbersAndCommonOcrNoise
+        return hasAtLeastOneDigit
     }
 
     private fun cleanNumberArtifacts(text: String): String {
@@ -93,7 +107,7 @@ object EntriesValidator : AttributeValidator {
             .replace(Regex("[zZ]"), "2")
             .replace(Regex("[sS]"), "5")
             .replace(Regex("[bB]"), "6")
-            .replace(" ", "")
+            .replace(Regex("\\s+"), "")
     }
 
     private fun cleanTextArtifacts(text: String): String {

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/AttributeValidator.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/AttributeValidator.kt
@@ -50,3 +50,53 @@ object SliderStyleValidator : AttributeValidator {
         }
     }
 }
+
+object EntriesValidator : AttributeValidator {
+
+    override fun validate(rawValue: String): String? {
+        val trimmed = rawValue.trim()
+        if (trimmed.startsWith("@")) return trimmed
+
+        val hasBrackets = isEnclosedInBrackets(trimmed)
+        val content = trimmed.removeSurrounding("[", "]")
+
+        val cleanedItems = content.split(",").map { processItem(it) }
+
+        val finalString = cleanedItems.joinToString(", ")
+        return if (hasBrackets) "[$finalString]" else finalString
+    }
+
+    private fun isEnclosedInBrackets(text: String): Boolean {
+        return text.startsWith("[") && text.endsWith("]")
+    }
+
+    private fun processItem(item: String): String {
+        val cleanItem = item.trim()
+        return if (isOcrGarbledNumber(cleanItem)) {
+            cleanNumberArtifacts(cleanItem)
+        } else {
+            cleanTextArtifacts(cleanItem)
+        }
+    }
+
+    private fun isOcrGarbledNumber(text: String): Boolean {
+        val hasDigit = text.any { it.isDigit() }
+        val onlyContainsNumbersAndCommonOcrNoise = text.matches(Regex("^[0-9oOlIzZsSbB\\s]+$"))
+
+        return hasDigit && onlyContainsNumbersAndCommonOcrNoise
+    }
+
+    private fun cleanNumberArtifacts(text: String): String {
+        return text
+            .replace(Regex("[oO]"), "0")
+            .replace(Regex("[lI]"), "1")
+            .replace(Regex("[zZ]"), "2")
+            .replace(Regex("[sS]"), "5")
+            .replace(Regex("[bB]"), "6")
+            .replace(" ", "")
+    }
+
+    private fun cleanTextArtifacts(text: String): String {
+        return text.replace(Regex("\\s+"), " ")
+    }
+}

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/WidgetGrammar.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/WidgetGrammar.kt
@@ -12,7 +12,7 @@ object SpinnerGrammar : WidgetGrammar {
         "android:layout_height" to DimensionValidator,
         "android:id" to PassThroughValidator,
         "android:text" to PassThroughValidator,
-        "android:entries" to PassThroughValidator
+        "tools:entries" to EntriesValidator
     )
 }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where dropdown `entries` were being omitted from the generated XML and corrupted by OCR noise. 
* **What:** Added a custom `EntriesValidator` and updated `SpinnerGrammar`.
* **How:** `SpinnerGrammar` now correctly maps to `tools:entries` instead of `android:entries` to prevent build errors with raw arrays. The new `EntriesValidator` processes the array elements individually, distinguishing between likely numbers and text. It cleans common OCR artifacts (like mistaking 'o' for '0' or 'l' for '1') in numeric data while safely preserving standard text strings and Android resource references (e.g., `@array/items`).
* **Why:** To ensure the generated XML is fully compatible for developers without breaking project compilation, while accurately reflecting the user's sketched data.

## Details

Logic update: Implemented regex-based sanitization for common OCR artifacts specifically targeted at numeric arrays, while preserving standard text words.


https://github.com/user-attachments/assets/f73b4d1e-1cb1-4290-9487-5a151be4768a


## Ticket

[ADFA-3755](https://appdevforall.atlassian.net/browse/ADFA-3755)

Also fixes:
[ADFA-3759](https://appdevforall.atlassian.net/browse/ADFA-3759)

[ADFA-3755]: https://appdevforall.atlassian.net/browse/ADFA-3755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ