### PR TITLE
ADFA-3871 | Improve dropdown entries parsing and metadata detection

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
@@ -125,7 +125,7 @@ object MarginAnnotationParser {
 
         for (block in explicitBlocks) {
             val tag = block.tag ?: continue
-            if (canvasTags.any { (canvasTag, _) -> canvasTag == tag }) {
+            if (canvasTags.isEmpty() || canvasTags.any { (canvasTag, _) -> canvasTag == tag }) {
                 annotationMap[tag] = block.annotationText
             }
         }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidWidget.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidWidget.kt
@@ -94,8 +94,8 @@ class SpinnerWidget(
 
         when {
             rawEntries == null -> Unit
-            rawEntries.startsWith("@") -> {
-                processed[AttributeKey.ENTRIES.xmlName] = rawEntries.escapeXmlAttr()
+            rawEntries.trimStart().startsWith("@") -> {
+                processed[AttributeKey.ENTRIES.xmlName] = rawEntries.trim().escapeXmlAttr()
             }
             else -> rawEntries
                 .toSpinnerEntries()
@@ -125,7 +125,7 @@ class SpinnerWidget(
 
     private fun String.removeTrailingDropdownGlyph(): String {
         return trim()
-            .replace(Regex("\\s*[▼▽▾▿⌄˅∨vV]$"), "")
+            .replace(Regex("\\s*[▼▽▾▿⌄˅∨]$|\\s+[vV]$"), "")
             .trim()
     }
 

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidWidget.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidWidget.kt
@@ -88,19 +88,50 @@ class SpinnerWidget(
 
     override fun processAttributes(context: XmlContext, id: String, attrs: Map<String, String>): Map<String, String> {
         val processed = mutableMapOf<String, String>()
+        val rawEntries = attrs[AttributeKey.ENTRIES.xmlName]
+            ?: attrs[AttributeKey.TEXT.xmlName]
+            ?: box.text.takeIf { it.isMeaningfulDropdownText() }
+
+        when {
+            rawEntries == null -> Unit
+            rawEntries.startsWith("@") -> {
+                processed[AttributeKey.ENTRIES.xmlName] = rawEntries.escapeXmlAttr()
+            }
+            else -> rawEntries
+                .toSpinnerEntries()
+                .takeIf { it.isNotEmpty() }
+                ?.let { items ->
+                    val arrayName = "${id}_array"
+                    context.stringArrays[arrayName] = items
+                    processed[AttributeKey.ENTRIES.xmlName] = "@array/$arrayName"
+                }
+        }
 
         attrs.forEach { (key, value) ->
-            if (key == AttributeKey.ENTRIES.xmlName && !value.startsWith("@")) {
-                val arrayName = "${id}_array"
-                val items = value.split(",").map { it.trim() }.filter { it.isNotEmpty() }
-
-                context.stringArrays[arrayName] = items
-                processed[key] = "@array/$arrayName"
-            } else {
-                processed[key] = value.escapeXmlAttr()
+            when {
+                key == AttributeKey.ENTRIES.xmlName || key == AttributeKey.TEXT.xmlName -> Unit
+                else -> processed[key] = value.escapeXmlAttr()
             }
         }
         return processed
+    }
+
+    private fun String.toSpinnerEntries(): List<String> {
+        return removeTrailingDropdownGlyph()
+            .split(Regex("\\s*[,;|/\\n]+\\s*"))
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+    }
+
+    private fun String.removeTrailingDropdownGlyph(): String {
+        return trim()
+            .replace(Regex("\\s*[▼▽▾▿⌄˅∨vV]$"), "")
+            .trim()
+    }
+
+    private fun String.isMeaningfulDropdownText(): Boolean {
+        val cleaned = removeTrailingDropdownGlyph()
+        return cleaned.isNotBlank() && !cleaned.equals("dropdown", ignoreCase = true)
     }
 }
 

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/MetadataDetector.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/MetadataDetector.kt
@@ -31,17 +31,13 @@ object MetadataDetector {
     )
 
     private val xmlAttributeRegex = Regex("""\b(?:android|app|tools):[a-zA-Z_]+\b""")
-    private val assignmentRegex = Regex("""\b[a-zA-Z_]+(?:[:=])[^\s]+""")
-
     fun isCanvasMetadata(text: String): Boolean {
         val lowerText = text.lowercase()
         if (lowerText.isBlank()) return false
         if (metadataSnippets.any { snippet -> lowerText.contains(snippet) }) return true
         if (xmlAttributeRegex.containsMatchIn(lowerText)) return true
         if (metadataKeywords.any { keyword -> lowerText.contains(keyword) }) return true
-
-        val assignmentCount = assignmentRegex.findAll(lowerText).count()
-        return assignmentCount >= 2
+        return false
     }
 
     fun isMetadataLabel(label: String): Boolean {


### PR DESCRIPTION
## Description

This PR refines the parsing logic within the `cv-image-to-xml` module to improve accuracy:
* **AndroidWidget**: Improved dropdown/spinner entries parsing. It now gracefully falls back to text attributes or box text, safely removes trailing dropdown glyphs (e.g., ▼, ⌄), and standardizes string arrays.
* **MarginAnnotationParser**: Updated logic to process explicit blocks even when the `canvasTags` list is empty.
* **MetadataDetector**: Removed the broad `assignmentRegex` check to prevent false positives when detecting canvas metadata.

## Details

Logic-related updates:
* Added `toSpinnerEntries()`, `removeTrailingDropdownGlyph()`, and `isMeaningfulDropdownText()` extension functions in `AndroidWidget.kt` to clean up text values.
* Adjusted the boolean evaluation in `MarginAnnotationParser.kt` to include `canvasTags.isEmpty()`.
* Removed `assignmentRegex` from `MetadataDetector.kt`.


https://github.com/user-attachments/assets/6e7e0a58-a352-4de8-b4c4-1231823c7fd4


## Ticket

[ADFA-3871](https://appdevforall.atlassian.net/browse/ADFA-3871)

## Observation

The removal of the assignment-based metadata detection in `MetadataDetector` is intended to reduce false positives where standard text with colons or equals signs was being incorrectly flagged as canvas metadata.

[ADFA-3871]: https://appdevforall.atlassian.net/browse/ADFA-3871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ