### PR TITLE
ADFA-3822 Fix race condition and add DB guard for LSP indexing

### DIFF
--- a/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/SQLiteIndex.kt
+++ b/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/SQLiteIndex.kt
@@ -9,6 +9,7 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.appdevforall.codeonthego.indexing.api.Index
+import java.util.concurrent.atomic.AtomicBoolean
 import org.appdevforall.codeonthego.indexing.api.IndexDescriptor
 import org.appdevforall.codeonthego.indexing.api.IndexQuery
 import org.appdevforall.codeonthego.indexing.api.Indexable
@@ -71,6 +72,7 @@ class SQLiteIndex<T : Indexable>(
         .filter { it.prefixSearchable }
         .associate { it.name to "f_${it.name}_lower" }
 
+    private val closed = AtomicBoolean(false)
     private val db: SupportSQLiteDatabase
 
     init {
@@ -103,6 +105,7 @@ class SQLiteIndex<T : Indexable>(
     }
 
     override fun query(query: IndexQuery): Sequence<T> {
+        if (closed.get()) return emptySequence()
         val (sql, args) = buildSelectQuery(query)
         val cursor = db.query(sql, args.toTypedArray())
         return cursor.use {
@@ -116,6 +119,7 @@ class SQLiteIndex<T : Indexable>(
     }
 
     override suspend fun get(key: String): T? = withContext(Dispatchers.IO) {
+        if (closed.get()) return@withContext null
         val cursor = db.query(
             "SELECT _payload FROM $tableName WHERE _key = ? LIMIT 1",
             arrayOf(key),
@@ -129,6 +133,7 @@ class SQLiteIndex<T : Indexable>(
 
     override suspend fun containsSource(sourceId: String): Boolean =
         withContext(Dispatchers.IO) {
+            if (closed.get()) return@withContext false
             val cursor = db.query(
                 "SELECT 1 FROM $tableName WHERE _source_id = ? LIMIT 1",
                 arrayOf(sourceId),
@@ -137,6 +142,7 @@ class SQLiteIndex<T : Indexable>(
         }
 
     override fun distinctValues(fieldName: String): Sequence<String> {
+        if (closed.get()) return emptySequence()
         val col = fieldColumns[fieldName]
             ?: throw IllegalArgumentException("Unknown field: $fieldName")
         val cursor = db.query("SELECT DISTINCT $col FROM $tableName WHERE $col IS NOT NULL")
@@ -150,6 +156,7 @@ class SQLiteIndex<T : Indexable>(
     }
 
     override suspend fun insertAll(entries: Sequence<T>) = withContext(Dispatchers.IO) {
+        if (closed.get()) return@withContext
         val batch = mutableListOf<T>()
         for (entry in entries) {
             batch.add(entry)
@@ -164,22 +171,27 @@ class SQLiteIndex<T : Indexable>(
     }
 
     override suspend fun insert(entry: T) = withContext(Dispatchers.IO) {
+        if (closed.get()) return@withContext
         insertBatch(listOf(entry))
     }
 
     override suspend fun removeBySource(sourceId: String) = withContext(Dispatchers.IO) {
+        if (closed.get()) return@withContext
         db.execSQL("DELETE FROM $tableName WHERE _source_id = ?", arrayOf(sourceId))
     }
 
     override suspend fun clear() = withContext(Dispatchers.IO) {
+        if (closed.get()) return@withContext
         db.execSQL("DELETE FROM $tableName")
     }
 
     override fun close() {
+        if (closed.getAndSet(true)) return
         db.close()
     }
 
     suspend fun size(): Int = withContext(Dispatchers.IO) {
+        if (closed.get()) return@withContext 0
         val cursor = db.query("SELECT COUNT(*) FROM $tableName")
         cursor.use { if (it.moveToFirst()) it.getInt(0) else 0 }
     }
@@ -225,6 +237,7 @@ class SQLiteIndex<T : Indexable>(
     }
 
     private fun insertBatch(entries: List<T>) {
+        if (closed.get()) return
         db.beginTransaction()
         try {
             for (entry in entries) {

--- a/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/SQLiteIndex.kt
+++ b/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/SQLiteIndex.kt
@@ -167,17 +167,17 @@ class SQLiteIndex<T : Indexable>(
         for (entry in entries) {
             batch.add(entry)
             if (batch.size >= batchSize) {
-                ifOpen { insertBatch(batch) }
+                ifOpen { insertBatchLocked(batch) }
                 batch.clear()
             }
         }
         if (batch.isNotEmpty()) {
-            ifOpen { insertBatch(batch) }
+            ifOpen { insertBatchLocked(batch) }
         }
     }
 
     override suspend fun insert(entry: T) = withContext(Dispatchers.IO) {
-        ifOpen { insertBatch(listOf(entry)) }
+        ifOpen { insertBatchLocked(listOf(entry)) }
     }
 
     override suspend fun removeBySource(sourceId: String) = withContext(Dispatchers.IO) {
@@ -251,7 +251,7 @@ class SQLiteIndex<T : Indexable>(
         }
     }
 
-    private fun insertBatch(entries: List<T>) {
+    private fun insertBatchLocked(entries: List<T>) {
         db.beginTransaction()
         try {
             for (entry in entries) {

--- a/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/SQLiteIndex.kt
+++ b/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/SQLiteIndex.kt
@@ -9,7 +9,9 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.appdevforall.codeonthego.indexing.api.Index
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
 import org.appdevforall.codeonthego.indexing.api.IndexDescriptor
 import org.appdevforall.codeonthego.indexing.api.IndexQuery
 import org.appdevforall.codeonthego.indexing.api.Indexable
@@ -72,7 +74,8 @@ class SQLiteIndex<T : Indexable>(
         .filter { it.prefixSearchable }
         .associate { it.name to "f_${it.name}_lower" }
 
-    private val closed = AtomicBoolean(false)
+    private val lock = ReentrantReadWriteLock()
+    @Volatile private var closed = false
     private val db: SupportSQLiteDatabase
 
     init {
@@ -104,11 +107,10 @@ class SQLiteIndex<T : Indexable>(
         createTable(db)
     }
 
-    override fun query(query: IndexQuery): Sequence<T> {
-        if (closed.get()) return emptySequence()
+    override fun query(query: IndexQuery): Sequence<T> = ifOpen(emptySequence()) {
         val (sql, args) = buildSelectQuery(query)
         val cursor = db.query(sql, args.toTypedArray())
-        return cursor.use {
+        cursor.use {
             val payloadIdx = it.getColumnIndexOrThrow("_payload")
             buildList {
                 while (it.moveToNext()) {
@@ -119,34 +121,35 @@ class SQLiteIndex<T : Indexable>(
     }
 
     override suspend fun get(key: String): T? = withContext(Dispatchers.IO) {
-        if (closed.get()) return@withContext null
-        val cursor = db.query(
-            "SELECT _payload FROM $tableName WHERE _key = ? LIMIT 1",
-            arrayOf(key),
-        )
-        cursor.use {
-            if (it.moveToFirst()) {
-                descriptor.deserialize(it.getBlob(0))
-            } else null
+        ifOpen(null) {
+            val cursor = db.query(
+                "SELECT _payload FROM $tableName WHERE _key = ? LIMIT 1",
+                arrayOf(key),
+            )
+            cursor.use {
+                if (it.moveToFirst()) {
+                    descriptor.deserialize(it.getBlob(0))
+                } else null
+            }
         }
     }
 
     override suspend fun containsSource(sourceId: String): Boolean =
         withContext(Dispatchers.IO) {
-            if (closed.get()) return@withContext false
-            val cursor = db.query(
-                "SELECT 1 FROM $tableName WHERE _source_id = ? LIMIT 1",
-                arrayOf(sourceId),
-            )
-            cursor.use { it.moveToFirst() }
+            ifOpen(false) {
+                val cursor = db.query(
+                    "SELECT 1 FROM $tableName WHERE _source_id = ? LIMIT 1",
+                    arrayOf(sourceId),
+                )
+                cursor.use { it.moveToFirst() }
+            }
         }
 
-    override fun distinctValues(fieldName: String): Sequence<String> {
-        if (closed.get()) return emptySequence()
+    override fun distinctValues(fieldName: String): Sequence<String> = ifOpen(emptySequence()) {
         val col = fieldColumns[fieldName]
             ?: throw IllegalArgumentException("Unknown field: $fieldName")
         val cursor = db.query("SELECT DISTINCT $col FROM $tableName WHERE $col IS NOT NULL")
-        return cursor.use {
+        cursor.use {
             buildList {
                 while (it.moveToNext()) {
                     add(it.getString(0))
@@ -156,44 +159,51 @@ class SQLiteIndex<T : Indexable>(
     }
 
     override suspend fun insertAll(entries: Sequence<T>) = withContext(Dispatchers.IO) {
-        if (closed.get()) return@withContext
         val batch = mutableListOf<T>()
         for (entry in entries) {
             batch.add(entry)
             if (batch.size >= batchSize) {
-                insertBatch(batch)
+                ifOpen { insertBatch(batch) }
                 batch.clear()
             }
         }
         if (batch.isNotEmpty()) {
-            insertBatch(batch)
+            ifOpen { insertBatch(batch) }
         }
     }
 
     override suspend fun insert(entry: T) = withContext(Dispatchers.IO) {
-        if (closed.get()) return@withContext
-        insertBatch(listOf(entry))
+        ifOpen { insertBatch(listOf(entry)) }
     }
 
     override suspend fun removeBySource(sourceId: String) = withContext(Dispatchers.IO) {
-        if (closed.get()) return@withContext
-        db.execSQL("DELETE FROM $tableName WHERE _source_id = ?", arrayOf(sourceId))
+        ifOpen { db.execSQL("DELETE FROM $tableName WHERE _source_id = ?", arrayOf(sourceId)) }
     }
 
     override suspend fun clear() = withContext(Dispatchers.IO) {
-        if (closed.get()) return@withContext
-        db.execSQL("DELETE FROM $tableName")
+        ifOpen { db.execSQL("DELETE FROM $tableName") }
     }
 
     override fun close() {
-        if (closed.getAndSet(true)) return
-        db.close()
+        lock.write {
+            if (closed) return
+            closed = true
+            db.close()
+        }
+    }
+
+    private inline fun <R> ifOpen(default: R, block: () -> R): R =
+        lock.read { if (closed) default else block() }
+
+    private inline fun ifOpen(block: () -> Unit) {
+        lock.read { if (!closed) block() }
     }
 
     suspend fun size(): Int = withContext(Dispatchers.IO) {
-        if (closed.get()) return@withContext 0
-        val cursor = db.query("SELECT COUNT(*) FROM $tableName")
-        cursor.use { if (it.moveToFirst()) it.getInt(0) else 0 }
+        ifOpen(0) {
+            val cursor = db.query("SELECT COUNT(*) FROM $tableName")
+            cursor.use { if (it.moveToFirst()) it.getInt(0) else 0 }
+        }
     }
 
     private fun createTable(db: SupportSQLiteDatabase) {
@@ -237,7 +247,6 @@ class SQLiteIndex<T : Indexable>(
     }
 
     private fun insertBatch(entries: List<T>) {
-        if (closed.get()) return
         db.beginTransaction()
         try {
             for (entry in entries) {

--- a/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/SQLiteIndex.kt
+++ b/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/SQLiteIndex.kt
@@ -3,6 +3,7 @@ package org.appdevforall.codeonthego.indexing
 import android.content.ContentValues
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
+import android.os.Looper
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
@@ -15,6 +16,7 @@ import org.appdevforall.codeonthego.indexing.api.Index
 import org.appdevforall.codeonthego.indexing.api.IndexDescriptor
 import org.appdevforall.codeonthego.indexing.api.IndexQuery
 import org.appdevforall.codeonthego.indexing.api.Indexable
+import org.slf4j.LoggerFactory
 import kotlin.collections.iterator
 
 /**
@@ -61,6 +63,10 @@ class SQLiteIndex<T : Indexable>(
     override val name: String = "sqlite:${descriptor.name}",
     private val batchSize: Int = 500,
 ) : Index<T> {
+    companion object {
+        private val log = LoggerFactory.getLogger(SQLiteIndex::class.java)
+    }
+
 
     private val tableName = descriptor.name.replace(Regex("[^a-zA-Z0-9_]"), "_")
 
@@ -189,6 +195,11 @@ class SQLiteIndex<T : Indexable>(
     }
 
     override fun close() {
+        if (Looper.getMainLooper() == Looper.myLooper()) {
+            log.warn(
+                "SQLiteIndex.close() called on the main thread; waiting on mutex and closing db may block and cause ANR"
+            )
+        }
         runBlocking {
             mutex.withLock {
                 if (closed) return@withLock

--- a/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/SQLiteIndex.kt
+++ b/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/SQLiteIndex.kt
@@ -7,11 +7,11 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.appdevforall.codeonthego.indexing.api.Index
-import java.util.concurrent.locks.ReentrantReadWriteLock
-import kotlin.concurrent.read
-import kotlin.concurrent.write
 import org.appdevforall.codeonthego.indexing.api.IndexDescriptor
 import org.appdevforall.codeonthego.indexing.api.IndexQuery
 import org.appdevforall.codeonthego.indexing.api.Indexable
@@ -74,7 +74,7 @@ class SQLiteIndex<T : Indexable>(
         .filter { it.prefixSearchable }
         .associate { it.name to "f_${it.name}_lower" }
 
-    private val lock = ReentrantReadWriteLock()
+    private val mutex = Mutex()
     @Volatile private var closed = false
     private val db: SupportSQLiteDatabase
 
@@ -107,17 +107,19 @@ class SQLiteIndex<T : Indexable>(
         createTable(db)
     }
 
-    override fun query(query: IndexQuery): Sequence<T> = ifOpen(emptySequence()) {
-        val (sql, args) = buildSelectQuery(query)
-        val cursor = db.query(sql, args.toTypedArray())
-        cursor.use {
-            val payloadIdx = it.getColumnIndexOrThrow("_payload")
-            buildList {
-                while (it.moveToNext()) {
-                    add(descriptor.deserialize(it.getBlob(payloadIdx)))
+    override fun query(query: IndexQuery): Sequence<T> = runBlocking {
+        ifOpen(emptySequence()) {
+            val (sql, args) = buildSelectQuery(query)
+            val cursor = db.query(sql, args.toTypedArray())
+            cursor.use {
+                val payloadIdx = it.getColumnIndexOrThrow("_payload")
+                buildList {
+                    while (it.moveToNext()) {
+                        add(descriptor.deserialize(it.getBlob(payloadIdx)))
+                    }
                 }
-            }
-        }.asSequence()
+            }.asSequence()
+        }
     }
 
     override suspend fun get(key: String): T? = withContext(Dispatchers.IO) {
@@ -145,17 +147,19 @@ class SQLiteIndex<T : Indexable>(
             }
         }
 
-    override fun distinctValues(fieldName: String): Sequence<String> = ifOpen(emptySequence()) {
-        val col = fieldColumns[fieldName]
-            ?: throw IllegalArgumentException("Unknown field: $fieldName")
-        val cursor = db.query("SELECT DISTINCT $col FROM $tableName WHERE $col IS NOT NULL")
-        cursor.use {
-            buildList {
-                while (it.moveToNext()) {
-                    add(it.getString(0))
+    override fun distinctValues(fieldName: String): Sequence<String> = runBlocking {
+        ifOpen(emptySequence()) {
+            val col = fieldColumns[fieldName]
+                ?: throw IllegalArgumentException("Unknown field: $fieldName")
+            val cursor = db.query("SELECT DISTINCT $col FROM $tableName WHERE $col IS NOT NULL")
+            cursor.use {
+                buildList {
+                    while (it.moveToNext()) {
+                        add(it.getString(0))
+                    }
                 }
-            }
-        }.asSequence()
+            }.asSequence()
+        }
     }
 
     override suspend fun insertAll(entries: Sequence<T>) = withContext(Dispatchers.IO) {
@@ -185,19 +189,20 @@ class SQLiteIndex<T : Indexable>(
     }
 
     override fun close() {
-        lock.write {
-            if (closed) return
-            closed = true
-            db.close()
+        runBlocking {
+            mutex.withLock {
+                if (closed) return@withLock
+                closed = true
+                db.close()
+            }
         }
     }
 
-    private inline fun <R> ifOpen(default: R, block: () -> R): R =
-        lock.read { if (closed) default else block() }
+    private suspend inline fun <R> ifOpen(default: R, crossinline block: () -> R): R =
+        mutex.withLock { if (closed) default else block() }
 
-    private inline fun ifOpen(block: () -> Unit) {
-        lock.read { if (!closed) block() }
-    }
+    private suspend inline fun ifOpen(crossinline block: () -> Unit) =
+        mutex.withLock { if (!closed) block() }
 
     suspend fun size(): Int = withContext(Dispatchers.IO) {
         ifOpen(0) {

--- a/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/util/BackgroundIndexer.kt
+++ b/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/util/BackgroundIndexer.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
@@ -163,7 +164,7 @@ class BackgroundIndexer<T : Indexable>(
     val activeJobCount: Int get() = activeJobs.size
 
     override fun close() {
-        activeJobs.values.forEach { it.cancel() }
+        scope.cancel("BackgroundIndexer closed")
         activeJobs.clear()
     }
 }

--- a/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/util/BackgroundIndexer.kt
+++ b/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/util/BackgroundIndexer.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.appdevforall.codeonthego.indexing.api.Index
 import org.appdevforall.codeonthego.indexing.api.Indexable
 import org.slf4j.LoggerFactory
@@ -52,6 +53,7 @@ class BackgroundIndexer<T : Indexable>(
 
     companion object {
         private val log = LoggerFactory.getLogger(BackgroundIndexer::class.java)
+        private const val CLOSE_TIMEOUT_MS = 5_000L
     }
 
     var progressListener: IndexingProgressListener? = null
@@ -165,7 +167,15 @@ class BackgroundIndexer<T : Indexable>(
     val activeJobCount: Int get() = activeJobs.size
 
     override fun close() {
-        runBlocking { job.cancelAndJoin() }
+        runBlocking {
+            val completed = withTimeoutOrNull(CLOSE_TIMEOUT_MS) {
+                job.cancelAndJoin()
+            }
+            if (completed == null) {
+                log.warn("Indexer close timed out after {}ms, force-cancelling", CLOSE_TIMEOUT_MS)
+                job.cancel()
+            }
+        }
         activeJobs.clear()
     }
 }

--- a/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/util/BackgroundIndexer.kt
+++ b/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/util/BackgroundIndexer.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeoutOrNull
 import org.appdevforall.codeonthego.indexing.api.Index
 import org.appdevforall.codeonthego.indexing.api.Indexable
 import org.slf4j.LoggerFactory
@@ -53,7 +52,6 @@ class BackgroundIndexer<T : Indexable>(
 
     companion object {
         private val log = LoggerFactory.getLogger(BackgroundIndexer::class.java)
-        private const val CLOSE_TIMEOUT_MS = 5_000L
     }
 
     var progressListener: IndexingProgressListener? = null
@@ -167,14 +165,15 @@ class BackgroundIndexer<T : Indexable>(
     val activeJobCount: Int get() = activeJobs.size
 
     override fun close() {
+        val activeCount = activeJobCount
+        if (activeCount > 0) {
+            log.warn(
+                "Closing indexer with {} active job(s); cancellation is cooperative and close will wait for completion",
+                activeCount,
+            )
+        }
         runBlocking {
-            val completed = withTimeoutOrNull(CLOSE_TIMEOUT_MS) {
-                job.cancelAndJoin()
-            }
-            if (completed == null) {
-                log.warn("Indexer close timed out after {}ms, force-cancelling", CLOSE_TIMEOUT_MS)
-                job.cancel()
-            }
+            job.cancelAndJoin()
         }
         activeJobs.clear()
     }

--- a/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/util/BackgroundIndexer.kt
+++ b/lsp/indexing/src/main/kotlin/org/appdevforall/codeonthego/indexing/util/BackgroundIndexer.kt
@@ -5,11 +5,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.appdevforall.codeonthego.indexing.api.Index
 import org.appdevforall.codeonthego.indexing.api.Indexable
 import org.slf4j.LoggerFactory
@@ -44,10 +44,11 @@ sealed class IndexingEvent {
  */
 class BackgroundIndexer<T : Indexable>(
     private val index: Index<T>,
-    private val scope: CoroutineScope = CoroutineScope(
-        SupervisorJob() + Dispatchers.Default
-    ),
+    parentScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
 ) : Closeable {
+
+    private val job = SupervisorJob(parentScope.coroutineContext[Job])
+    private val scope = CoroutineScope(parentScope.coroutineContext + job)
 
     companion object {
         private val log = LoggerFactory.getLogger(BackgroundIndexer::class.java)
@@ -164,7 +165,7 @@ class BackgroundIndexer<T : Indexable>(
     val activeJobCount: Int get() = activeJobs.size
 
     override fun close() {
-        scope.cancel("BackgroundIndexer closed")
+        runBlocking { job.cancelAndJoin() }
         activeJobs.clear()
     }
 }

--- a/lsp/jvm-symbol-index/src/main/kotlin/org/appdevforall/codeonthego/indexing/jvm/JvmSymbolIndex.kt
+++ b/lsp/jvm-symbol-index/src/main/kotlin/org/appdevforall/codeonthego/indexing/jvm/JvmSymbolIndex.kt
@@ -139,11 +139,7 @@ class JvmSymbolIndex(
 	suspend fun awaitIndexing() = indexer.awaitAll()
 
 	override fun close() {
-		super.close()
-		if (backing is AutoCloseable) {
-			backing.close()
-		}
-
 		indexer.close()
+		super.close()
 	}
 }


### PR DESCRIPTION
Fix for Sentry APPDEVFORALL-S6

  1. SQLiteIndex.kt — Added AtomicBoolean closed guard to all DB operations. close() uses getAndSet(true) to prevent double-close. Operations on a closed DB return early (null/empty/no-op) instead of crashing.
  2. JvmSymbolIndex.kt — Fixed close ordering: indexer is now cancelled before super.close() closes the database. Removed the redundant backing.close() call (already handled by FilteredIndex.close()).
  3. BackgroundIndexer.kt — close() now cancels the entire coroutine scope (not just individual jobs), which also prevents new jobs from being launched after close.