### PR TITLE
fix(ADFA-3837): Show input field above keyboard

### DIFF
--- a/app/src/main/res/layout/fragment_git_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_git_bottom_sheet.xml
@@ -1,171 +1,186 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="16dp">
+    android:fillViewport="true">
 
-    <TextView
-        android:id="@+id/tv_branch_name"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:ellipsize="end"
-        android:maxLines="2"
-        android:textAppearance="?attr/textAppearanceSubtitle1"
-        android:textStyle="bold"
-        android:visibility="gone"
-        app:layout_constraintEnd_toStartOf="@id/btnPull"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btnPull"
-        style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/pull"
-        android:visibility="gone"
-        app:icon="@drawable/ic_sync"
-        app:layout_constraintBottom_toBottomOf="@id/tv_branch_name"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/tv_branch_name" />
-
-    <com.google.android.material.progressindicator.CircularProgressIndicator
-        android:id="@+id/pullProgress"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:indeterminate="true"
-        android:visibility="gone"
-        app:indicatorSize="24dp"
-        app:layout_constraintBottom_toBottomOf="@id/btnPull"
-        app:layout_constraintEnd_toEndOf="@id/btnPull"
-        app:layout_constraintStart_toStartOf="@id/btnPull"
-        app:layout_constraintTop_toTopOf="@id/btnPull" />
-
-    <TextView
-        android:id="@+id/emptyView"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:text="@string/no_uncommitted_changes"
-        android:textAppearance="?attr/textAppearanceBody2"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_branch_name" />
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:clipToPadding="false"
-        android:paddingVertical="8dp"
-        app:layout_constraintBottom_toTopOf="@id/commitSummaryLayout"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_branch_name" />
-
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/authorAvatar"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:layout_marginEnd="8dp"
-        android:background="?attr/colorSecondaryContainer"
-        android:padding="2dp"
-        android:scaleType="centerInside"
-        android:src="@drawable/ic_account"
-        app:layout_constraintBottom_toBottomOf="@id/commitSummaryLayout"
-        app:layout_constraintEnd_toStartOf="@id/commitSummaryLayout"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@id/commitSummaryLayout"
-        app:shapeAppearanceOverlay="@style/AppTheme.ShapeAppearance.Circle" />
-
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/commitSummaryLayout"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:hint="@string/commit_summary"
-        app:layout_constraintBottom_toTopOf="@id/commitDescriptionLayout"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/authorAvatar">
+        android:padding="16dp">
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/commitSummary"
+        <TextView
+            android:id="@+id/tv_branch_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:textStyle="bold"
+            android:visibility="gone"
+            app:layout_constraintEnd_toStartOf="@id/btnPull"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnPull"
+            style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/pull"
+            android:visibility="gone"
+            app:icon="@drawable/ic_sync"
+            app:layout_constraintBottom_toBottomOf="@id/tv_branch_name"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_branch_name" />
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/pullProgress"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:indeterminate="true"
+            android:visibility="gone"
+            app:indicatorSize="24dp"
+            app:layout_constraintBottom_toBottomOf="@id/btnPull"
+            app:layout_constraintEnd_toEndOf="@id/btnPull"
+            app:layout_constraintStart_toStartOf="@id/btnPull"
+            app:layout_constraintTop_toTopOf="@id/btnPull" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_limit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.45" />
+
+        <TextView
+            android:id="@+id/emptyView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="@string/no_uncommitted_changes"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_branch_name" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:clipToPadding="false"
+            android:paddingVertical="8dp"
+            app:layout_constraintBottom_toTopOf="@id/guideline_limit"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_branch_name" />
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/authorAvatar"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_marginEnd="8dp"
+            android:background="?attr/colorSecondaryContainer"
+            android:padding="2dp"
+            android:scaleType="centerInside"
+            android:src="@drawable/ic_account"
+            app:layout_constraintBottom_toBottomOf="@id/commitSummaryLayout"
+            app:layout_constraintEnd_toStartOf="@id/commitSummaryLayout"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/commitSummaryLayout"
+            app:shapeAppearanceOverlay="@style/AppTheme.ShapeAppearance.Circle" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/commitSummaryLayout"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:hint="@string/commit_summary"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/authorAvatar"
+            app:layout_constraintTop_toBottomOf="@id/guideline_limit">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/commitSummary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/commitDescriptionLayout"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="text"
-            android:maxLines="1" />
-    </com.google.android.material.textfield.TextInputLayout>
+            android:layout_marginTop="8dp"
+            android:hint="@string/commit_description_optional"
+            app:layout_constraintTop_toBottomOf="@id/commitSummaryLayout">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/commitDescriptionLayout"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
-        android:hint="@string/commit_description_optional"
-        app:layout_constraintBottom_toTopOf="@id/authorWarning">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/commitDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="top|start"
+                android:inputType="textMultiLine"
+                android:maxLines="4"
+                android:minLines="2" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/commitDescription"
+        <TextView
+            android:id="@+id/authorWarning"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="top|start"
-            android:inputType="textMultiLine"
-            android:maxLines="4"
-            android:minLines="2" />
-    </com.google.android.material.textfield.TextInputLayout>
+            android:layout_marginTop="8dp"
+            android:text="@string/idepref_git_author_missing_warning"
+            android:textAppearance="?attr/textAppearanceCaption"
+            android:textColor="?attr/colorError"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@id/commitDescriptionLayout" />
 
-    <TextView
-        android:id="@+id/authorWarning"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:text="@string/idepref_git_author_missing_warning"
-        android:textAppearance="?attr/textAppearanceCaption"
-        android:textColor="?attr/colorError"
-        android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@id/commitButton" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/commitButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="@string/commit"
+            app:layout_constraintTop_toBottomOf="@id/authorWarning" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/commitButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:enabled="false"
-        android:text="@string/commit"
-        app:layout_constraintBottom_toTopOf="@id/btnAbortMerge" />
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/commit_section"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:constraint_referenced_ids="authorAvatar, commitSummaryLayout, commitDescriptionLayout, commitButton" />
 
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/commit_section"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:constraint_referenced_ids="authorAvatar, commitSummaryLayout, commitDescriptionLayout, commitButton" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnAbortMerge"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/abort_merge"
+            android:textColor="?attr/colorError"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@id/commitButton"
+            app:strokeColor="?attr/colorError" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btnAbortMerge"
-        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:text="@string/abort_merge"
-        android:textColor="?attr/colorError"
-        app:strokeColor="?attr/colorError"
-        android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@id/commitHistoryButton" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/commitHistoryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/view_commit_history"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btnAbortMerge"
+            app:layout_constraintVertical_bias="1.0" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/commitHistoryButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="@string/view_commit_history"
-        app:layout_constraintBottom_toBottomOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_git_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_git_bottom_sheet.xml
@@ -7,7 +7,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:padding="16dp">
 
         <TextView


### PR DESCRIPTION
Resolve issue with commit inputs - summary and description being hidden under the keyboard or overlapping with other widgets when the keyboard is open.

<img width="685" height="712" alt="Screenshot 2026-05-12 at 14 29 17" src="https://github.com/user-attachments/assets/32e53da2-1576-4b8d-bcf9-3842aeb3b0d1" />

