### PR TITLE
ADFA-3952 | Add dedicated text box for dropdown titles

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/WidgetFactory.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/WidgetFactory.kt
@@ -2,6 +2,7 @@ package org.appdevforall.codeonthego.computervision.domain.xml
 
 import org.appdevforall.codeonthego.computervision.domain.model.LayoutItem
 import org.appdevforall.codeonthego.computervision.domain.model.ScaledBox
+import org.appdevforall.codeonthego.computervision.domain.parser.AttributeKey
 import org.appdevforall.codeonthego.computervision.domain.parser.FuzzyAttributeParser
 
 class WidgetFactory(
@@ -16,18 +17,55 @@ class WidgetFactory(
     )
 
     fun createWidgets(item: LayoutItem): List<AndroidWidget> = when (item) {
-        is LayoutItem.SimpleView -> listOf(createSimpleWidget(item.box))
+        is LayoutItem.SimpleView -> createWidgetsForBox(item.box)
         is LayoutItem.HorizontalRow -> createHorizontalRow(item)
         is LayoutItem.RadioGroup -> createRadioGroup(item)
         is LayoutItem.CheckboxGroup -> createCheckboxGroup(item)
     }
 
     private fun createHorizontalRow(item: LayoutItem.HorizontalRow): List<AndroidWidget> {
-        val children = item.row.mapIndexed { index, box ->
+        val children = item.row.flatMapIndexed { index, box ->
             val extraAttrs = getMarginEndForHorizontalGap(item.row, index)
-            createSimpleWidget(box, extraAttrs = extraAttrs)
+            createWidgetsForBox(box, extraAttrs = extraAttrs)
         }
         return listOf(HorizontalRowWidget(children))
+    }
+
+    private fun createWidgetsForBox(
+        box: ScaledBox,
+        extraAttrs: Map<String, String> = emptyMap(),
+        idOverride: String? = null,
+        parsedAttrsOverride: Map<String, String>? = null
+    ): List<AndroidWidget> {
+        val widgets = mutableListOf<AndroidWidget>()
+
+        val dropdownTitle = box.text
+            .takeIf { box.label == "dropdown" }
+            ?.let(::extractDropdownTitle)
+
+        if (dropdownTitle != null) {
+            val titleBox = box.copy(label = "text", text = dropdownTitle)
+
+            val titleAttrs = mapOf(
+                AttributeKey.WIDTH.xmlName to AndroidConstants.WRAP_CONTENT,
+                AttributeKey.HEIGHT.xmlName to AndroidConstants.WRAP_CONTENT,
+                AttributeKey.LAYOUT_MARGIN_BOTTOM.xmlName to "4dp",
+                AttributeKey.TEXT.xmlName to dropdownTitle,
+                AttributeKey.TEXT_STYLE.xmlName to "bold"
+            )
+            widgets.add(createSimpleWidget(titleBox, parsedAttrsOverride = titleAttrs))
+
+            val baseParsedAttrs = parsedAttrsOverride?.toMutableMap()
+                ?: FuzzyAttributeParser.parse(annotations[box], AndroidWidget.getTagFor(box.label)).toMutableMap()
+
+            val spinnerBox = box.copy(text = "")
+            widgets.add(createSimpleWidget(spinnerBox, extraAttrs, idOverride, baseParsedAttrs))
+
+            return widgets
+        }
+
+        widgets.add(createSimpleWidget(box, extraAttrs, idOverride, parsedAttrsOverride))
+        return widgets
     }
 
     private fun createRadioGroup(item: LayoutItem.RadioGroup): List<AndroidWidget> {
@@ -121,6 +159,15 @@ class WidgetFactory(
             this.idOverride = idOverride
             this.extraAttrs = extraAttrs
         }
+    }
+
+    private fun extractDropdownTitle(rawText: String): String? {
+        val cleaned = rawText.trim()
+            .replace(Regex("\\s*[▼▽▾▿⌄˅∨]$|\\s+[vV]$"), "")
+            .replace(Regex("^[vV]\\s+"), "")
+            .trim()
+
+        return cleaned.takeIf { it.isNotBlank() && !it.equals("dropdown", ignoreCase = true) }
     }
 
     private fun getMarginEndForHorizontalGap(boxes: List<ScaledBox>, currentIndex: Int): Map<String, String> {

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/WidgetFactory.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/xml/WidgetFactory.kt
@@ -57,6 +57,7 @@ class WidgetFactory(
 
             val baseParsedAttrs = parsedAttrsOverride?.toMutableMap()
                 ?: FuzzyAttributeParser.parse(annotations[box], AndroidWidget.getTagFor(box.label)).toMutableMap()
+            baseParsedAttrs.remove(AttributeKey.TEXT.xmlName)
 
             val spinnerBox = box.copy(text = "")
             widgets.add(createSimpleWidget(spinnerBox, extraAttrs, idOverride, baseParsedAttrs))


### PR DESCRIPTION
# Description

This PR fixes the issue where dropdown titles were missing in the generated XML. The logic now extracts text from boxes labeled as "dropdown", cleans up common UI arrow symbols, and creates a separate `TextView` widget to serve as a title appearing immediately before the dropdown widget itself.

## Details

* Modified `WidgetFactory.kt` to replace single-widget creation with a list-based creation method (`createWidgetsForBox`).
* Implemented `extractDropdownTitle` using regex to strip decorative characters (arrows, "v" markers) from the raw text.
* Added logic to generate a bolded `TextView` with standard margins when a title is detected.

https://github.com/user-attachments/assets/6dd4c4f5-159e-412b-9de6-e0abea78d95e


## Ticket

[ADFA-3952](https://appdevforall.atlassian.net/browse/ADFA-3952)

## Observation

The `createWidgetsForBox` method is designed to be extensible if other widget types require multi-part generation in the future. The title extraction includes a check to ensure the label "dropdown" itself isn't used as the title text.

[ADFA-3952]: https://appdevforall.atlassian.net/browse/ADFA-3952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ