### PR TITLE
ADFA-2759 Fix LogViewFragment ArrayIndexOutOfBoundsException on early append

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/fragments/output/LogViewFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/LogViewFragment.kt
@@ -112,6 +112,13 @@ abstract class LogViewFragment<V : LogViewModel> :
 	}
 
 	private suspend fun observeLogs(): Nothing {
+		// Wait for the editor's first layout pass. The sora-editor's
+		// LineBreakLayout populates its line-width tracker asynchronously after
+		// layout; appending before that races BlockIntList.set on an empty list.
+		_binding?.editor?.awaitLayout(
+			onForceVisible = { emptyStateViewModel.setEmpty(false) },
+		)
+
 		viewModel.uiEvents.collect { event ->
 			when (event) {
 				is LogViewModel.UiEvent.Append -> {
@@ -161,9 +168,10 @@ abstract class LogViewFragment<V : LogViewModel> :
 			return
 		}
 
-		_binding?.editor?.append(chars)?.also {
-			emptyStateViewModel.setEmpty(false)
-		}
+		val editor = _binding?.editor ?: return
+		if (!editor.isReadyToAppend) return
+		editor.appendBatch(chars.toString())
+		emptyStateViewModel.setEmpty(false)
 	}
 
 	@UiThread


### PR DESCRIPTION
The Sora editor's LineBreakLayout populates its line-width tracker asynchronously after the first layout pass. When ViewPager2 placed IDELogFragment / AppLogFragment during a swipe and the log flow emitted before that pass, Content.insert reached BlockIntList.set on a length-0 list and crashed (Sentry APPDEVFORALL-D0).

Apply the same awaitLayout + appendBatch pattern already proven in BuildOutputFragment (ADFA-2593): wait once for editor layout before collecting, and route per-emission appends through appendBatch, which is gated by isReadyToAppend and wraps the underlying call in runCatching.