### PR TITLE
ADFA-3919: upgrade kotlin-android to latest version

### DIFF
--- a/subprojects/kotlin-analysis-api/build.gradle.kts
+++ b/subprojects/kotlin-analysis-api/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 
 val ktAndroidRepo = "https://github.com/appdevforall/kotlin-android"
 val ktAndroidVersion = "2.3.255"
-val ktAndroidTag = "v${ktAndroidVersion}-73dd157"
+val ktAndroidTag = "v${ktAndroidVersion}-ac7aa4b"
 val ktAndroidJarName = "analysis-api-standalone-embeddable-for-ide-${ktAndroidVersion}-SNAPSHOT.jar"
 
 externalAssets {
@@ -21,7 +21,7 @@ externalAssets {
 		source =
 			AssetSource.External(
 				url = uri("$ktAndroidRepo/releases/download/$ktAndroidTag/$ktAndroidJarName"),
-				sha256Checksum = "40d05b02579f495c07a38724314ce4d4c68e55325e0433a9bbe49d3243049607",
+				sha256Checksum = "810a93e148c2fa697a7aaf6e3c2d3356146602ed8c937ba7faf7685348f988f6",
 			)
 	}
 }


### PR DESCRIPTION
Fixes an issue where the kotlin-android's Unsafe class would reset all exemptions.

See [ADFA-3919](https://appdevforall.atlassian.net/browse/ADFA-3919) for more details.

[ADFA-3919]: https://appdevforall.atlassian.net/browse/ADFA-3919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ