### PR TITLE
ADFA-2794 Another attempt to fix all the TimeoutException / unknown finalizer crashes

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -211,6 +211,12 @@ class IDEApplication :
 			return
 		}
 
+		if (isFinalizerWatchdogTimeout(thread, exception)) {
+			logger.warn("Non-fatal: FinalizerWatchdogDaemon timeout (suppressed crash)", exception)
+			Sentry.captureException(exception)
+			return
+		}
+
 		if (isUserUnlocked) {
 			CredentialProtectedApplicationLoader.handleUncaughtException(thread, exception)
 			return
@@ -225,5 +231,11 @@ class IDEApplication :
 			it.className.contains("CleanableResource") ||
 				it.className.contains("PhantomCleanable")
 		}
+	}
+
+	private fun isFinalizerWatchdogTimeout(thread: Thread, exception: Throwable): Boolean {
+		if (exception !is java.util.concurrent.TimeoutException) return false
+		return thread.name.contains("FinalizerWatchdogDaemon") ||
+			exception.stackTrace.any { it.className.contains("Daemons\$FinalizerWatchdogDaemon") }
 	}
 }

--- a/composite-builds/build-deps/java-compiler/src/main/java/com/itsaky/androidide/zipfs2/ZipFileSystem.java
+++ b/composite-builds/build-deps/java-compiler/src/main/java/com/itsaky/androidide/zipfs2/ZipFileSystem.java
@@ -1089,13 +1089,11 @@ public class ZipFileSystem extends FileSystem {
 
     @SuppressWarnings("deprecation")
     protected void finalize() throws IOException {
-        try {
-            close();
-        } catch (Throwable ignored) {
-            // On devices with flaky storage, close() can throw UncheckedIOException
-            // wrapping EIO. Swallow all errors during finalization to prevent
-            // killing the FinalizerDaemon thread.
-        }
+        // No-op: do NOT perform I/O during finalization.
+        // On slow storage, close() can exceed the 10-second FinalizerWatchdogDaemon
+        // timeout, causing a fatal TimeoutException crash (Sentry APPDEVFORALL-E8).
+        // All ZipFileSystems should be closed deterministically via close()/doClose().
+        // The OS reclaims file descriptors at process exit regardless.
     }
 
     // Reads len bytes of data from the specified offset into buf.

--- a/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/ToolTipManager.kt
+++ b/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/ToolTipManager.kt
@@ -97,51 +97,50 @@ object TooltipManager {
             try {
                 val db = SQLiteDatabase.openDatabase(dbPath, null, SQLiteDatabase.OPEN_READONLY)
 
-                var cursor = db.rawQuery(QUERY_LAST_CHANGE, arrayOf())
-                cursor.moveToFirst()
-
-                lastChange = "${cursor.getString(0)} ${cursor.getString(1)}"
-
-                Log.d(TAG, "last change is '${lastChange}'.")
-
-                cursor = db.rawQuery(QUERY_TOOLTIP, arrayOf(tag, category))
-
-                when (cursor.count) {
-                    0 -> throw NoTooltipFoundException(category, tag)
-                    1 -> { /* Expected case, continue processing */
+                db.use { database ->
+                    database.rawQuery(QUERY_LAST_CHANGE, arrayOf()).use { c ->
+                        c.moveToFirst()
+                        lastChange = "${c.getString(0)} ${c.getString(1)}"
                     }
 
-                    else -> throw DatabaseCorruptionException(
-                        "Multiple tooltips found for category='$category', tag='$tag' (found ${cursor.count} rows). " +
-                                "Each category/tag combination should be unique."
+                    Log.d(TAG, "last change is '${lastChange}'.")
+
+                    database.rawQuery(QUERY_TOOLTIP, arrayOf(tag, category)).use { c ->
+                        when (c.count) {
+                            0 -> throw NoTooltipFoundException(category, tag)
+                            1 -> { /* Expected case, continue processing */
+                            }
+
+                            else -> throw DatabaseCorruptionException(
+                                "Multiple tooltips found for category='$category', tag='$tag' (found ${c.count} rows). " +
+                                        "Each category/tag combination should be unique."
+                            )
+                        }
+
+                        c.moveToFirst()
+
+                        rowId = c.getInt(0)
+                        tooltipId = c.getInt(1)
+                        summary = c.getString(2)
+                        detail = c.getString(3)
+                    }
+
+                    database.rawQuery(QUERY_TOOLTIP_BUTTONS, arrayOf(tooltipId.toString())).use { c ->
+                        while (c.moveToNext()) {
+                            buttons.add(
+                                Pair(
+                                    c.getString(0),
+                                    "http://localhost:6174/" + c.getString(1)
+                                )
+                            )
+                        }
+                    }
+
+                    Log.d(
+                        TAG,
+                        "For tooltip ${tooltipId}, retrieved ${buttons.size} buttons. They are $buttons."
                     )
                 }
-
-                cursor.moveToFirst()
-
-                rowId = cursor.getInt(0)
-                tooltipId = cursor.getInt(1)
-                summary = cursor.getString(2)
-                detail = cursor.getString(3)
-
-                cursor = db.rawQuery(QUERY_TOOLTIP_BUTTONS, arrayOf(tooltipId.toString()))
-
-                while (cursor.moveToNext()) {
-                    buttons.add(
-                        Pair(
-                            cursor.getString(0),
-                            "http://localhost:6174/" + cursor.getString(1)
-                        )
-                    )
-                }
-
-                Log.d(
-                    TAG,
-                    "For tooltip ${tooltipId}, retrieved ${buttons.size} buttons. They are $buttons."
-                )
-
-                cursor.close()
-                db.close()
 
             } catch (e: Exception) {
                 Log.e(

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/ColorFragment.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/ColorFragment.java
@@ -85,6 +85,8 @@ public class ColorFragment extends Fragment {
         try (InputStream stream = new FileInputStream(filePath)) {
             colorParser = new ValuesResourceParser(stream, ValuesResourceParser.TAG_COLOR);
             colorList = colorParser.getValuesList();
+        } catch (FileNotFoundException e) {
+            throw e;
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/ColorFragment.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/ColorFragment.java
@@ -36,6 +36,7 @@ import org.appdevforall.codeonthego.layouteditor.utils.SBUtils;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -81,9 +82,12 @@ public class ColorFragment extends Fragment {
      * @param filePath = Current project colors file path;
      */
     public void loadColorsFromXML(String filePath) throws FileNotFoundException {
-        InputStream stream = new FileInputStream(filePath);
-        colorParser = new ValuesResourceParser(stream, ValuesResourceParser.TAG_COLOR);
-        colorList = colorParser.getValuesList();
+        try (InputStream stream = new FileInputStream(filePath)) {
+            colorParser = new ValuesResourceParser(stream, ValuesResourceParser.TAG_COLOR);
+            colorList = colorParser.getValuesList();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     private void setupDialogViews(LayoutValuesItemDialogBinding bind) {

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/StringFragment.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/StringFragment.java
@@ -79,6 +79,8 @@ public class StringFragment extends Fragment {
     try (InputStream stream = new FileInputStream(filePath)) {
       stringParser = new ValuesResourceParser(stream, ValuesResourceParser.TAG_STRING);
       stringList = stringParser.getValuesList();
+    } catch (FileNotFoundException e) {
+      throw e;
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/StringFragment.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/StringFragment.java
@@ -31,6 +31,7 @@ import org.appdevforall.codeonthego.layouteditor.utils.SBUtils;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -75,9 +76,12 @@ public class StringFragment extends Fragment {
    * @param filePath = Current project strings file path;
    */
   public void loadStringsFromXML(String filePath) throws FileNotFoundException {
-    InputStream stream = new FileInputStream(filePath);
-    stringParser = new ValuesResourceParser(stream, ValuesResourceParser.TAG_STRING);
-    stringList = stringParser.getValuesList();
+    try (InputStream stream = new FileInputStream(filePath)) {
+      stringParser = new ValuesResourceParser(stream, ValuesResourceParser.TAG_STRING);
+      stringList = stringParser.getValuesList();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
   }
 
   public void addString() {

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/managers/ValuesManager.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/managers/ValuesManager.java
@@ -5,21 +5,22 @@ import org.appdevforall.codeonthego.layouteditor.tools.ValuesResourceParser;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 
 public class ValuesManager {
 
   public static String getValueFromResources(String tag, String value, String path) {
     String resValueName = value.substring(value.indexOf("/") + 1);
     String result = null;
-    try {
-      ValuesResourceParser parser = new ValuesResourceParser(new FileInputStream(path), tag);
+    try (FileInputStream stream = new FileInputStream(path)) {
+      ValuesResourceParser parser = new ValuesResourceParser(stream, tag);
 
       for (ValuesItem item : parser.getValuesList()) {
         if (item.name.equals(resValueName)) {
           result = item.value;
         }
       }
-    } catch (FileNotFoundException e) {
+    } catch (IOException e) {
       e.printStackTrace();
     }
     return result;

--- a/vectormaster/src/main/java/org/appdevforall/codeonthego/vectormaster/VectorMasterDrawable.java
+++ b/vectormaster/src/main/java/org/appdevforall/codeonthego/vectormaster/VectorMasterDrawable.java
@@ -400,6 +400,14 @@ public class VectorMasterDrawable extends Drawable {
       }
     } catch (XmlPullParserException | IOException e) {
       e.printStackTrace();
+    } finally {
+      if (vectorStream != null) {
+        try {
+          vectorStream.close();
+        } catch (IOException ignored) {
+        }
+        vectorStream = null;
+      }
     }
   }
 

--- a/vectormaster/src/main/java/org/appdevforall/codeonthego/vectormaster/VectorMasterView.java
+++ b/vectormaster/src/main/java/org/appdevforall/codeonthego/vectormaster/VectorMasterView.java
@@ -610,6 +610,14 @@ public class VectorMasterView extends View {
       }
     } catch (XmlPullParserException | IOException e) {
       e.printStackTrace();
+    } finally {
+      if (vectorStream != null) {
+        try {
+          vectorStream.close();
+        } catch (IOException ignored) {
+        }
+        vectorStream = null;
+      }
     }
   }
 


### PR DESCRIPTION
Regarding [APPDEVFORALL-E8](https://appdevforall-inc-9p.sentry.io/issues/7255927987/events/0f23a8e8f3834a41afa80a9552289a80/?project=4506663030751232&referrer=previous-event) in Sentry...

1. ZipFileSystem.java — Neutered finalize() to a no-op. This was the most likely culprit: its close() does heavy I/O (sync, channel close, inflater/deflater cleanup) that can exceed the 10s watchdog timeout on slow storage.
2. ToolTipManager.kt — Rewrote cursor handling to use .use {} blocks. Previously, 3 cursors shared one variable — the first two were overwritten without closing, left for GC with their finalize() methods.
3. VectorMasterView.java + VectorMasterDrawable.java — Added finally blocks to close vectorStream (FileInputStream) after XML parsing. FileInputStream.finalize() calls close() and is a known source of finalizer pressure on Android.
4. StringFragment.java + ColorFragment.java + ValuesManager.java — Wrapped FileInputStream in try-with-resources. Same leak pattern.

Bonus!

5. IDEApplication.kt — Added isFinalizerWatchdogTimeout() predicate that detects TimeoutException from the FinalizerWatchdogDaemon thread. When matched, it logs a warning, reports to Sentry as non-fatal, and returns without crashing. This catches any remaining finalizer timeouts from framework/third-party code we don't control. Other organizations do this quite commonly.