### PR TITLE
ADFA-3909 | Fix smart boundary detection zones and initial state

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/SmartBoundaryDetector.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/utils/SmartBoundaryDetector.kt
@@ -6,8 +6,8 @@ import org.appdevforall.codeonthego.computervision.utils.BitmapUtils.calculateVe
 object SmartBoundaryDetector {
 
     private const val DEFAULT_EDGE_IGNORE_PERCENT = 0.05f
-    private const val LEFT_ZONE_END_PERCENT = 0.4f
-    private const val RIGHT_ZONE_START_PERCENT = 0.6f
+    private const val LEFT_ZONE_END_PERCENT = 0.5f
+    private const val RIGHT_ZONE_START_PERCENT = 0.5f
     private const val MIN_GAP_WIDTH_PERCENT = 0.02
     private const val PRIMARY_ACTIVITY_THRESHOLD = 0.05f
     private const val FALLBACK_ACTIVITY_THRESHOLD = 0.01f
@@ -77,7 +77,7 @@ object SmartBoundaryDetector {
         var maxGapLength = 0
         var maxGapMidpoint: Int? = null
         var currentGapStart = -1
-        var previousIsActive = false
+        var previousIsActive = true
 
         signal.forEachIndexed { index, value ->
             val isActive = value > threshold


### PR DESCRIPTION
## Description

This PR fixes the issue where the calculated left and right margins were incorrectly placed, either intersecting with widgets or snapping to the far edges. I adjusted the `LEFT_ZONE_END_PERCENT` and `RIGHT_ZONE_START_PERCENT` to `0.5f` so the scanning zones divide the screen exactly in half. Additionally, `previousIsActive` was updated to initialize as `true`, ensuring that large empty spaces at the very left edge of the image are immediately recognized as valid gaps.

## Details

https://github.com/user-attachments/assets/915dfb95-e69a-4e82-8aea-431b4927efa5


## Ticket

[ADFA-3909](https://appdevforall.atlassian.net/browse/ADFA-3909)

[ADFA-3909]: https://appdevforall.atlassian.net/browse/ADFA-3909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ