### PR TITLE
ADFA-3736 | Ignore canvas metadata and fix attribute parsing

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
@@ -1,6 +1,7 @@
 package org.appdevforall.codeonthego.computervision.domain
 
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+import org.appdevforall.codeonthego.computervision.utils.MetadataDetector
 import kotlin.math.abs
 
 object MarginAnnotationParser {
@@ -38,6 +39,10 @@ object MarginAnnotationParser {
         leftGuidePct: Float,
         rightGuidePct: Float
     ): Pair<List<DetectionResult>, Map<String, String>> {
+        val sanitizedDetections = detections.filterNot { detection ->
+            MetadataDetector.isMetadataDetection(detection.label, detection.text)
+        }
+
         val leftMarginPx = imageWidth * leftGuidePct
         val rightMarginPx = imageWidth * rightGuidePct
 
@@ -45,7 +50,7 @@ object MarginAnnotationParser {
         val leftMarginDetections = mutableListOf<DetectionResult>()
         val rightMarginDetections = mutableListOf<DetectionResult>()
 
-        for (detection in detections) {
+        for (detection in sanitizedDetections) {
             val centerX = centerX(detection)
             when {
                 centerX > leftMarginPx && centerX < rightMarginPx -> canvasDetections.add(detection)
@@ -72,8 +77,7 @@ object MarginAnnotationParser {
     private data class ParsedBlock(
         val tag: String?,
         val annotationText: String,
-        val centerY: Float,
-        val lineCount: Int
+        val centerY: Float
     )
 
     private fun parseMarginGroup(
@@ -88,13 +92,13 @@ object MarginAnnotationParser {
         val gapBlocks = clusterIntoBlocks(sorted)
         val refinedBlocks = gapBlocks.flatMap { splitAtTags(it, validPrefixes) }
 
-        val parsedBlocks = refinedBlocks.mapIndexed { _, block ->
+        val parsedBlocks = refinedBlocks.map { block ->
             val result = parseBlock(block)
             val centerY = block.map { centerY(it) }.average().toFloat()
             val annotationText = result?.second
                 ?: block.joinToString(" ") { it.text.trim() }.trim()
 
-            ParsedBlock(result?.first, annotationText, centerY, block.size)
+            ParsedBlock(result?.first, annotationText, centerY)
         }
 
         val annotationMap = mutableMapOf<String, String>()
@@ -106,14 +110,22 @@ object MarginAnnotationParser {
             }
 
         val explicitBlocks = parsedBlocks
-            .filter { it.tag != null && it.annotationText.isNotBlank() }
+            .filter {
+                it.tag != null &&
+                    it.annotationText.isNotBlank() &&
+                    !MetadataDetector.isCanvasMetadata(it.annotationText)
+            }
 
         val implicitBlocks = parsedBlocks
-            .filter { it.tag == null && it.annotationText.length >= 5 }
+            .filter {
+                it.tag == null &&
+                    it.annotationText.length >= 5 &&
+                    !MetadataDetector.isCanvasMetadata(it.annotationText)
+            }
 
         for (block in explicitBlocks) {
             val tag = block.tag ?: continue
-            if (canvasTags.isEmpty() || canvasTags.any { (canvasTag, _) -> canvasTag == tag }) {
+            if (canvasTags.any { (canvasTag, _) -> canvasTag == tag }) {
                 annotationMap[tag] = block.annotationText
             }
         }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetAnnotationMatcher.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetAnnotationMatcher.kt
@@ -5,7 +5,7 @@ import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
 class WidgetAnnotationMatcher {
     companion object {
         private val TAG_REGEX = Regex("^(?i)(B|P|D|T|C|R|SW|S)-\\d+$")
-        private val TAG_EXTRACT_REGEX = Regex("^(?i)(SW|S\\s*8|8\\s*W|[BPDTCRS8]\\s*W?)[^a-zA-Z0-9]*([\\dlIoO!]+)$")
+        private val TAG_EXTRACT_REGEX = Regex("^(?i)(SW|S\\s*8|8\\s*W|[BPDTCRS8]\\s*W?)[^a-zA-Z0-9]*([\\dlIoO!]+)(?:\\s+(.+))?$")
     }
 
     internal fun matchAnnotationsToElements(
@@ -25,6 +25,7 @@ class WidgetAnnotationMatcher {
                 val widgetType = getTagType(normalizedTag) ?: return@mapNotNull null
 
                 val matchingTagBox = deduplicatedTags.find { normalizeTagText(it.text) == normalizedTag }
+                    ?: return@mapNotNull null
 
                 TaggedAnnotation(
                     normalizedTag = normalizedTag,

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverter.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/YoloToXmlConverter.kt
@@ -2,6 +2,7 @@ package org.appdevforall.codeonthego.computervision.domain
 
 import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
 import org.appdevforall.codeonthego.computervision.domain.xml.AndroidXmlGenerator
+import org.appdevforall.codeonthego.computervision.utils.MetadataDetector
 import kotlin.comparisons.compareBy
 
 class YoloToXmlConverter(
@@ -21,6 +22,7 @@ class YoloToXmlConverter(
     ): Pair<String, String> {
         val uiCandidates = detections
             .filter { (it.isYolo || it.label == "text") && it.label != "widget_tag" }
+            .filterNot { MetadataDetector.isMetadataDetection(it.label, it.text) }
             .distinctBy {
                 if (it.label.startsWith("switch")) {
                     "${((it.boundingBox.top + it.boundingBox.bottom) / 2f).toInt() / 50}"
@@ -38,7 +40,9 @@ class YoloToXmlConverter(
         texts = scaledBoxes.filter { it.label == "text" && !annotationMatcher.isTag(it.text) }
         scaledBoxes = geometryProcessor.assignNearbyTextToWidgets(scaledBoxes, texts)
 
-        val uiElements = scaledBoxes.filter { !annotationMatcher.isTag(it.text) }
+        val uiElements = scaledBoxes.filter {
+            !annotationMatcher.isTag(it.text) && !MetadataDetector.isMetadataDetection(it.label, it.text)
+        }
         val widgetTags = detections.filter { it.label == "widget_tag" || (!it.isYolo && annotationMatcher.isTag(it.text)) }
         val canvasTags = widgetTags.map { geometryProcessor.scaleDetection(it, sourceImageWidth, sourceImageHeight, targetDpWidth, targetDpHeight) }
 

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/MetadataDetector.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/MetadataDetector.kt
@@ -1,0 +1,55 @@
+package org.appdevforall.codeonthego.computervision.utils
+
+object MetadataDetector {
+    private val metadataSnippets = listOf(
+        "<?xml",
+        "xmlns:",
+        "<linearlayout",
+        "<scrollview",
+        "<button",
+        "<switch",
+        "<view",
+        "android:",
+        "app:",
+        "tools:",
+        "/>"
+    )
+
+    private val metadataKeywords = listOf(
+        "layout_width",
+        "layout_height",
+        "layout_margin",
+        "layout_gravity",
+        "textstyle",
+        "textcolor",
+        "textsize",
+        "padding",
+        "orientation",
+        "baselinealigned",
+        "match_parent",
+        "wrap_content"
+    )
+
+    private val xmlAttributeRegex = Regex("""\b(?:android|app|tools):[a-zA-Z_]+\b""")
+    private val assignmentRegex = Regex("""\b[a-zA-Z_]+(?:[:=])[^\s]+""")
+
+    fun isCanvasMetadata(text: String): Boolean {
+        val lowerText = text.lowercase()
+        if (lowerText.isBlank()) return false
+        if (metadataSnippets.any { snippet -> lowerText.contains(snippet) }) return true
+        if (xmlAttributeRegex.containsMatchIn(lowerText)) return true
+        if (metadataKeywords.any { keyword -> lowerText.contains(keyword) }) return true
+
+        val assignmentCount = assignmentRegex.findAll(lowerText).count()
+        return assignmentCount >= 2
+    }
+
+    fun isMetadataLabel(label: String): Boolean {
+        val normalized = label.trim().lowercase()
+        return normalized == "margin_metadata" || normalized.contains("metadata")
+    }
+
+    fun isMetadataDetection(label: String, text: String): Boolean {
+        return isMetadataLabel(label) || isCanvasMetadata(text)
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes an issue where margin and layout metadata present in the canvas areas were being incorrectly detected as text and included in the generated XML code, causing attribute mix-ups. It introduces a `METADATA_KEYWORDS` list to actively filter out these layout properties and updates the regex and validation logic to correctly parse widget tags and array attributes. 

## Details

Logic updates only. YOLO text detections matching canvas metadata (e.g., `layout_width`, `match_parent`, `wrap_content`) are now successfully filtered out in `YoloToXmlConverter`. 


https://github.com/user-attachments/assets/901523a4-36ff-4015-832d-719c54dcde4a


## Ticket

[ADFA-3736](https://appdevforall.atlassian.net/browse/ADFA-3736)

## Observation

In addition to the metadata filtering, `AttributeValidator` was updated to more aggressively strip various enclosing bracket types (e.g., `(`, `{`, `<`) before standardizing the final string array output to use square brackets `[ ]`. `android:background` and `app:backgroundTint` were also added as pass-through validators in `WidgetGrammar`.

[ADFA-3736]: https://appdevforall.atlassian.net/browse/ADFA-3736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ