### PR TITLE
ADFA-3938 | Fix OCR property scaling issues

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/ValueCleanersImpl.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/ValueCleanersImpl.kt
@@ -45,6 +45,7 @@ internal object DimensionCleaner : ValueCleaner {
     private val matchKeywords = setOf("match", "parent")
     private val wrapKeywords = setOf("wrap", "content", "wrapcan")
     private val DIMENSION_CONSTANTS = listOf("wrap_content", "match_parent")
+    private val explicitDimensionRegex = Regex("^(-?\\d+)(dp|sp|px|dip)\\s*$")
 
     override fun clean(rawValue: String): String {
         val normalized = rawValue.lowercase().replace(" ", "_")
@@ -55,9 +56,32 @@ internal object DimensionCleaner : ValueCleaner {
         if (fuzzyResult.score >= 60) return fuzzyResult.string
 
         val fixedUnit = normalized.replace(Regex("0p$|op$|olp$"), "dp")
-        val numericPart = NumberCleaner.clean(fixedUnit.replace("_", ""))
+        explicitDimensionRegex.matchEntire(fixedUnit)?.let { match ->
+            val normalizedNumber = normalizeOcrDimensionNumber(match.groupValues[1])
+            return normalizedNumber + match.groupValues[2]
+        }
 
-        return if (numericPart != fixedUnit) "${numericPart}dp" else rawValue
+        val numericPart = NumberCleaner.clean(fixedUnit.replace("_", ""))
+        val normalizedNumericPart = normalizeOcrDimensionNumber(numericPart)
+
+        return if (numericPart != fixedUnit) "${normalizedNumericPart}dp" else rawValue
+    }
+
+    private fun normalizeOcrDimensionNumber(numericPart: String): String {
+        if (!numericPart.matches(Regex("-?\\d+"))) return numericPart
+
+        val isNegative = numericPart.startsWith("-")
+        val numericValue = numericPart.toLongOrNull() ?: return numericPart
+        val canonical = numericValue.toString()
+        val unsignedCanonical = canonical.removePrefix("-")
+
+        // OCR sometimes reads the trailing "dp" as a single zero, turning 150dp into 1500.
+        if (unsignedCanonical.endsWith('0') && unsignedCanonical.toLong() >= 1000L) {
+            val normalizedValue = numericValue / 10L
+            return normalizedValue.toString()
+        }
+
+        return if (isNegative && numericValue == 0L) "0" else canonical
     }
 }
 

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/ValueCleanersImpl.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/ValueCleanersImpl.kt
@@ -45,10 +45,12 @@ internal object DimensionCleaner : ValueCleaner {
     private val matchKeywords = setOf("match", "parent")
     private val wrapKeywords = setOf("wrap", "content", "wrapcan")
     private val DIMENSION_CONSTANTS = listOf("wrap_content", "match_parent")
-    private val explicitDimensionRegex = Regex("^(-?\\d+)(dp|sp|px|dip)\\s*$")
+    private val explicitDimensionRegex = Regex("^(-?\\d+)(dp|sp|px|dip)$")
 
     override fun clean(rawValue: String): String {
-        val normalized = rawValue.lowercase().replace(" ", "_")
+        val trimmedValue = rawValue.trim()
+        val normalized = trimmedValue.lowercase().replace(" ", "_")
+
         if (matchKeywords.any { it in normalized }) return "match_parent"
         if (wrapKeywords.any { it in normalized }) return "wrap_content"
 
@@ -64,7 +66,7 @@ internal object DimensionCleaner : ValueCleaner {
         val numericPart = NumberCleaner.clean(fixedUnit.replace("_", ""))
         val normalizedNumericPart = normalizeOcrDimensionNumber(numericPart)
 
-        return if (numericPart != fixedUnit) "${normalizedNumericPart}dp" else rawValue
+        return if (numericPart != fixedUnit) "${normalizedNumericPart}dp" else trimmedValue
     }
 
     private fun normalizeOcrDimensionNumber(numericPart: String): String {

--- a/cv-image-to-xml/src/test/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParserTest.kt
+++ b/cv-image-to-xml/src/test/java/org/appdevforall/codeonthego/computervision/domain/FuzzyAttributeParserTest.kt
@@ -133,6 +133,30 @@ class FuzzyAttributeParserTest {
     }
 
     @Test
+    fun `OCR dimension with trailing zero before dp is normalized`() {
+        val annotation = "height: 1500dp | width: 100dp"
+        val result = FuzzyAttributeParser.parse(annotation, "EditText")
+
+        assertEquals("150dp", result["android:layout_height"])
+    }
+
+    @Test
+    fun `zero padded dimension values are normalized`() {
+        val annotation = "height: 0010dp | width: 100dp"
+        val result = FuzzyAttributeParser.parse(annotation, "EditText")
+
+        assertEquals("10dp", result["android:layout_height"])
+    }
+
+    @Test
+    fun `all zero padded dimension values normalize to zero`() {
+        val annotation = "height: 0000dp | width: 100dp"
+        val result = FuzzyAttributeParser.parse(annotation, "EditText")
+
+        assertEquals("0dp", result["android:layout_height"])
+    }
+
+    @Test
     fun `empty chunks between pipes are skipped`() {
         val annotation = "width: 100dp | | height: 80dp"
         val result = FuzzyAttributeParser.parse(annotation, "Button")


### PR DESCRIPTION
## Description

This PR fixes a bug in the Computer Vision parser where OCR misinterprets unit labels (like "dp") as a trailing zero. This resulted in incorrect property scaling, such as a widget defaulting to 1500dp instead of the intended 150dp.

## Details

* Implemented `normalizeOcrDimensionNumber` within `ValueCleanersImpl.kt` to detect and trim trailing zeros from large numeric parts (4+ digits) that appear before a unit.
* Added `explicitDimensionRegex` to specifically match and normalize strings containing explicit units like dp, sp, px, or dip.
* Included a new unit test in `FuzzyAttributeParserTest.kt` to ensure that strings like "1500dp" are correctly scaled back to "150dp".


https://github.com/user-attachments/assets/0ae1dbc9-4388-4f39-a25f-9b369ada90db


## Ticket

[ADFA-3938](https://appdevforall.atlassian.net/browse/ADFA-3938)

## Observation

The normalization logic targets dimensions with four or more digits ending in '0', as these are the most common instances of OCR "noise" where the unit is merged into the numeric value. This heuristic avoids affecting smaller, standard dimensions.

[ADFA-3938]: https://appdevforall.atlassian.net/browse/ADFA-3938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ