### PR TITLE
ADFA-3972 | Add visual hints for image placeholders

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/data/repository/DrawableImportHelper.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/data/repository/DrawableImportHelper.kt
@@ -8,10 +8,25 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.Locale
 
+/**
+ * Helper class responsible for importing and managing image files within an Android project's
+ * resource directory (e.g., res/drawable).
+ *
+ * @property contentResolver The ContentResolver used to read data from content URIs.
+ */
 class DrawableImportHelper(
     private val contentResolver: ContentResolver
 ) {
 
+    /**
+     * Imports an image from a given URI into the 'res/drawable' directory associated with
+     * the provided layout file.
+     *
+     * @param sourceUri The URI of the image to import.
+     * @param layoutFilePath The absolute path to the current layout XML file. Used to locate the 'res' directory.
+     * @param fallbackName A name to use if the original file name cannot be resolved.
+     * @return A [Result] containing an [ImportedDrawable] if successful, or an exception on failure.
+     */
     suspend fun importDrawable(
         sourceUri: Uri,
         layoutFilePath: String?,
@@ -19,26 +34,63 @@ class DrawableImportHelper(
     ): Result<ImportedDrawable> = withContext(Dispatchers.IO) {
         runCatching {
             requireNotNull(layoutFilePath) { "Layout file path is not available." }
-            val layoutFile = File(layoutFilePath)
 
-            val drawableDir = resolveDrawableDir(layoutFile)
-            check(drawableDir.exists() || drawableDir.mkdirs()) {
-                "Could not create drawable directory: ${drawableDir.absolutePath}"
-            }
-
+            val drawableDir = getOrCreateDrawableDirectory(layoutFilePath)
             val extension = resolveSupportedExtension(sourceUri, fallbackName)
             val baseName = sanitizeResourceName(resolveDisplayName(sourceUri) ?: fallbackName)
             val destinationFile = resolveAvailableFile(drawableDir, baseName, extension)
 
-            contentResolver.openInputStream(sourceUri)?.use { input ->
-                destinationFile.outputStream().use(input::copyTo)
-            } ?: error("Could not open selected image.")
+            copyImageToDestination(sourceUri, destinationFile)
 
             ImportedDrawable(
                 resourceName = destinationFile.nameWithoutExtension,
                 drawableReference = "@drawable/${destinationFile.nameWithoutExtension}",
                 file = destinationFile
             )
+        }
+    }
+
+    /**
+     * Deletes an imported drawable file from the filesystem.
+     *
+     * @param layoutFilePath The absolute path to the current layout XML file. Used to locate the 'res' directory.
+     * @param resourceName The sanitized name of the resource to delete (without extension).
+     * @return A [Result] indicating success (true if deleted, false if file did not exist) or failure.
+     */
+    suspend fun deleteDrawable(
+        layoutFilePath: String?,
+        resourceName: String
+    ): Result<Boolean> = withContext(Dispatchers.IO) {
+        runCatching {
+            requireNotNull(layoutFilePath) { "Layout file path is not available." }
+
+            val drawableDir = resolveDrawableDir(File(layoutFilePath))
+            if (!drawableDir.exists()) return@runCatching false
+
+            val targetFile = findFileByResourceName(drawableDir, resourceName)
+
+            targetFile?.delete() ?: false
+        }
+    }
+
+    private fun getOrCreateDrawableDirectory(layoutFilePath: String): File {
+        val layoutFile = File(layoutFilePath)
+        val drawableDir = resolveDrawableDir(layoutFile)
+        check(drawableDir.exists() || drawableDir.mkdirs()) {
+            "Could not create drawable directory: ${drawableDir.absolutePath}"
+        }
+        return drawableDir
+    }
+
+    private fun copyImageToDestination(sourceUri: Uri, destinationFile: File) {
+        contentResolver.openInputStream(sourceUri)?.use { input ->
+            destinationFile.outputStream().use(input::copyTo)
+        } ?: error("Could not open selected image.")
+    }
+
+    private fun findFileByResourceName(directory: File, resourceName: String): File? {
+         return directory.listFiles()?.firstOrNull {
+            it.nameWithoutExtension == resourceName
         }
     }
 

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/ui/ComputerVisionActivity.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/ui/ComputerVisionActivity.kt
@@ -120,6 +120,7 @@ class ComputerVisionActivity : AppCompatActivity() {
                 selectedPlaceholderIds = state.selectedImagesByPlaceholderId.keys
             )
         } else {
+            detectionVisualizer.clearCache()
             state.currentBitmap
         }
 

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/ui/ComputerVisionActivity.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/ui/ComputerVisionActivity.kt
@@ -3,15 +3,8 @@ package org.appdevforall.codeonthego.computervision.ui
 import android.Manifest
 import android.content.ContentValues
 import android.content.Intent
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Paint
-import android.os.Build
 import android.os.Bundle
-import android.os.Environment
 import android.provider.MediaStore
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
@@ -23,50 +16,25 @@ import com.itsaky.androidide.FeedbackButtonManager
 import kotlinx.coroutines.launch
 import org.appdevforall.codeonthego.computervision.R
 import org.appdevforall.codeonthego.computervision.databinding.ActivityComputerVisionBinding
-import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
 import org.appdevforall.codeonthego.computervision.ui.viewmodel.ComputerVisionViewModel
+import org.appdevforall.codeonthego.computervision.utils.DetectionVisualizer
+import org.appdevforall.codeonthego.computervision.utils.XmlFileManager
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
-import java.io.File
-import java.io.FileOutputStream
-import java.io.IOException
 
 class ComputerVisionActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityComputerVisionBinding
     private var feedbackButtonManager: FeedbackButtonManager? = null
+
+    private val detectionVisualizer by lazy { DetectionVisualizer(this) }
+    private val xmlFileManager by lazy { XmlFileManager(this) }
+
     private val viewModel: ComputerVisionViewModel by viewModel {
         parametersOf(
             intent.getStringExtra(EXTRA_LAYOUT_FILE_PATH),
             intent.getStringExtra(EXTRA_LAYOUT_FILE_NAME)
         )
-    }
-
-    private val boundingBoxPaint by lazy {
-        Paint().apply {
-            color = Color.GREEN
-            style = Paint.Style.STROKE
-            strokeWidth = 5.0f
-            alpha = 200
-        }
-    }
-
-    private val textRecognitionBoxPaint by lazy {
-        Paint().apply {
-            color = Color.BLUE
-            style = Paint.Style.STROKE
-            strokeWidth = 3.0f
-            alpha = 200
-        }
-    }
-
-    private val textPaint by lazy {
-        Paint().apply {
-            color = Color.WHITE
-            style = Paint.Style.FILL
-            textSize = 40.0f
-            setShadowLayer(5.0f, 0f, 0f, Color.BLACK)
-        }
     }
 
     private var currentCameraUri: android.net.Uri? = null
@@ -87,12 +55,10 @@ class ComputerVisionActivity : AppCompatActivity() {
         else Toast.makeText(this, R.string.msg_camera_permission_required, Toast.LENGTH_LONG).show()
     }
 
-    private val pickPlaceholderImageLauncher =
-        registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-            uri?.let {
-                viewModel.onEvent(ComputerVisionEvent.PlaceholderImageSelected(it))
-            } ?: Toast.makeText(this, R.string.msg_no_image_selected, Toast.LENGTH_SHORT).show()
-        }
+    private val pickPlaceholderImageLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        uri?.let { viewModel.onEvent(ComputerVisionEvent.PlaceholderImageSelected(it)) }
+            ?: Toast.makeText(this, R.string.msg_no_image_selected, Toast.LENGTH_SHORT).show()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -113,28 +79,12 @@ class ComputerVisionActivity : AppCompatActivity() {
     }
 
     private fun setupClickListeners() {
-        binding.imageView.setOnClickListener {
-            viewModel.onEvent(ComputerVisionEvent.OpenImagePicker)
-        }
-        binding.detectButton.setOnClickListener {
-            viewModel.onEvent(ComputerVisionEvent.RunDetection)
-        }
-        binding.updateButton.setOnClickListener {
-            viewModel.onEvent(ComputerVisionEvent.UpdateLayoutFile)
-        }
-        binding.saveButton.setOnClickListener {
-            viewModel.onEvent(ComputerVisionEvent.SaveToDownloads)
-        }
-        binding.imageView.onImageTapListener = imageTap@{ imageX, imageY ->
-            if (!viewModel.isImagePlaceholderAt(imageX, imageY)) return@imageTap false
-
-            viewModel.onEvent(
-                ComputerVisionEvent.ImagePlaceholderTapped(
-                    imageX = imageX,
-                    imageY = imageY
-                )
-            )
-            true
+        with(binding) {
+            imageView.setOnClickListener { viewModel.onEvent(ComputerVisionEvent.OpenImagePicker) }
+            detectButton.setOnClickListener { viewModel.onEvent(ComputerVisionEvent.RunDetection) }
+            updateButton.setOnClickListener { viewModel.onEvent(ComputerVisionEvent.UpdateLayoutFile) }
+            saveButton.setOnClickListener { viewModel.onEvent(ComputerVisionEvent.SaveToDownloads) }
+            imageView.onImageTapListener = ::handleImageTap
         }
     }
 
@@ -142,22 +92,14 @@ class ComputerVisionActivity : AppCompatActivity() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.onScreenStarted()
-                viewModel.uiState.collect { state -> updateUi(state) }
-            }
-        }
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.uiEffect.collect { effect -> handleEffect(effect) }
+                launch { viewModel.uiState.collect { updateUi(it) } }
+                launch { viewModel.uiEffect.collect { handleEffect(it) } }
             }
         }
     }
+
     private fun setupFeedbackButton(){
-        feedbackButtonManager =
-            FeedbackButtonManager(
-                activity = this,
-                feedbackFab = binding.fabFeedback,
-            )
+        feedbackButtonManager = FeedbackButtonManager(activity = this, feedbackFab = binding.fabFeedback)
         feedbackButtonManager?.setupDraggableFab()
     }
 
@@ -172,10 +114,15 @@ class ComputerVisionActivity : AppCompatActivity() {
 
     private fun updateUi(state: ComputerVisionUiState) {
         val displayBitmap = if (state.hasDetections && state.currentBitmap != null) {
-            visualizeDetections(state.currentBitmap, state.detections)
+            detectionVisualizer.visualize(
+                bitmap = state.currentBitmap,
+                detections = state.detections,
+                selectedPlaceholderIds = state.selectedImagesByPlaceholderId.keys
+            )
         } else {
             state.currentBitmap
         }
+
         binding.imageView.setImageBitmap(displayBitmap)
         state.currentBitmap?.let {
             binding.guidelinesView.setImageDimensions(it.width, it.height)
@@ -203,25 +150,41 @@ class ComputerVisionActivity : AppCompatActivity() {
             is ComputerVisionEffect.ShowConfirmDialog ->
                 showUpdateConfirmationDialog(effect.fileName)
             is ComputerVisionEffect.ReturnXmlResult -> returnXmlResult(effect.layoutXml, effect.stringsXml)
-            is ComputerVisionEffect.FileSaved -> saveXmlToFile(effect.fileName)
             ComputerVisionEffect.NavigateBack -> finish()
             ComputerVisionEffect.OpenPlaceholderImagePicker ->
                 pickPlaceholderImageLauncher.launch("image/*")
+            is ComputerVisionEffect.FileSaved -> saveXmlFile(effect.fileName)
         }
     }
 
-    private fun visualizeDetections(bitmap: Bitmap, detections: List<DetectionResult>): Bitmap {
-        val mutableBitmap = bitmap.copy(Bitmap.Config.ARGB_8888, true)
-        val canvas = Canvas(mutableBitmap)
-        for (result in detections) {
-            val paint = if (result.isYolo) boundingBoxPaint else textRecognitionBoxPaint
-            canvas.drawRect(result.boundingBox, paint)
-            val label = result.label.take(15)
-            val text = if (result.text.isNotEmpty()) "${label}: ${result.text}" else label
-            canvas.drawText(text, result.boundingBox.left, result.boundingBox.top - 5, textPaint)
+    /**
+     * Handles tap events on the image view, determining whether the user tapped
+     * a delete action or a general placeholder, and routes the event to the ViewModel.
+     *
+     * @param imageX The X coordinate of the tap on the original image.
+     * @param imageY The Y coordinate of the tap on the original image.
+     * @return True if the tap was handled, false otherwise.
+     */
+    private fun handleImageTap(imageX: Float, imageY: Float): Boolean {
+        val tappedDeleteId = detectionVisualizer.getTappedDeleteIconId(imageX, imageY)
+        if (tappedDeleteId != null) {
+            viewModel.onEvent(ComputerVisionEvent.RemovePlaceholderImage(tappedDeleteId))
+            return true
         }
-        Log.d(TAG, "Visualizing ${detections.size} detections")
-        return mutableBitmap
+
+        if (!viewModel.isImagePlaceholderAt(imageX, imageY)) return false
+
+        viewModel.onEvent(ComputerVisionEvent.ImagePlaceholderTapped(imageX, imageY))
+        return true
+    }
+
+    private fun saveXmlFile(xmlString: String) {
+        val result = xmlFileManager.saveXmlToDownloads(xmlString)
+        result.onSuccess { fileName ->
+            Toast.makeText(this, getString(R.string.msg_saved_to_downloads, fileName), Toast.LENGTH_LONG).show()
+        }.onFailure { error ->
+            Toast.makeText(this, getString(R.string.msg_error_saving_file, error.message), Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun showUpdateConfirmationDialog(fileName: String) {
@@ -246,41 +209,6 @@ class ComputerVisionActivity : AppCompatActivity() {
         finish()
     }
 
-    private fun saveXmlToFile(xmlString: String) {
-        val fileName = "testing_result.xml"
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                val resolver = contentResolver
-                val contentValues = ContentValues().apply {
-                    put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
-                    put(MediaStore.MediaColumns.MIME_TYPE, "text/xml")
-                    put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
-                }
-                val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
-                    ?: throw IOException("Failed to create new MediaStore record.")
-                resolver.openOutputStream(uri).use { outputStream ->
-                    outputStream?.write(xmlString.toByteArray())
-                }
-            } else {
-                @Suppress("DEPRECATION")
-                val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-                if (!downloadsDir.exists()) downloadsDir.mkdirs()
-                val file = File(downloadsDir, fileName)
-                FileOutputStream(file).use { outputStream ->
-                    outputStream.write(xmlString.toByteArray())
-                }
-            }
-            Toast.makeText(this, getString(R.string.msg_saved_to_downloads, fileName), Toast.LENGTH_LONG).show()
-        } catch (e: IOException) {
-            Log.e(TAG, "Failed to save XML file", e)
-            Toast.makeText(this, getString(R.string.msg_error_saving_file, e.message), Toast.LENGTH_SHORT).show()
-        }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        feedbackButtonManager?.loadFabPosition()
-    }
     private fun launchCamera() {
         val values = ContentValues().apply {
             put(MediaStore.Images.Media.TITLE, getString(R.string.camera_picture_title))
@@ -292,8 +220,12 @@ class ComputerVisionActivity : AppCompatActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        feedbackButtonManager?.loadFabPosition()
+    }
+
     companion object {
-        private const val TAG = "ComputerVisionActivity"
         const val EXTRA_LAYOUT_FILE_PATH = "com.example.images.LAYOUT_FILE_PATH"
         const val EXTRA_LAYOUT_FILE_NAME = "com.example.images.LAYOUT_FILE_NAME"
         const val RESULT_GENERATED_XML = "ide.uidesigner.generatedXml"

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/ui/ComputerVisionEvent.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/ui/ComputerVisionEvent.kt
@@ -14,4 +14,5 @@ sealed class ComputerVisionEvent {
     data class UpdateGuides(val leftPct: Float, val rightPct: Float) : ComputerVisionEvent()
     data class ImagePlaceholderTapped(val imageX: Float, val imageY: Float) : ComputerVisionEvent()
     data class PlaceholderImageSelected(val uri: Uri) : ComputerVisionEvent()
+    data class RemovePlaceholderImage(val placeholderId: String) : ComputerVisionEvent()
 }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/ui/viewmodel/ComputerVisionViewModel.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/ui/viewmodel/ComputerVisionViewModel.kt
@@ -462,16 +462,15 @@ class ComputerVisionViewModel(
                 resourceName = importedImageInfo.resourceName
             )
 
-            if (deletionResult.isSuccess || deletionResult.exceptionOrNull() is Exception) {
-                // Update state idiomatically by filtering out the removed key
+            deletionResult.onSuccess {
                 _uiState.update { currentState ->
                     currentState.copy(
-                        selectedImagesByPlaceholderId = currentState.selectedImagesByPlaceholderId.filterKeys { it != placeholderId }
+                        selectedImagesByPlaceholderId = currentState.selectedImagesByPlaceholderId - placeholderId
                     )
                 }
                 _uiEffect.send(ComputerVisionEffect.ShowToast(R.string.msg_image_removed))
-            } else {
-                _uiEffect.send(ComputerVisionEffect.ShowError("Failed to clean up image file."))
+            }.onFailure { exception ->
+                _uiEffect.send(ComputerVisionEffect.ShowError("Failed to clean up image file: ${exception.message}"))
             }
         }
     }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/ui/viewmodel/ComputerVisionViewModel.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/ui/viewmodel/ComputerVisionViewModel.kt
@@ -90,6 +90,10 @@ class ComputerVisionViewModel(
             is ComputerVisionEvent.PlaceholderImageSelected -> {
                 handlePlaceholderImageSelected(event.uri)
             }
+
+            is ComputerVisionEvent.RemovePlaceholderImage -> {
+                removePlaceholderImage(event.placeholderId)
+            }
         }
     }
 
@@ -438,6 +442,36 @@ class ComputerVisionViewModel(
                         "Image import failed: ${exception.message}"
                     )
                 )
+            }
+        }
+    }
+
+    /**
+     * Safely removes a selected image from the placeholder state.
+     * Uses Dispatchers.IO for any required file cleanup to prevent UI blocking.
+     *
+     * @param placeholderId The ID of the placeholder to clear.
+     */
+    private fun removePlaceholderImage(placeholderId: String) {
+        val state = _uiState.value
+        val importedImageInfo = state.selectedImagesByPlaceholderId[placeholderId] ?: return
+
+        viewModelScope.launch {
+            val deletionResult = drawableImportHelper.deleteDrawable(
+                layoutFilePath = state.layoutFilePath,
+                resourceName = importedImageInfo.resourceName
+            )
+
+            if (deletionResult.isSuccess || deletionResult.exceptionOrNull() is Exception) {
+                // Update state idiomatically by filtering out the removed key
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        selectedImagesByPlaceholderId = currentState.selectedImagesByPlaceholderId.filterKeys { it != placeholderId }
+                    )
+                }
+                _uiEffect.send(ComputerVisionEffect.ShowToast(R.string.msg_image_removed))
+            } else {
+                _uiEffect.send(ComputerVisionEffect.ShowError("Failed to clean up image file."))
             }
         }
     }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/DetectionVisualizer.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/DetectionVisualizer.kt
@@ -222,4 +222,8 @@ class DetectionVisualizer(private val context: Context) {
         iconDrawable.setBounds(left, top, right, bottom)
         iconDrawable.draw(canvas)
     }
+
+    fun clearCache() {
+        deleteIconClickableAreas.clear()
+    }
 }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/DetectionVisualizer.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/DetectionVisualizer.kt
@@ -7,7 +7,6 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.drawable.Drawable
-import android.util.Log
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.toColorInt
 import org.appdevforall.codeonthego.computervision.R
@@ -126,7 +125,6 @@ class DetectionVisualizer(private val context: Context) {
             }
         }
 
-        Log.d("DetectionVisualizer", "Visualizing ${detections.size} detections")
         return mutableBitmap
     }
 

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/DetectionVisualizer.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/DetectionVisualizer.kt
@@ -1,0 +1,225 @@
+package org.appdevforall.codeonthego.computervision.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.drawable.Drawable
+import android.util.Log
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.toColorInt
+import org.appdevforall.codeonthego.computervision.R
+import org.appdevforall.codeonthego.computervision.domain.model.DetectionResult
+
+
+/**
+ * Utility class responsible for visualizing computer vision detection results.
+ * It handles drawing bounding boxes, text labels, and interactive visual hints
+ * directly onto image bitmaps.
+ *
+ * @property context The context used to retrieve resources such as drawables.
+ */
+class DetectionVisualizer(private val context: Context) {
+
+    private val boundingBoxPaint by lazy {
+        Paint().apply {
+            color = Color.GREEN
+            style = Paint.Style.STROKE
+            strokeWidth = 5.0f
+            alpha = 200
+        }
+    }
+
+    private val imagePlaceholderPaint by lazy {
+        Paint().apply {
+            color = "#FF8A00".toColorInt()
+            style = Paint.Style.STROKE
+            strokeWidth = 7.0f
+            alpha = 230
+        }
+    }
+
+    private val imagePlaceholderFillPaint by lazy {
+        Paint().apply {
+            color = "#FF8A00".toColorInt()
+            style = Paint.Style.FILL
+            alpha = 40
+        }
+    }
+
+    private val textRecognitionBoxPaint by lazy {
+        Paint().apply {
+            color = Color.BLUE
+            style = Paint.Style.STROKE
+            strokeWidth = 3.0f
+            alpha = 200
+        }
+    }
+
+    private val textPaint by lazy {
+        Paint().apply {
+            color = Color.WHITE
+            style = Paint.Style.FILL
+            textSize = 40.0f
+            setShadowLayer(5.0f, 0f, 0f, Color.BLACK)
+        }
+    }
+
+    private val imagePlaceholderUploadDrawable: Drawable? by lazy {
+        AppCompatResources.getDrawable(context, R.drawable.ic_placeholder_upload)?.mutate()?.apply {
+            setTint(Color.WHITE)
+        }
+    }
+
+    private val imagePlaceholderDeleteDrawable: Drawable? by lazy {
+        AppCompatResources.getDrawable(context, R.drawable.ic_placeholder_delete)?.mutate()?.apply {
+            setTint(Color.WHITE)
+        }
+    }
+
+    private val imagePlaceholderBadgePaint by lazy {
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = "#CC111111".toColorInt()
+            style = Paint.Style.FILL
+        }
+    }
+
+    private val deleteBadgeBackgroundPaint by lazy {
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = "#CCB3261E".toColorInt()
+            style = Paint.Style.FILL
+        }
+    }
+
+    private val deleteIconClickableAreas = mutableMapOf<String, RectF>()
+
+    /**
+     * Draws detection bounding boxes, labels, and interactive placeholder hints on a given bitmap.
+     *
+     * @param bitmap The original image on which detections were performed.
+     * @param detections A list of [DetectionResult] objects containing the bounding boxes and labels.
+     * @param selectedPlaceholderIds A set of IDs representing image placeholders that have been selected/filled.
+     * @return A new [Bitmap] instance with the visualized detections drawn over it.
+     */
+    fun visualize(
+        bitmap: Bitmap,
+        detections: List<DetectionResult>,
+        selectedPlaceholderIds: Set<String>
+    ): Bitmap {
+        val mutableBitmap = bitmap.copy(Bitmap.Config.ARGB_8888, true)
+        val canvas = Canvas(mutableBitmap)
+
+        deleteIconClickableAreas.clear()
+
+        val placeholderIdsByDetection = mapPlaceholderDetections(detections)
+
+        for (result in detections) {
+            if (result.label == IMAGE_PLACEHOLDER_LABEL) {
+                val placeholderId = placeholderIdsByDetection[result] ?: continue
+                val hasSelectedImage = selectedPlaceholderIds.contains(placeholderId)
+
+                drawImagePlaceholderHint(canvas, result.boundingBox, hasSelectedImage, placeholderId)
+            } else {
+                drawStandardDetection(canvas, result)
+            }
+        }
+
+        Log.d("DetectionVisualizer", "Visualizing ${detections.size} detections")
+        return mutableBitmap
+    }
+
+    /**
+     * Checks if the given X, Y coordinates intersect with any drawn delete icon.
+     * @return The placeholderId if a delete icon was tapped, null otherwise.
+     */
+    fun getTappedDeleteIconId(x: Float, y: Float): String? {
+        return deleteIconClickableAreas.entries.firstOrNull { it.value.contains(x, y) }?.key
+    }
+
+    /**
+     * Filters and maps image placeholder detections to their corresponding auto-generated IDs.
+     * Placeholders are sorted from top to bottom, left to right to ensure consistent ID assignment.
+     *
+     * @param detections The full list of detections.
+     * @return A map linking each placeholder [DetectionResult] to its generated string ID (e.g., "ph_0").
+     */
+    private fun mapPlaceholderDetections(detections: List<DetectionResult>): Map<DetectionResult, String> {
+        return detections
+            .filter { it.label == IMAGE_PLACEHOLDER_LABEL }
+            .sortedWith(compareBy({ it.boundingBox.top }, { it.boundingBox.left }))
+            .mapIndexed { index, detection ->
+                detection to "ph_$index"
+            }.toMap()
+    }
+
+    /**
+     * Draws a standard detection bounding box and its corresponding text label.
+     * It uses different colors depending on whether the detection is from YOLO or Text Recognition.
+     *
+     * @param canvas The canvas to draw the detection on.
+     * @param result The [DetectionResult] containing the coordinates, label, and detection type.
+     */
+    private fun drawStandardDetection(canvas: Canvas, result: DetectionResult) {
+        val paint = if (result.isYolo) boundingBoxPaint else textRecognitionBoxPaint
+        canvas.drawRect(result.boundingBox, paint)
+
+        val label = result.label.take(15)
+        val text = if (result.text.isNotEmpty()) "$label: ${result.text}" else label
+        canvas.drawText(text, result.boundingBox.left, result.boundingBox.top - 5, textPaint)
+    }
+
+    /**
+     * Draws a highlighted region and a central badge for an image placeholder detection.
+     *
+     * @param canvas The canvas to draw the hint on.
+     * @param boundingBox The rectangular bounds of the detected image placeholder.
+     * @param hasSelectedImage A flag indicating whether the user has already selected an image for this placeholder.
+     */
+    private fun drawImagePlaceholderHint(
+        canvas: Canvas,
+        boundingBox: RectF,
+        hasSelectedImage: Boolean,
+        placeholderId: String
+    ) {
+        canvas.drawRect(boundingBox, imagePlaceholderFillPaint)
+        canvas.drawRect(boundingBox, imagePlaceholderPaint)
+
+        val badgeHeight = (boundingBox.height() * 0.24f).coerceIn(44f, 72f)
+        val badgeTop = (boundingBox.centerY() - badgeHeight / 2f).coerceAtLeast(boundingBox.top + 8f)
+        val badgeBottom = (badgeTop + badgeHeight).coerceAtMost(boundingBox.bottom - 8f)
+
+        val badgeRect = RectF(
+            boundingBox.left + 12f,
+            badgeTop,
+            boundingBox.right - 12f,
+            badgeBottom
+        )
+
+        val bgPaint = if (hasSelectedImage) deleteBadgeBackgroundPaint else imagePlaceholderBadgePaint
+        canvas.drawRoundRect(badgeRect, 16f, 16f, bgPaint)
+
+        drawPlaceholderIcon(canvas, badgeRect, hasSelectedImage)
+
+        if (hasSelectedImage) {
+            deleteIconClickableAreas[placeholderId] = badgeRect
+        }
+    }
+
+    private fun drawPlaceholderIcon(canvas: Canvas, badgeRect: RectF, hasSelectedImage: Boolean) {
+        val iconDrawable = if (hasSelectedImage) imagePlaceholderDeleteDrawable else imagePlaceholderUploadDrawable
+        if (iconDrawable == null) return
+
+        val iconSize = minOf(badgeRect.width(), badgeRect.height()) * 0.80f
+
+        val left = (badgeRect.centerX() - iconSize / 2f).toInt()
+        val top = (badgeRect.centerY() - iconSize / 2f).toInt()
+        val right = (badgeRect.centerX() + iconSize / 2f).toInt()
+        val bottom = (badgeRect.centerY() + iconSize / 2f).toInt()
+
+        iconDrawable.alpha = 255
+        iconDrawable.setBounds(left, top, right, bottom)
+        iconDrawable.draw(canvas)
+    }
+}

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/XmlFileManager.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/XmlFileManager.kt
@@ -25,10 +25,10 @@ class XmlFileManager(private val context: Context) {
      * Android 10 (API 29+) and older versions.
      *
      * @param xmlString The XML content to be saved.
-     * @param fileName The desired name for the output file. Defaults to "testing_result.xml".
+     * @param fileName The desired name for the output file. Defaults to "layout_result.xml".
      * @return A [Result] containing the file name if successful, or an [IOException] on failure.
      */
-    fun saveXmlToDownloads(xmlString: String, fileName: String = "testing_result.xml"): Result<String> {
+    fun saveXmlToDownloads(xmlString: String, fileName: String = "layout_result.xml"): Result<String> {
         return try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 saveUsingMediaStore(xmlString, fileName)

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/XmlFileManager.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/XmlFileManager.kt
@@ -1,0 +1,90 @@
+package org.appdevforall.codeonthego.computervision.utils
+
+import android.content.ContentValues
+import android.content.Context
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.annotation.RequiresApi
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+
+/**
+ * Utility class responsible for managing file input/output operations.
+ * Specifically handles saving XML files to the device's public Downloads directory,
+ * adapting to different Android API levels (Scoped Storage vs Legacy).
+ *
+ * @property context The application or activity context needed to access content resolvers.
+ */
+class XmlFileManager(private val context: Context) {
+
+    /**
+     * Saves an XML string to a file in the device's public Downloads directory.
+     * It automatically handles the differences in file storage APIs between
+     * Android 10 (API 29+) and older versions.
+     *
+     * @param xmlString The XML content to be saved.
+     * @param fileName The desired name for the output file. Defaults to "testing_result.xml".
+     * @return A [Result] containing the file name if successful, or an [IOException] on failure.
+     */
+    fun saveXmlToDownloads(xmlString: String, fileName: String = "testing_result.xml"): Result<String> {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                saveUsingMediaStore(xmlString, fileName)
+            } else {
+                saveUsingLegacyFileApi(xmlString, fileName)
+            }
+            Result.success(fileName)
+        } catch (e: IOException) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Saves the file using the MediaStore API.
+     * This is the required approach for Android 10 (API 29) and above due to Scoped Storage restrictions.
+     *
+     * @param xmlString The XML content to write.
+     * @param fileName The name of the file.
+     * @throws IOException If the MediaStore record cannot be created or written to.
+     */
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun saveUsingMediaStore(xmlString: String, fileName: String) {
+        val resolver = context.contentResolver
+        val contentValues = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
+            put(MediaStore.MediaColumns.MIME_TYPE, "text/xml")
+            put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+        }
+
+        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
+            ?: throw IOException("Failed to create new MediaStore record for $fileName.")
+
+        resolver.openOutputStream(uri)?.use { outputStream ->
+            outputStream.write(xmlString.toByteArray())
+        } ?: throw IOException("Failed to open output stream for MediaStore URI.")
+    }
+
+    /**
+     * Saves the file using the legacy File API.
+     * This approach is used for devices running Android 9 (API 28) or lower.
+     *
+     * @param xmlString The XML content to write.
+     * @param fileName The name of the file.
+     * @throws IOException If the Downloads directory or the file cannot be created.
+     */
+    @Suppress("DEPRECATION")
+    private fun saveUsingLegacyFileApi(xmlString: String, fileName: String) {
+        val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+
+        if (!downloadsDir.exists() && !downloadsDir.mkdirs()) {
+            throw IOException("Failed to create Downloads directory.")
+        }
+
+        val file = File(downloadsDir, fileName)
+        FileOutputStream(file).use { outputStream ->
+            outputStream.write(xmlString.toByteArray())
+        }
+    }
+}

--- a/cv-image-to-xml/src/main/res/drawable/ic_placeholder_delete.xml
+++ b/cv-image-to-xml/src/main/res/drawable/ic_placeholder_delete.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M280,800Q247,800 223.5,776.5Q200,753 200,720L200,240L160,240L160,160L360,160L360,120L600,120L600,160L800,160L800,240L760,240L760,720Q760,753 736.5,776.5Q713,800 680,800L280,800ZM680,240L280,240L280,720L680,720L680,240ZM360,640L440,640L440,320L360,320L360,640ZM520,640L600,640L600,320L520,320L520,640ZM280,240L280,720L280,240Z"/>
+</vector>

--- a/cv-image-to-xml/src/main/res/drawable/ic_placeholder_upload.xml
+++ b/cv-image-to-xml/src/main/res/drawable/ic_placeholder_upload.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M440,640L440,314L336,418L280,360L480,160L680,360L624,418L520,314L520,640L440,640ZM240,800Q207,800 183.5,776.5Q160,753 160,720L160,600L240,600L240,720Q240,720 240,720Q240,720 240,720L720,720Q720,720 720,720Q720,720 720,720L720,600L800,600L800,720Q800,753 776.5,776.5Q753,800 720,800L240,800Z"/>
+</vector>

--- a/cv-image-to-xml/src/main/res/values/strings.xml
+++ b/cv-image-to-xml/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="msg_error_saving_file">Error saving file: %s</string>
     <string name="msg_share_xml_layout">Share XML Layout</string>
     <string name="msg_placeholder_image_selected">Image selected for placeholder.</string>
+    <string name="msg_image_removed">Image deleted from the project</string>
 
     <string name="layout_default_name">layout</string>
     <string name="image_placeholder_desc">Image placeholder for object detection</string>


### PR DESCRIPTION
## Description

Added visual indicators (upload and delete badges) to YOLO-detected image placeholders. This provides users with clear, actionable feedback that they can tap on the bounding box to import or remove an image, addressing the lack of visual cues on placeholders.

## Details

* Extracted rendering and bounding box drawing logic from `ComputerVisionActivity` into a new `DetectionVisualizer` class.
* Added new vector icons (`ic_placeholder_upload` and `ic_placeholder_delete`) and integrated them as badges on image placeholders.
* Updated touch event routing to distinguish between general placeholder taps (for importing) and delete badge taps (for removal).
* Extracted XML file saving functionality into a new `XmlFileManager` class.
* Updated `ComputerVisionViewModel` and `DrawableImportHelper` with robust file deletion logic to cleanly remove imported images from the project.


https://github.com/user-attachments/assets/914d2ca5-f8d7-4017-8f28-1cc6ab9b9297



## Ticket

[ADFA-3972](https://appdevforall.atlassian.net/browse/ADFA-3972)

## Observation

Refactoring the `ComputerVisionActivity` to delegate visualization (`DetectionVisualizer`) and file saving (`XmlFileManager`) significantly reduces its bloat and adheres closer to the Single Responsibility Principle, making future UI/canvas modifications much easier to manage.

[ADFA-3972]: https://appdevforall.atlassian.net/browse/ADFA-3972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ