### PR TITLE
ADFA-3870: mainline Kotlin LSP

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/handlers/LspHandler.kt
+++ b/app/src/main/java/com/itsaky/androidide/handlers/LspHandler.kt
@@ -34,9 +34,7 @@ object LspHandler {
 	fun registerLanguageServers() {
 		ILanguageServerRegistry.default.apply {
 			getServer(JavaLanguageServer.SERVER_ID) ?: register(JavaLanguageServer())
-			if (FeatureFlags.isExperimentsEnabled) {
-				getServer(KotlinLanguageServer.SERVER_ID) ?: register(KotlinLanguageServer())
-			}
+			getServer(KotlinLanguageServer.SERVER_ID) ?: register(KotlinLanguageServer())
 			getServer(XMLLanguageServer.SERVER_ID) ?: register(XMLLanguageServer())
 		}
 	}


### PR DESCRIPTION
Makes the Kotlin LSP mainline so that it can be used without turning on experimental features.