### PR TITLE
ADFA-3785 | Fix textStyle fuzzy parsing for OCR errors

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParser.kt
@@ -10,7 +10,7 @@ object FuzzyAttributeParser {
     private const val FUZZY_DIMENSION_THRESHOLD = 60
     private const val FUZZY_TEXT_STYLE_THRESHOLD = 60
     private val DIMENSION_CONSTANTS = listOf("wrap_content", "match_parent")
-    private val TEXT_STYLE_VALUES = listOf("normal", "bold", "italic")
+    private val TEXT_STYLE_VALUES = listOf("normal", "bold", "italic", "bold|italic")
     private val ID_VOCABULARY = listOf("cb", "rb", "group", "checkbox", "radio", "btn", "button", "text", "view", "img", "image", "input")
 
     private fun fuzzyKeyThreshold(keyLength: Int): Int = when {

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParser.kt
@@ -8,7 +8,9 @@ object FuzzyAttributeParser {
 
     private const val FUZZY_VALUE_THRESHOLD = 75
     private const val FUZZY_DIMENSION_THRESHOLD = 60
+    private const val FUZZY_TEXT_STYLE_THRESHOLD = 60
     private val DIMENSION_CONSTANTS = listOf("wrap_content", "match_parent")
+    private val TEXT_STYLE_VALUES = listOf("normal", "bold", "italic")
     private val ID_VOCABULARY = listOf("cb", "rb", "group", "checkbox", "radio", "btn", "button", "text", "view", "img", "image", "input")
 
     private fun fuzzyKeyThreshold(keyLength: Int): Int = when {
@@ -35,7 +37,7 @@ object FuzzyAttributeParser {
 
         TEXT_SIZE("android:textSize", listOf("textsize", "text_size"), ValueType.SP_DIMENSION),
         TEXT_COLOR("android:textColor", listOf("textcolor", "text_color", "color", "text_colar", "textcolar"), ValueType.COLOR),
-        TEXT_STYLE("android:textStyle", listOf("textstyle", "text_style", "style"), ValueType.RAW),
+        TEXT_STYLE("android:textStyle", listOf("textstyle", "text_style", "style"), ValueType.TEXT_STYLE),
         TEXT_ALIGNMENT("android:textAlignment", listOf("textalignment", "text_alignment")),
         TEXT_ALL_CAPS("android:textAllCaps", listOf("textallcaps", "text_all_caps")),
         FONT_FAMILY("android:fontFamily", listOf("fontfamily", "font_family", "font")),
@@ -131,8 +133,25 @@ object FuzzyAttributeParser {
         ID,
         DRAWABLE,
         INTEGER,
-        FLOAT
+        FLOAT,
+        TEXT_STYLE
     }
+
+    fun interface ValueCleaner {
+        fun clean(rawValue: String): String
+    }
+
+    private val valueCleaners: Map<ValueType, ValueCleaner> = mapOf(
+        ValueType.DIMENSION to ValueCleaner(::cleanDimension),
+        ValueType.SP_DIMENSION to ValueCleaner(::cleanSpDimension),
+        ValueType.COLOR to ValueCleaner(::cleanColor),
+        ValueType.ID to ValueCleaner(::cleanId),
+        ValueType.DRAWABLE to ValueCleaner(::cleanDrawable),
+        ValueType.INTEGER to ValueCleaner(::cleanInteger),
+        ValueType.FLOAT to ValueCleaner(::cleanFloat),
+        ValueType.TEXT_STYLE to ValueCleaner(::cleanTextStyle),
+        ValueType.RAW to ValueCleaner { it }
+    )
 
     internal val colorMap = mapOf(
         "red" to "#FF0000", "rel" to "#FF0000", "green" to "#00FF00", "blue" to "#0000FF",
@@ -399,17 +418,22 @@ object FuzzyAttributeParser {
 
     private fun cleanValue(rawValue: String, key: AttributeKey): String {
         val trimmed = rawValue.trim()
+        val cleaner = valueCleaners[key.valueType] ?: ValueCleaner { it }
 
-        return when (key.valueType) {
-            ValueType.DIMENSION -> cleanDimension(trimmed)
-            ValueType.SP_DIMENSION -> cleanSpDimension(trimmed)
-            ValueType.COLOR -> cleanColor(trimmed)
-            ValueType.ID -> cleanId(trimmed)
-            ValueType.DRAWABLE -> cleanDrawable(trimmed)
-            ValueType.INTEGER -> cleanInteger(trimmed)
-            ValueType.FLOAT -> cleanFloat(trimmed)
-            ValueType.RAW -> trimmed
+        return cleaner.clean(trimmed)
+    }
+
+    private fun cleanTextStyle(value: String): String {
+        val normalizedValue = value.lowercase().replace(" ", "_")
+
+        if (normalizedValue in TEXT_STYLE_VALUES) return normalizedValue
+
+        val result = FuzzySearch.extractOne(normalizedValue, TEXT_STYLE_VALUES)
+        if (result.score >= FUZZY_TEXT_STYLE_THRESHOLD) {
+            return result.string
         }
+
+        return value
     }
 
     private fun cleanDimension(value: String): String {


### PR DESCRIPTION
## Description

Added a dedicated `TEXT_STYLE` entry to the `ValueType` enum inside `FuzzyAttributeParser` to properly handle text style properties. Implemented the `cleanTextStyle` method to perform fuzzy matching against valid style options (normal, bold, italic). Additionally, the `cleanValue` method was refactored to use a `ValueCleaner` map mapping each `ValueType` to its respective cleaning function, replacing the previous `when` statement for better scalability.

## Details

Logic update: The parser now correctly evaluates and corrects noisy OCR text for `android:textStyle`. Generated XML outputs will now reliably contain `android:textStyle="bold"` instead of raw garbled strings. The value cleaning process is now more streamlined using the new `ValueCleaner` interface.

### Sketch tested

<img width="936" height="1158" alt="UI_sketch_BasicSwitchonMetaData (5)" src="https://github.com/user-attachments/assets/43b2c5c8-8502-4696-bc20-9ab4f4311c0c" />


https://github.com/user-attachments/assets/f99a14a8-9148-428b-b76b-9cace17271c4

## Ticket

[ADFA-3785](https://appdevforall.atlassian.net/browse/ADFA-3785)

## Observation

To maintain the parser's architectural consistency and avoid magic numbers, the local tolerance of 60 was extracted into a dedicated `FUZZY_TEXT_STYLE_THRESHOLD` constant at the object level. The refactoring to `ValueCleaner` ensures that adding future value types will require less boilerplate code.

[ADFA-3785]: https://appdevforall.atlassian.net/browse/ADFA-3785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ