### PR TITLE
ADFA-3910 | Fix single placeholder dropdown array generation in strings file

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
@@ -8,31 +8,6 @@ object MarginAnnotationParser {
     private const val GAP_MULTIPLIER = 1.5f
     private const val HEIGHT_FRACTION = 0.8f
 
-    private val TAG_REGEX = Regex("^(?i)(B|P|D|T|C|R|SW|S)-\\d+$")
-    private val TAG_EXTRACT_REGEX = Regex("^(?i)([BPDTCRS8]\\s*W?)[^a-zA-Z0-9]*([\\dlIoO!]+)(?:\\s+(.+))?$")
-
-    private fun normalizeOcrDigits(raw: String): String =
-        raw.replace('l', '1').replace('I', '1').replace('!', '1')
-            .replace('o', '0').replace('O', '0')
-
-    private fun isTag(text: String): Boolean = text.matches(TAG_REGEX)
-
-    private fun extractTag(text: String): Pair<String, String?>? {
-        val trimmed = text.trim().trimEnd('.', ',', ';', '_', '|')
-        val match = TAG_EXTRACT_REGEX.find(trimmed) ?: return null
-
-        var prefix = match.groupValues[1].replace(Regex("\\s+"), "").uppercase()
-        if (prefix == "8") prefix = "B"
-        if (prefix == "8W" || prefix == "S8") prefix = "SW"
-
-        val digit = normalizeOcrDigits(match.groupValues[2])
-        val remaining = match.groupValues[3].takeIf { it.isNotBlank() }
-        val tag = "$prefix-$digit"
-
-        if (isTag(tag)) return tag to remaining
-        return null
-    }
-
     fun parse(
         detections: List<DetectionResult>,
         imageWidth: Int,
@@ -40,7 +15,8 @@ object MarginAnnotationParser {
         rightGuidePct: Float
     ): Pair<List<DetectionResult>, Map<String, String>> {
         val sanitizedDetections = detections.filterNot { detection ->
-            MetadataDetector.isMetadataDetection(detection.label, detection.text)
+            MetadataDetector.isMetadataLabel(detection.label) ||
+                (detection.isYolo && MetadataDetector.isCanvasMetadata(detection.text))
         }
 
         val leftMarginPx = imageWidth * leftGuidePct
@@ -60,7 +36,7 @@ object MarginAnnotationParser {
         }
 
         val canvasTags = canvasDetections.mapNotNull { det ->
-            extractTag(det.text)?.let { (tag, _) -> tag to det }
+            WidgetTagParser.extractTag(det.text)?.let { (tag, _) -> tag to det }
         }
 
         val canvasMidX = imageWidth * (leftGuidePct + rightGuidePct) / 2f
@@ -112,15 +88,13 @@ object MarginAnnotationParser {
         val explicitBlocks = parsedBlocks
             .filter {
                 it.tag != null &&
-                    it.annotationText.isNotBlank() &&
-                    !MetadataDetector.isCanvasMetadata(it.annotationText)
+                    it.annotationText.isNotBlank()
             }
 
         val implicitBlocks = parsedBlocks
             .filter {
                 it.tag == null &&
-                    it.annotationText.length >= 5 &&
-                    !MetadataDetector.isCanvasMetadata(it.annotationText)
+                    it.annotationText.length >= 5
             }
 
         for (block in explicitBlocks) {
@@ -136,7 +110,7 @@ object MarginAnnotationParser {
             .mapValues { (_, tags) ->
                 tags.map { it.first }
                     .filter { tag -> tag !in annotationMap }
-                    .sortedBy { tag -> extractOrdinal(tag) ?: Int.MAX_VALUE }
+                    .sortedBy { tag -> WidgetTagParser.extractOrdinal(tag) ?: Int.MAX_VALUE }
                     .toMutableList()
             }
             .toMutableMap()
@@ -163,10 +137,6 @@ object MarginAnnotationParser {
         }
 
         return annotationMap
-    }
-
-    private fun extractOrdinal(tag: String): Int? {
-        return tag.substringAfter('-', "").toIntOrNull()
     }
 
     private fun centerX(detection: DetectionResult): Float {
@@ -212,7 +182,7 @@ object MarginAnnotationParser {
         var currentBlock = mutableListOf<DetectionResult>()
 
         for (detection in block) {
-            val tagExtraction = extractTag(detection.text.trim())
+            val tagExtraction = WidgetTagParser.extractTag(detection.text.trim())
             val isValidSplit = tagExtraction != null &&
                 (validPrefixes.isEmpty() || tagExtraction.first.substringBefore('-') in validPrefixes)
 
@@ -236,7 +206,7 @@ object MarginAnnotationParser {
                 .trim()
                 .trimStart('|', ':', ';', '.', ',', '_')
 
-            val tagExtraction = extractTag(text)
+            val tagExtraction = WidgetTagParser.extractTag(text)
 
             if (tag == null && tagExtraction != null && index <= 2) {
                 tag = tagExtraction.first

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetAnnotationMatcher.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetAnnotationMatcher.kt
@@ -3,11 +3,6 @@ package org.appdevforall.codeonthego.computervision.domain
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
 
 class WidgetAnnotationMatcher {
-    companion object {
-        private val TAG_REGEX = Regex("^(?i)(B|P|D|T|C|R|SW|S)-\\d+$")
-        private val TAG_EXTRACT_REGEX = Regex("^(?i)(SW|S\\s*8|8\\s*W|[BPDTCRS8]\\s*W?)[^a-zA-Z0-9]*([\\dlIoO!]+)(?:\\s+(.+))?$")
-    }
-
     internal fun matchAnnotationsToElements(
         canvasTags: List<ScaledBox>,
         uiElements: List<ScaledBox>,
@@ -17,14 +12,14 @@ class WidgetAnnotationMatcher {
         val claimedWidgets = mutableSetOf<ScaledBox>()
 
         val deduplicatedTags = canvasTags
-            .distinctBy { normalizeTagText(it.text) }
+            .distinctBy { WidgetTagParser.normalizeTagText(it.text) }
 
         val tagsByWidgetType = annotations
             .mapNotNull { (tagText, annotationText) ->
-                val normalizedTag = normalizeTagText(tagText)
+                val normalizedTag = WidgetTagParser.normalizeTagText(tagText)
                 val widgetType = getTagType(normalizedTag) ?: return@mapNotNull null
 
-                val matchingTagBox = deduplicatedTags.find { normalizeTagText(it.text) == normalizedTag }
+                val matchingTagBox = deduplicatedTags.find { WidgetTagParser.normalizeTagText(it.text) == normalizedTag }
                     ?: return@mapNotNull null
 
                 TaggedAnnotation(
@@ -45,14 +40,14 @@ class WidgetAnnotationMatcher {
 
             val sortedTags = taggedAnnotations.sortedWith(
                 compareBy(
-                    { extractTagOrdinal(it.normalizedTag) ?: Int.MAX_VALUE },
+                    { WidgetTagParser.extractOrdinal(it.normalizedTag) ?: Int.MAX_VALUE },
                     { it.tagBox?.y ?: Int.MAX_VALUE },
                     { it.tagBox?.x ?: Int.MAX_VALUE }
                 )
             )
 
             for (taggedAnnotation in sortedTags) {
-                val ordinal = extractTagOrdinal(taggedAnnotation.normalizedTag)
+                val ordinal = WidgetTagParser.extractOrdinal(taggedAnnotation.normalizedTag)
                 val matchedWidget = findWidgetByOrdinalOrFallback(
                     ordinal = ordinal,
                     tagBox = taggedAnnotation.tagBox,
@@ -68,22 +63,7 @@ class WidgetAnnotationMatcher {
         return finalAnnotations
     }
 
-    private fun normalizeOcrDigits(raw: String): String =
-        raw.replace('l', '1').replace('I', '1').replace('!', '1')
-            .replace('o', '0').replace('O', '0')
-
-    private fun normalizeTagText(text: String): String {
-        val trimmed = text.trim().trimEnd('.', ',', ';', ':', '_', '|')
-        val match = TAG_EXTRACT_REGEX.find(trimmed) ?: return trimmed.uppercase()
-
-        var prefix = match.groupValues[1].replace(Regex("\\s+"), "").uppercase()
-        if (prefix == "8") prefix = "B"
-        if (prefix == "8W" || prefix == "S8") prefix = "SW"
-
-        return "$prefix-${normalizeOcrDigits(match.groupValues[2])}"
-    }
-
-    internal fun isTag(text: String): Boolean = normalizeTagText(text).matches(TAG_REGEX)
+    internal fun isTag(text: String): Boolean = WidgetTagParser.isTag(text)
 
     private fun getTagType(tag: String): String? {
         return when {
@@ -109,10 +89,6 @@ class WidgetAnnotationMatcher {
         label.startsWith("slider") -> "slider"
         label.startsWith("image_placeholder") || label.startsWith("icon") -> "image_placeholder"
         else -> label
-    }
-
-    private fun extractTagOrdinal(tag: String): Int? {
-        return tag.substringAfter('-', "").toIntOrNull()
     }
 
     private fun findWidgetByOrdinalOrFallback(

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetTagParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetTagParser.kt
@@ -15,37 +15,41 @@ internal object WidgetTagParser {
 
     /**
      * Normalizes raw OCR text into a standard tag format (e.g., "Prefix-Token").
-     * Fixes common OCR prefix misreads, such as reading 'B' as '8'.
      */
     fun normalizeTagText(text: String): String {
         val trimmed = text.trim().trimEnd('.', ',', ';', ':', '_', '|')
         val match = tagExtractRegex.find(trimmed) ?: return trimmed.uppercase()
 
-        var prefix = match.groupValues[1].replace(Regex("\\s+"), "").uppercase()
-        if (prefix == "8") prefix = "B"
-        if (prefix == "8W" || prefix == "S8") prefix = "SW"
-
+        val prefix = normalizePrefix(match.groupValues[1])
         val token = normalizeTagToken(match.groupValues[2].trim('-'))
+
         return "$prefix-$token"
     }
 
     /**
      * Extracts a normalized widget tag and any remaining trailing text from a raw string.
-     * * @return A Pair containing the [normalized tag, trailing text], or null if no valid tag is found.
+     * @return A Pair containing the [normalized tag, trailing text], or null if no valid tag is found.
      */
     fun extractTag(text: String): Pair<String, String?>? {
         val trimmed = text.trim().trimEnd('.', ',', ';', ':', '_', '|')
         val match = tagExtractRegex.find(trimmed) ?: return null
 
-        var prefix = match.groupValues[1].replace(Regex("\\s+"), "").uppercase()
-        if (prefix == "8") prefix = "B"
-        if (prefix == "8W" || prefix == "S8") prefix = "SW"
-
+        val prefix = normalizePrefix(match.groupValues[1])
         val token = normalizeTagToken(match.groupValues[2].trim('-'))
         val tag = "$prefix-$token"
         val trailingText = match.groupValues[3].takeIf { it.isNotBlank() }
 
         return (tag to trailingText).takeIf { isTag(tag) }
+    }
+
+    /**
+     * Normalizes the prefix using Regex to handle common OCR misreads (e.g., '8' as 'B').
+     */
+    private fun normalizePrefix(rawPrefix: String): String {
+        return rawPrefix.uppercase()
+            .replace(Regex("\\s+"), "")
+            .replace(Regex("^8$"), "B")
+            .replace(Regex("^(8W|S8)$"), "SW")
     }
 
     /**
@@ -55,7 +59,7 @@ internal object WidgetTagParser {
 
     /**
      * Cleans up the token suffix. If the token consists entirely of numbers or OCR artifacts,
-     * it converts those artifacts back to digits. Otherwise, it replaces invalid characters with underscores.
+     * it converts those artifacts back to digits.
      */
     private fun normalizeTagToken(rawToken: String): String {
         if (rawToken.isBlank()) return rawToken

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetTagParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetTagParser.kt
@@ -1,0 +1,84 @@
+package org.appdevforall.codeonthego.computervision.domain
+
+/**
+ * Parses and normalizes raw OCR text into standardized Android widget tags.
+ * Handles common OCR misreads and formatting inconsistencies.
+ */
+internal object WidgetTagParser {
+    private val tagRegex = Regex("^(?i)(B|P|D|T|C|R|SW|S)-[A-Z0-9_]+$")
+    private val tagExtractRegex = Regex("^(?i)(SW|S\\s*8|8\\s*W|[BPDTCRS8]\\s*W?)[^a-zA-Z0-9]*([A-Z0-9_\\-]+)(?:\\s+(.+))?$")
+
+    /**
+     * Checks if the given text represents a valid, normalized widget tag.
+     */
+    fun isTag(text: String): Boolean = normalizeTagText(text).matches(tagRegex)
+
+    /**
+     * Normalizes raw OCR text into a standard tag format (e.g., "Prefix-Token").
+     * Fixes common OCR prefix misreads, such as reading 'B' as '8'.
+     */
+    fun normalizeTagText(text: String): String {
+        val trimmed = text.trim().trimEnd('.', ',', ';', ':', '_', '|')
+        val match = tagExtractRegex.find(trimmed) ?: return trimmed.uppercase()
+
+        var prefix = match.groupValues[1].replace(Regex("\\s+"), "").uppercase()
+        if (prefix == "8") prefix = "B"
+        if (prefix == "8W" || prefix == "S8") prefix = "SW"
+
+        val token = normalizeTagToken(match.groupValues[2].trim('-'))
+        return "$prefix-$token"
+    }
+
+    /**
+     * Extracts a normalized widget tag and any remaining trailing text from a raw string.
+     * * @return A Pair containing the [normalized tag, trailing text], or null if no valid tag is found.
+     */
+    fun extractTag(text: String): Pair<String, String?>? {
+        val trimmed = text.trim().trimEnd('.', ',', ';', ':', '_', '|')
+        val match = tagExtractRegex.find(trimmed) ?: return null
+
+        var prefix = match.groupValues[1].replace(Regex("\\s+"), "").uppercase()
+        if (prefix == "8") prefix = "B"
+        if (prefix == "8W" || prefix == "S8") prefix = "SW"
+
+        val token = normalizeTagToken(match.groupValues[2].trim('-'))
+        val tag = "$prefix-$token"
+        val trailingText = match.groupValues[3].takeIf { it.isNotBlank() }
+
+        return (tag to trailingText).takeIf { isTag(tag) }
+    }
+
+    /**
+     * Extracts the numeric or alphanumeric identifier part of the tag (the part after the hyphen).
+     */
+    fun extractOrdinal(tag: String): Int? = tag.substringAfter('-', "").toIntOrNull()
+
+    /**
+     * Cleans up the token suffix. If the token consists entirely of numbers or OCR artifacts,
+     * it converts those artifacts back to digits. Otherwise, it replaces invalid characters with underscores.
+     */
+    private fun normalizeTagToken(rawToken: String): String {
+        if (rawToken.isBlank()) return rawToken
+
+        val uppercaseToken = rawToken.uppercase().replace('-', '_')
+        return if (uppercaseToken.all(::isNumericLikeOcrChar)) {
+            normalizeOcrDigits(uppercaseToken)
+        } else {
+            uppercaseToken.replace(Regex("[^A-Z0-9_]"), "_")
+        }
+    }
+
+    /**
+     * Replaces characters that are commonly misread by OCR with their intended numeric values.
+     */
+    private fun normalizeOcrDigits(raw: String): String =
+        raw.replace('l', '1').replace('I', '1').replace('!', '1')
+            .replace('o', '0').replace('O', '0')
+
+    /**
+     * Determines whether a character is a digit or a letter frequently confused with a digit by OCR.
+     */
+    private fun isNumericLikeOcrChar(char: Char): Boolean {
+        return char.isDigit() || char in setOf('O', 'I', 'L', 'Z', 'S', 'B', '!')
+    }
+}

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetTagParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetTagParser.kt
@@ -72,8 +72,13 @@ internal object WidgetTagParser {
      * Replaces characters that are commonly misread by OCR with their intended numeric values.
      */
     private fun normalizeOcrDigits(raw: String): String =
-        raw.replace('l', '1').replace('I', '1').replace('!', '1')
-            .replace('o', '0').replace('O', '0')
+        raw.replace('I', '1')
+            .replace('L', '1')
+            .replace('!', '1')
+            .replace('O', '0')
+            .replace('Z', '2')
+            .replace('S', '5')
+            .replace('B', '6')
 
     /**
      * Determines whether a character is a digit or a letter frequently confused with a digit by OCR.

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/AttributeValidator.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/grammar/AttributeValidator.kt
@@ -2,6 +2,7 @@ package org.appdevforall.codeonthego.computervision.domain.grammar
 
 
 import com.itsaky.androidide.fuzzysearch.FuzzySearch
+import org.appdevforall.codeonthego.computervision.utils.extractOcrEntries
 
 interface AttributeValidator {
     fun validate(rawValue: String): String?
@@ -76,13 +77,12 @@ object SliderStyleValidator : AttributeValidator {
 }
 
 object EntriesValidator : AttributeValidator {
-
     override fun validate(rawValue: String): String? {
         val trimmed = rawValue.trim()
         if (trimmed.startsWith("@")) return trimmed
 
         val content = trimmed.removeSurrounding("[", "]")
-        val rawItems = content.split(",")
+        val rawItems = content.extractOcrEntries()
 
         val isNumericArray = isEntireArrayLikelyNumeric(rawItems)
 
@@ -96,10 +96,6 @@ object EntriesValidator : AttributeValidator {
         }
 
         return cleanedItems.joinToString(",")
-    }
-
-    private fun isEnclosedInBrackets(text: String): Boolean {
-        return text.startsWith("[") && text.endsWith("]")
     }
 
     private fun isEntireArrayLikelyNumeric(items: List<String>): Boolean {

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidWidget.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/AndroidWidget.kt
@@ -2,6 +2,7 @@ package org.appdevforall.codeonthego.computervision.domain.xml
 
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
 import org.appdevforall.codeonthego.computervision.domain.FuzzyAttributeParser.AttributeKey
+import org.appdevforall.codeonthego.computervision.utils.extractOcrEntries
 
 sealed class AndroidWidget(
     protected open val box: ScaledBox?,
@@ -28,7 +29,7 @@ sealed class AndroidWidget(
         writeXml(context, indent, finalAttributes)
     }
 
-    private fun resolveWidgetId(context: XmlContext): String {
+    protected open fun resolveWidgetId(context: XmlContext): String {
         val requestedId = idOverride ?: parsedAttrs[AttributeKey.ID.xmlName]?.substringAfterLast('/')
         return context.resolveId(requestedId, fallbackIdLabel())
     }
@@ -76,6 +77,9 @@ sealed class AndroidWidget(
     }
 
     companion object {
+        private val nonAlphanumericRegex = Regex("[^a-z0-9_]")
+        private val multipleUnderscoresRegex = Regex("_+")
+
         fun create(box: ScaledBox, parsedAttrs: Map<String, String>): AndroidWidget {
             return when (box.label) {
                 "text", "button", "radio_button_unchecked", "radio_button_checked" ->
@@ -101,15 +105,42 @@ sealed class AndroidWidget(
             "slider" -> AndroidWidgetTags.SEEK_BAR
             else -> AndroidWidgetTags.VIEW
         }
+
+        internal fun sanitizeResourceName(raw: String): String {
+            return raw
+                .lowercase()
+                .replace('-', '_')
+                .replace(nonAlphanumericRegex, "_")
+                .replace(multipleUnderscoresRegex, "_")
+                .trim('_')
+        }
     }
 }
 
 class SpinnerWidget(
     override val box: ScaledBox, parsedAttrs: Map<String, String>
 ) : AndroidWidget(box, parsedAttrs) {
+    companion object {
+        private val placeholderEntries = setOf("year", "month", "day", "select", "choose", "dropdown")
+    }
+
     override val tag = AndroidWidgetTags.SPINNER
-    override fun fallbackIdLabel(): String = "spinner"
+    override fun fallbackIdLabel(): String {
+        val normalizedLabel = sanitizeResourceName(box.text.normalizedDropdownLabel())
+        return normalizedLabel.takeIf { it.isNotBlank() }?.let { "dd_$it" } ?: "spinner"
+    }
     override fun specificAttributes() = emptyMap<String, String>()
+
+    override fun resolveWidgetId(context: XmlContext): String {
+        val requestedId = idOverride ?: parsedAttrs[AttributeKey.ID.xmlName]?.substringAfterLast('/')
+        if (requestedId != null) return context.resolveId(requestedId, fallbackIdLabel())
+
+        val derivedId = fallbackIdLabel()
+        return derivedId
+            .takeUnless { it == "spinner" }
+            ?.let { context.resolveId(it, "spinner") }
+            ?: context.nextId("spinner")
+    }
 
     override fun processAttributes(context: XmlContext, id: String, attrs: Map<String, String>): Map<String, String> {
         val processed = mutableMapOf<String, String>()
@@ -124,7 +155,7 @@ class SpinnerWidget(
             }
             else -> rawEntries
                 .toSpinnerEntries()
-                .takeIf { it.isNotEmpty() }
+                .takeIf { items -> items.isNotEmpty() && !items.isSinglePlaceholderEntry() }
                 ?.let { items ->
                     val arrayName = "${id}_array"
                     context.stringArrays[arrayName] = items
@@ -141,11 +172,13 @@ class SpinnerWidget(
         return processed
     }
 
+    private fun List<String>.isSinglePlaceholderEntry(): Boolean {
+        if (size != 1) return false
+        return first().normalizedDropdownLabel().lowercase() in placeholderEntries
+    }
+
     private fun String.toSpinnerEntries(): List<String> {
-        return removeTrailingDropdownGlyph()
-            .split(Regex("\\s*[,;|/\\n]+\\s*"))
-            .map { it.trim() }
-            .filter { it.isNotEmpty() }
+        return this.removeTrailingDropdownGlyph().extractOcrEntries()
     }
 
     private fun String.removeTrailingDropdownGlyph(): String {
@@ -154,8 +187,20 @@ class SpinnerWidget(
             .trim()
     }
 
+    private fun String.removeLeadingDropdownHint(): String {
+        return trim()
+            .replace(Regex("^[vV]\\s+"), "")
+            .trim()
+    }
+
+    private fun String.normalizedDropdownLabel(): String {
+        return removeTrailingDropdownGlyph()
+            .removeLeadingDropdownHint()
+            .trim()
+    }
+
     private fun String.isMeaningfulDropdownText(): Boolean {
-        val cleaned = removeTrailingDropdownGlyph()
+        val cleaned = normalizedDropdownLabel()
         return cleaned.isNotBlank() && !cleaned.equals("dropdown", ignoreCase = true)
     }
 }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/OcrExtensions.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/OcrExtensions.kt
@@ -1,0 +1,29 @@
+package org.appdevforall.codeonthego.computervision.utils
+
+private val PUNCTUATION_DELIMITERS = Regex("\\s*[,;|/\\n]+\\s*")
+private val WHITESPACE_DELIMITERS = Regex("\\s+")
+private val OCR_NUMERIC_PATTERN = Regex("^[0-9oOlIzZsSbB]+$")
+
+/**
+ * Extracts separated entries from a raw OCR string.
+ * Tries to split by punctuation first. If no punctuation is found,
+ * it falls back to space-separated tokens, provided they all look like numbers or OCR artifacts.
+ */
+internal fun String.extractOcrEntries(): List<String> {
+    // Try to split by explicit punctuation or newlines
+    val punctuatedTokens = this.split(PUNCTUATION_DELIMITERS).filter { it.isNotBlank() }
+
+    // If successfully split into multiple items (or none), return them
+    if (punctuatedTokens.size != 1) {
+        return punctuatedTokens
+    }
+
+    // Fallback: check if elements were separated only by spaces
+    val whitespaceTokens = this.trim().split(WHITESPACE_DELIMITERS).filter { it.isNotBlank() }
+
+    // Only accept space separation if all resulting tokens look like numbers (or OCR artifacts)
+    val isSpaceSeparatedOcrNumbers = whitespaceTokens.size > 1 &&
+            whitespaceTokens.all { it.matches(OCR_NUMERIC_PATTERN) }
+
+    return if (isSpaceSeparatedOcrNumbers) whitespaceTokens else punctuatedTokens
+}


### PR DESCRIPTION
## Description

Fixed an issue where single placeholder labels (e.g., "dropdown", "select", "choose") sketched inside a spinner/dropdown widget incorrectly generated a `string-array` in `strings.xml`. Additionally, OCR tag parsing logic has been refactored and centralized into a new `WidgetTagParser` object.

## Details

* Added `isSinglePlaceholderEntry()` check in `SpinnerWidget` to bypass string array creation when the only item is a known placeholder.
* Extracted and centralized OCR normalization and tag extraction logic from `MarginAnnotationParser` and `WidgetAnnotationMatcher` into `WidgetTagParser`.
* Improved regex tokenization for splitting entry candidates in `AttributeValidator`.

https://github.com/user-attachments/assets/33268bce-b79c-440c-b72a-424aac5adfd7


## Ticket

[ADFA-3910](https://appdevforall.atlassian.net/browse/ADFA-3910)

## Observation

Centralizing the tag parsing logic into `WidgetTagParser` significantly cleans up the margin and annotation matching domains, ensuring that OCR text normalization (e.g., replacing 'l' with '1', 'O' with '0') is applied consistently across the entire pipeline.

[ADFA-3910]: https://appdevforall.atlassian.net/browse/ADFA-3910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ