### PR TITLE
ADFA-3828 Fix 3 StrictMode violations

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/OnboardingActivity.kt
@@ -249,10 +249,14 @@ class OnboardingActivity : AppIntro2() {
 		checkToolsIsInstalled() &&
 				PermissionsHelper.areAllPermissionsGranted(this)
 
+	internal fun navigateToMain() {
+		startActivity(Intent(this, MainActivity::class.java))
+		finish()
+	}
+
 	internal fun tryNavigateToMainIfSetupIsCompleted(): Boolean {
 		if (isSetupCompleted()) {
-			startActivity(Intent(this, MainActivity::class.java))
-			finish()
+			navigateToMain()
 			return true
 		}
 

--- a/app/src/main/java/com/itsaky/androidide/fragments/onboarding/PermissionsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/onboarding/PermissionsFragment.kt
@@ -233,17 +233,17 @@ class PermissionsFragment :
     }
 
 	private fun startIdeSetup() {
-		val shouldProceed = viewModel.checkStorageAndNotify(requireContext())
-		if (!shouldProceed) {
-			return
-		}
-
-		if (viewModel.isSetupComplete()) {
-			(activity as? OnboardingActivity)?.tryNavigateToMainIfSetupIsCompleted()
-			return
-		}
-
 		viewLifecycleScope.launch {
+			val shouldProceed = viewModel.checkStorageAndNotify(requireContext())
+			if (!shouldProceed) {
+				return@launch
+			}
+
+			if (viewModel.isSetupComplete()) {
+				(activity as? OnboardingActivity)?.tryNavigateToMainIfSetupIsCompleted()
+				return@launch
+			}
+
 			doAsyncWithProgress(
 				Dispatchers.IO,
 				configureFlashbar = { builder, _ ->

--- a/app/src/main/java/com/itsaky/androidide/fragments/onboarding/PermissionsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/onboarding/PermissionsFragment.kt
@@ -240,7 +240,7 @@ class PermissionsFragment :
 			}
 
 			if (viewModel.isSetupCompleteAsync()) {
-				(activity as? OnboardingActivity)?.tryNavigateToMainIfSetupIsCompleted()
+				(activity as? OnboardingActivity)?.navigateToMain()
 				return@launch
 			}
 
@@ -265,7 +265,7 @@ class PermissionsFragment :
 						when (state) {
 							is InstallationState.InstallationComplete -> {
 								withContext(Dispatchers.Main) {
-									(activity as? OnboardingActivity)?.tryNavigateToMainIfSetupIsCompleted()
+									(activity as? OnboardingActivity)?.navigateToMain()
 								}
 								true
 							}

--- a/app/src/main/java/com/itsaky/androidide/fragments/onboarding/PermissionsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/onboarding/PermissionsFragment.kt
@@ -239,7 +239,7 @@ class PermissionsFragment :
 				return@launch
 			}
 
-			if (viewModel.isSetupComplete()) {
+			if (viewModel.isSetupCompleteAsync()) {
 				(activity as? OnboardingActivity)?.tryNavigateToMainIfSetupIsCompleted()
 				return@launch
 			}

--- a/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
+++ b/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
@@ -8,6 +8,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
 import java.io.PrintWriter
+import android.net.TrafficStats
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.net.Socket
@@ -134,8 +135,10 @@ FROM   LastChange
             // NEW FEATURE: Log database metadata when debug is enabled
             if (debugEnabled) logDatabaseLastChanged()
 
+            TrafficStats.setThreadStatsTag(0xC0DE)
             serverSocket = ServerSocket().apply { reuseAddress = true }
             serverSocket.bind(InetSocketAddress(config.bindName, config.port))
+            TrafficStats.clearThreadStatsTag()
             log.info("WebServer started successfully on '{}', port {}.", config.bindName, config.port)
 
             while (true) {

--- a/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
+++ b/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
@@ -111,6 +111,7 @@ FROM   LastChange
     }
 
     fun start() {
+        TrafficStats.setThreadStatsTag(0xC0DE)
         try {
             log.info(
                 "Starting WebServer on {}, port {}, debugEnabled={}, debugEnablePath='{}', debugDatabasePath='{}', experimentsEnabled={}, experimentsEnablePath='{}'.",
@@ -135,10 +136,8 @@ FROM   LastChange
             // NEW FEATURE: Log database metadata when debug is enabled
             if (debugEnabled) logDatabaseLastChanged()
 
-            TrafficStats.setThreadStatsTag(0xC0DE)
             serverSocket = ServerSocket().apply { reuseAddress = true }
             serverSocket.bind(InetSocketAddress(config.bindName, config.port))
-            TrafficStats.clearThreadStatsTag()
             log.info("WebServer started successfully on '{}', port {}.", config.bindName, config.port)
 
             while (true) {
@@ -223,6 +222,7 @@ clientSocket and the catch block logic are updated accordingly.
             if (::serverSocket.isInitialized) {
                 serverSocket.close()
             }
+            TrafficStats.clearThreadStatsTag()
         }
     }
 

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/InstallationViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/InstallationViewModel.kt
@@ -64,7 +64,7 @@ class InstallationViewModel : ViewModel() {
 			if (!checkStorageAndNotify(context)) {
 				return@launch
 			}
-			if (checkToolsIsInstalled()) {
+			if (withContext(Dispatchers.IO) { checkToolsIsInstalled() }) {
 				// Tools already installed
 				_state.update { InstallationComplete }
 				return@launch
@@ -120,6 +120,8 @@ class InstallationViewModel : ViewModel() {
 	}
 
 	fun isSetupComplete(): Boolean = checkToolsIsInstalled()
+
+	suspend fun isSetupCompleteAsync(): Boolean = withContext(Dispatchers.IO) { checkToolsIsInstalled() }
 
 	private fun checkToolsIsInstalled(): Boolean =
 		IJdkDistributionProvider.getInstance().installedDistributions.isNotEmpty() &&

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/InstallationViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/InstallationViewModel.kt
@@ -60,66 +60,62 @@ class InstallationViewModel : ViewModel() {
 			return
 		}
 
-		if (!checkStorageAndNotify(context)) {
-			return
-		}
-		if (!checkToolsIsInstalled()) {
-			viewModelScope.launch {
-				try {
-					_state.update { Installing() }
+		viewModelScope.launch {
+			if (!checkStorageAndNotify(context)) {
+				return@launch
+			}
+			if (checkToolsIsInstalled()) {
+				// Tools already installed
+				_state.update { InstallationComplete }
+				return@launch
+			}
+			try {
+				_state.update { Installing() }
 
-					withContext(Dispatchers.IO) {
-						val result =
-							withStopWatch("Assets installation") {
-								AssetsInstallationHelper.install(context) { progress ->
-									log.debug("Assets installation progress: {}", progress.message)
-									_installationProgress.value = progress.message
-								}
+				withContext(Dispatchers.IO) {
+					val result =
+						withStopWatch("Assets installation") {
+							AssetsInstallationHelper.install(context) { progress ->
+								log.debug("Assets installation progress: {}", progress.message)
+								_installationProgress.value = progress.message
 							}
+						}
 
-						log.info("Assets installation result: {}", result)
+					log.info("Assets installation result: {}", result)
 
-						when (result) {
-							is AssetsInstallationHelper.Result.Success -> {
-								val distributionProvider = IJdkDistributionProvider.getInstance()
-								distributionProvider.loadDistributions()
+					when (result) {
+						is AssetsInstallationHelper.Result.Success -> {
+							val distributionProvider = IJdkDistributionProvider.getInstance()
+							distributionProvider.loadDistributions()
 
-								_state.update { InstallationComplete }
+							_state.update { InstallationComplete }
+						}
+						is AssetsInstallationHelper.Result.Failure -> {
+							if (result.shouldReportToSentry) {
+								result.cause?.let { Sentry.captureException(it) }
 							}
-							is AssetsInstallationHelper.Result.Failure -> {
-								if (result.shouldReportToSentry) {
-									result.cause?.let { Sentry.captureException(it) }
-								}
-								val errorMsg = result.errorMessage
-									?: context.getString(R.string.title_installation_failed)
-								viewModelScope.launch {
-									_events.emit(InstallationEvent.ShowError(errorMsg))
-								}
-								_state.update {
-									InstallationError(errorMsg)
-								}
+							val errorMsg = result.errorMessage
+								?: context.getString(R.string.title_installation_failed)
+							_events.emit(InstallationEvent.ShowError(errorMsg))
+							_state.update {
+								InstallationError(errorMsg)
 							}
 						}
 					}
-				} catch (e: Exception) {
-					if (e is CancellationException) {
-						_state.update { InstallationPending }
-						throw e
-					}
-					Sentry.captureException(e)
-					log.error("IDE setup installation failed", e)
-					val errorMsg = e.message ?: context.getString(R.string.unknown_error)
-					viewModelScope.launch {
-						_events.emit(InstallationEvent.ShowError(errorMsg))
-					}
-					_state.update {
-						InstallationError(errorMsg)
-					}
+				}
+			} catch (e: Exception) {
+				if (e is CancellationException) {
+					_state.update { InstallationPending }
+					throw e
+				}
+				Sentry.captureException(e)
+				log.error("IDE setup installation failed", e)
+				val errorMsg = e.message ?: context.getString(R.string.unknown_error)
+				_events.emit(InstallationEvent.ShowError(errorMsg))
+				_state.update {
+					InstallationError(errorMsg)
 				}
 			}
-		} else {
-			// Tools already installed
-			_state.update { InstallationComplete }
 		}
 	}
 
@@ -147,7 +143,7 @@ class InstallationViewModel : ViewModel() {
         return StorageInfo(isLowStorage, availableStorageInBytes, additionalBytesNeeded)
     }
 
-    fun checkStorageAndNotify(context: Context): Boolean {
+    suspend fun checkStorageAndNotify(context: Context): Boolean = withContext(Dispatchers.IO) {
         val storageInfo = getStorageInfo(context)
 
         if (storageInfo.isLowStorage) {
@@ -160,13 +156,11 @@ class InstallationViewModel : ViewModel() {
                 availableGB
             )
 
-            viewModelScope.launch {
-                _events.emit(InstallationEvent.ShowError(errorMessage))
-            }
-            return false
+            _events.emit(InstallationEvent.ShowError(errorMessage))
+            return@withContext false
         }
 
-        return true
+        return@withContext true
     }
 
 }


### PR DESCRIPTION
  1. WebServer socket tagging -- No more UntaggedSocketViolation from our WebServer (the ones showing are from OkHttp and JDI, outside our control)
  2. InstallationViewModel.checkStorageAndNotify() -- Now runs via withContext(Dispatchers.IO) inside a viewModelScope.launch block, no main-thread disk reads
  3. PermissionsFragment.startIdeSetup() -- Storage check now inside a coroutine scope, no synchronous main-thread call before the async block
