### PR TITLE
ADFA- 3701 Protect against project name collisions during project rename action

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/adapters/RecentProjectsAdapter.kt
+++ b/app/src/main/java/com/itsaky/androidide/adapters/RecentProjectsAdapter.kt
@@ -228,11 +228,12 @@ class RecentProjectsAdapter(
         builder.setNegativeButton(R.string.cancel) { dialog, _ -> dialog.dismiss() }
         builder.setPositiveButton(R.string.rename) { _, _ ->
             val newName = binding.textinputEdittext.text.toString()
-            val newPath = project.path.substringBeforeLast("/") + "/" + newName
+            val oldPath = project.path
+            val newPath = oldPath.substringBeforeLast("/") + "/" + newName
             try {
                 project.rename(newPath)
                 flashSuccess(R.string.renamed)
-                onFileRenamed(RenamedFile(oldName, newName, newPath))
+                onFileRenamed(RenamedFile(oldName, newName, oldPath, newPath))
                 notifyItemChanged(position)
             } catch (e: Exception) {
 				logger.error("Failed to rename project", e)
@@ -300,5 +301,10 @@ class RecentProjectsAdapter(
         }
     }
 
-    data class RenamedFile(val oldName: String, val newName: String, val newPath: String)
+    data class RenamedFile(
+        val oldName: String,
+        val newName: String,
+        val oldPath: String,
+        val newPath: String
+    )
 }

--- a/app/src/main/java/com/itsaky/androidide/adapters/RecentProjectsAdapter.kt
+++ b/app/src/main/java/com/itsaky/androidide/adapters/RecentProjectsAdapter.kt
@@ -288,6 +288,15 @@ class RecentProjectsAdapter(
                 positiveButton.isEnabled = false
             }
 
+            newName.contains('/') ||
+                newName.contains('\\') ||
+                newName.contains(File.separatorChar) ||
+                newName == "." ||
+                newName == ".." -> {
+                inputLayout.error = dialog.context.getString(R.string.msg_invalid_name)
+                positiveButton.isEnabled = false
+            }
+
             newName != oldName && nameExists(newName) -> {
                 inputLayout.error =
                     dialog.context.getString(R.string.msg_current_name_unavailable)

--- a/app/src/main/java/com/itsaky/androidide/adapters/RecentProjectsAdapter.kt
+++ b/app/src/main/java/com/itsaky/androidide/adapters/RecentProjectsAdapter.kt
@@ -39,6 +39,7 @@ class RecentProjectsAdapter(
     private val onRemoveProjectClick: (ProjectFile) -> Unit,
     private val onFileRenamed: (RenamedFile) -> Unit,
     private val onInfoClick: (ProjectFile) -> Unit,
+    private val nameExists: (String) -> Boolean,
 ) : RecyclerView.Adapter<RecentProjectsAdapter.ProjectViewHolder>() {
 
 	private var projectOptionsPopup: PopupWindow? = null
@@ -286,7 +287,7 @@ class RecentProjectsAdapter(
                 positiveButton.isEnabled = false
             }
 
-            newName != oldName && projects.any { it.name == newName } -> {
+            newName != oldName && nameExists(newName) -> {
                 inputLayout.error =
                     dialog.context.getString(R.string.msg_current_name_unavailable)
                 positiveButton.isEnabled = false

--- a/app/src/main/java/com/itsaky/androidide/adapters/RecentProjectsAdapter.kt
+++ b/app/src/main/java/com/itsaky/androidide/adapters/RecentProjectsAdapter.kt
@@ -261,13 +261,14 @@ class RecentProjectsAdapter(
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
-                validateProjectName(binding.textinputLayout, s.toString(), dialog)
+                validateProjectName(binding.textinputLayout, s.toString(), oldName, dialog)
             }
         })
 
         validateProjectName(
             binding.textinputLayout,
             binding.textinputEdittext.text.toString(),
+            oldName,
             dialog
         )
     }
@@ -275,12 +276,19 @@ class RecentProjectsAdapter(
     private fun validateProjectName(
         inputLayout: TextInputLayout,
 		newName: String,
+		oldName: String,
 		dialog: AlertDialog
     ) {
         val positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
         when {
             newName.isEmpty() -> {
                 inputLayout.error = dialog.context.getString(R.string.msg_cannnot_empty)
+                positiveButton.isEnabled = false
+            }
+
+            newName != oldName && projects.any { it.name == newName } -> {
+                inputLayout.error =
+                    dialog.context.getString(R.string.msg_current_name_unavailable)
                 positiveButton.isEnabled = false
             }
 

--- a/app/src/main/java/com/itsaky/androidide/adapters/RecentProjectsAdapter.kt
+++ b/app/src/main/java/com/itsaky/androidide/adapters/RecentProjectsAdapter.kt
@@ -227,7 +227,7 @@ class RecentProjectsAdapter(
 
         builder.setNegativeButton(R.string.cancel) { dialog, _ -> dialog.dismiss() }
         builder.setPositiveButton(R.string.rename) { _, _ ->
-            val newName = binding.textinputEdittext.text.toString()
+            val newName = binding.textinputEdittext.text.toString().trim()
             val oldPath = project.path
             val newPath = oldPath.substringBeforeLast("/") + "/" + newName
             try {
@@ -263,13 +263,13 @@ class RecentProjectsAdapter(
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
-                validateProjectName(binding.textinputLayout, s.toString(), oldName, dialog)
+                validateProjectName(binding.textinputLayout, s.toString().trim(), oldName, dialog)
             }
         })
 
         validateProjectName(
             binding.textinputLayout,
-            binding.textinputEdittext.text.toString(),
+            binding.textinputEdittext.text.toString().trim(),
             oldName,
             dialog
         )

--- a/app/src/main/java/com/itsaky/androidide/fragments/RecentProjectsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/RecentProjectsFragment.kt
@@ -82,6 +82,7 @@ class RecentProjectsFragment : BaseFragment() {
 		setupClickListeners()
         bootstrapFromFixedFolderIfNeeded()
         observeDeletionStatus()
+        observeRenameStatus()
 	}
 
 	private fun setupRecyclerView() {
@@ -423,6 +424,17 @@ class RecentProjectsFragment : BaseFragment() {
                     flashSuccess(R.string.deleted)
                 } else {
                     flashError(R.string.delete_failed)
+                }
+            }
+        }
+    }
+
+    private fun observeRenameStatus() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.renameStatus.collect { status ->
+                if (!status) {
+                    flashError(R.string.rename_failed)
+                    viewModel.loadProjects()
                 }
             }
         }

--- a/app/src/main/java/com/itsaky/androidide/fragments/RecentProjectsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/RecentProjectsFragment.kt
@@ -334,7 +334,8 @@ class RecentProjectsFragment : BaseFragment() {
 					onProjectClick = ::openProject,
           onRemoveProjectClick = viewModel::deleteProject,
 					onFileRenamed = viewModel::updateProject,
-					onInfoClick = { project -> openProjectInfo(project) }
+					onInfoClick = { project -> openProjectInfo(project) },
+					nameExists = viewModel::projectNameExists
 				)
 				binding.listProjects.adapter = adapter
 			} else {

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/RecentProjectsViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/RecentProjectsViewModel.kt
@@ -196,16 +196,26 @@ class RecentProjectsViewModel(application: Application) : AndroidViewModel(appli
     }
 
 	fun updateProject(renamedFile: RecentProjectsAdapter.RenamedFile) =
-		updateProject(renamedFile.oldName, renamedFile.newName, renamedFile.newPath)
+		updateProject(
+			renamedFile.oldName,
+			renamedFile.newName,
+			renamedFile.oldPath,
+			renamedFile.newPath
+		)
 
-    fun updateProject(oldName: String, newName: String, location: String) =
+    fun updateProject(
+        oldName: String,
+        newName: String,
+        oldLocation: String,
+        newLocation: String
+    ) =
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val modifiedAt = System.currentTimeMillis().toString()
                 recentProjectDao.updateNameAndLocation(
                     oldName = oldName,
                     newName = newName,
-                    newLocation = location
+                    newLocation = newLocation
                 )
                 recentProjectDao.updateLastModified(
                     projectName = newName,
@@ -214,6 +224,12 @@ class RecentProjectsViewModel(application: Application) : AndroidViewModel(appli
                 loadProjects()
             } catch (e: SQLException) {
                 logger.error("Failed to update project after rename ($oldName -> $newName)", e)
+                val rolledBack = File(newLocation).renameTo(File(oldLocation))
+                if (rolledBack) {
+                    logger.info("Rolled back filesystem rename: $newLocation -> $oldLocation")
+                } else {
+                    logger.error("Rollback failed; filesystem and DB are out of sync (disk=$newLocation, db=$oldLocation)")
+                }
                 _renameStatus.emit(false)
             }
         }

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/RecentProjectsViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/RecentProjectsViewModel.kt
@@ -222,6 +222,7 @@ class RecentProjectsViewModel(application: Application) : AndroidViewModel(appli
                     lastModified = modifiedAt
                 )
                 loadProjects()
+                _renameStatus.emit(true)
             } catch (e: SQLException) {
                 logger.error("Failed to update project after rename ($oldName -> $newName)", e)
                 val rolledBack = File(newLocation).renameTo(File(oldLocation))

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/RecentProjectsViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/RecentProjectsViewModel.kt
@@ -130,6 +130,9 @@ class RecentProjectsViewModel(application: Application) : AndroidViewModel(appli
         }
     }
 
+    fun projectNameExists(name: String): Boolean =
+        allProjects.any { it.name == name }
+
     fun insertProjectFromFolder(name: String, location: String) =
         viewModelScope.launch(Dispatchers.IO) {
             // Check if the project already exists

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/RecentProjectsViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/RecentProjectsViewModel.kt
@@ -55,6 +55,9 @@ class RecentProjectsViewModel(application: Application) : AndroidViewModel(appli
     private val _deletionStatus = MutableSharedFlow<Boolean>(replay = 1)
     val deletionStatus = _deletionStatus.asSharedFlow()
 
+    private val _renameStatus = MutableSharedFlow<Boolean>()
+    val renameStatus = _renameStatus.asSharedFlow()
+
     // Get the database and DAO instance
     private val recentProjectDatabase: RecentProjectRoomDatabase =
         RecentProjectRoomDatabase.getDatabase(application, viewModelScope)
@@ -194,17 +197,22 @@ class RecentProjectsViewModel(application: Application) : AndroidViewModel(appli
 
     fun updateProject(oldName: String, newName: String, location: String) =
         viewModelScope.launch(Dispatchers.IO) {
-            val modifiedAt = System.currentTimeMillis().toString()
-            recentProjectDao.updateNameAndLocation(
-                oldName = oldName,
-                newName = newName,
-                newLocation = location
-            )
-            recentProjectDao.updateLastModified(
-                projectName = newName,
-                lastModified = modifiedAt
-            )
-            loadProjects()
+            try {
+                val modifiedAt = System.currentTimeMillis().toString()
+                recentProjectDao.updateNameAndLocation(
+                    oldName = oldName,
+                    newName = newName,
+                    newLocation = location
+                )
+                recentProjectDao.updateLastModified(
+                    projectName = newName,
+                    lastModified = modifiedAt
+                )
+                loadProjects()
+            } catch (e: SQLException) {
+                logger.error("Failed to update project after rename ($oldName -> $newName)", e)
+                _renameStatus.emit(false)
+            }
         }
 
 	fun updateProjectModifiedDate(name: String) =

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/ProjectFile.kt
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/ProjectFile.kt
@@ -10,7 +10,6 @@ import org.appdevforall.codeonthego.layouteditor.utils.FileUtil
 import com.itsaky.androidide.utils.formatDate
 import org.jetbrains.annotations.Contract
 import java.io.File
-import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -45,12 +44,7 @@ class ProjectFile : Parcelable {
   fun rename(newPath: String) {
     val newFile = File(newPath)
     val oldFile = File(path)
-    if (newFile.exists()) {
-      throw IOException("Destination already exists: $newPath")
-    }
-    if (!oldFile.renameTo(newFile)) {
-      throw IOException("Failed to rename $path to $newPath")
-    }
+    oldFile.renameTo(newFile)
 
     path = newPath
     name = FileUtil.getLastSegmentFromPath(path)

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/ProjectFile.kt
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/ProjectFile.kt
@@ -10,6 +10,7 @@ import org.appdevforall.codeonthego.layouteditor.utils.FileUtil
 import com.itsaky.androidide.utils.formatDate
 import org.jetbrains.annotations.Contract
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -44,7 +45,12 @@ class ProjectFile : Parcelable {
   fun rename(newPath: String) {
     val newFile = File(newPath)
     val oldFile = File(path)
-    oldFile.renameTo(newFile)
+    if (newFile.exists()) {
+      throw IOException("Destination already exists: $newPath")
+    }
+    if (!oldFile.renameTo(newFile)) {
+      throw IOException("Failed to rename $path to $newPath")
+    }
 
     path = newPath
     name = FileUtil.getLastSegmentFromPath(path)


### PR DESCRIPTION
validateProjectName now also rejects names matching another project
Disables the Rename button and shows an error message (which is in strings.xml)
