### PR TITLE
ADFA-3911 | Fix widget tag parsing and centralize OCR correction rules

### DIFF
--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
@@ -24,13 +24,12 @@ object MarginAnnotationParser {
 
         val distribution = distributeDetections(sanitizedDetections, imageWidth, leftGuidePct, rightGuidePct)
         val canvasTags = extractCanvasTags(distribution.canvas)
-        val leftAnnotations = parseMarginGroup(distribution.leftMargin, canvasTags)
-        val rightAnnotations = parseMarginGroup(distribution.rightMargin, canvasTags)
 
-        val annotationMap = (leftAnnotations.toList() + rightAnnotations.toList())
-            .groupBy({ it.first }, { it.second })
-            .mapValues { (_, values) -> values.joinToString(" | ") }
-            .toMutableMap()
+        val annotationMap = parseMarginsGlobally(
+            leftMargin = distribution.leftMargin,
+            rightMargin = distribution.rightMargin,
+            canvasTags = canvasTags
+        )
 
         return Pair(distribution.canvas, annotationMap)
     }
@@ -78,26 +77,43 @@ object MarginAnnotationParser {
     }
 
     /**
-     * Processes a specific margin (left or right), extracting explicit annotations and
-     * resolving implicit ones against the available canvas tags.
+     * Processes both margins simultaneously to prevent cross-margin collisions.
+     * Gathers all explicit annotations first, then resolves all implicit blocks
+     * against a shared pool of remaining tags.
      */
-    private fun parseMarginGroup(
-        detections: List<DetectionResult>,
+    private fun parseMarginsGlobally(
+        leftMargin: List<DetectionResult>,
+        rightMargin: List<DetectionResult>,
         canvasTags: List<Pair<String, DetectionResult>>
     ): Map<String, String> {
-        if (detections.isEmpty()) return emptyMap()
+        val leftBlocks = extractBlocks(leftMargin.sortedBy { it.boundingBox.top })
+        val rightBlocks = extractBlocks(rightMargin.sortedBy { it.boundingBox.top })
 
-        val sortedDetections = detections.sortedBy { it.boundingBox.top }
-
-        val groupedBlocks = extractBlocks(sortedDetections)
-
-        val resolvedImplicitAnnotations = resolveImplicitBlocks(
-            implicitBlocks = groupedBlocks.implicitBlocks,
-            canvasTags = canvasTags,
-            existingAnnotations = groupedBlocks.explicitAnnotations
+        val globalExplicitAnnotations = mergeAnnotations(
+            leftBlocks.explicitAnnotations,
+            rightBlocks.explicitAnnotations
         )
 
-        return groupedBlocks.explicitAnnotations + resolvedImplicitAnnotations
+        val allImplicitBlocks = leftBlocks.implicitBlocks + rightBlocks.implicitBlocks
+
+        val resolvedImplicitAnnotations = resolveImplicitBlocks(
+            implicitBlocks = allImplicitBlocks,
+            canvasTags = canvasTags,
+            existingAnnotations = globalExplicitAnnotations
+        )
+
+        return mergeAnnotations(globalExplicitAnnotations, resolvedImplicitAnnotations)
+    }
+
+    /**
+     * Merges multiple annotation maps. If a tag exists in multiple maps,
+     * their values are combined separated by " | ".
+     */
+    private fun mergeAnnotations(vararg maps: Map<String, String>): MutableMap<String, String> {
+        return maps.flatMap { it.toList() }
+            .groupBy({ it.first }, { it.second })
+            .mapValues { (_, values) -> values.joinToString(" | ") }
+            .toMutableMap()
     }
 
     /**

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/MarginAnnotationParser.kt
@@ -24,11 +24,13 @@ object MarginAnnotationParser {
 
         val distribution = distributeDetections(sanitizedDetections, imageWidth, leftGuidePct, rightGuidePct)
         val canvasTags = extractCanvasTags(distribution.canvas)
-        val (leftCanvasTags, rightCanvasTags) = splitCanvasTags(canvasTags, imageWidth, leftGuidePct, rightGuidePct)
+        val leftAnnotations = parseMarginGroup(distribution.leftMargin, canvasTags)
+        val rightAnnotations = parseMarginGroup(distribution.rightMargin, canvasTags)
 
-        val annotationMap = mutableMapOf<String, String>()
-        annotationMap.putAll(parseMarginGroup(distribution.leftMargin, leftCanvasTags))
-        annotationMap.putAll(parseMarginGroup(distribution.rightMargin, rightCanvasTags))
+        val annotationMap = (leftAnnotations.toList() + rightAnnotations.toList())
+            .groupBy({ it.first }, { it.second })
+            .mapValues { (_, values) -> values.joinToString(" | ") }
+            .toMutableMap()
 
         return Pair(distribution.canvas, annotationMap)
     }
@@ -73,21 +75,6 @@ object MarginAnnotationParser {
         return canvasDetections.mapNotNull { det ->
             WidgetTagParser.extractTag(det.text)?.let { (tag, _) -> tag to det }
         }
-    }
-
-    /**
-     * Splits the extracted canvas tags into left and right groups based on the canvas midpoint.
-     */
-    private fun splitCanvasTags(
-        canvasTags: List<Pair<String, DetectionResult>>,
-        imageWidth: Int,
-        leftGuidePct: Float,
-        rightGuidePct: Float
-    ): Pair<List<Pair<String, DetectionResult>>, List<Pair<String, DetectionResult>>> {
-        val canvasMidX = imageWidth * (leftGuidePct + rightGuidePct) / 2f
-        val leftTags = canvasTags.filter { (_, det) -> centerX(det) < canvasMidX }
-        val rightTags = canvasTags.filter { (_, det) -> centerX(det) >= canvasMidX }
-        return Pair(leftTags, rightTags)
     }
 
     /**

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetTagParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/WidgetTagParser.kt
@@ -6,7 +6,8 @@ package org.appdevforall.codeonthego.computervision.domain
  */
 internal object WidgetTagParser {
     private val tagRegex = Regex("^(?i)(B|P|D|T|C|R|SW|S)-[A-Z0-9_]+$")
-    private val tagExtractRegex = Regex("^(?i)(SW|S\\s*8|8\\s*W|[BPDTCRS8]\\s*W?)([\\s\\-_]*)([A-Z0-9_\\-]+)")
+    private val tagExtractRegex = Regex("^(?i)([A-Z0-9\\s]+)([\\s\\-_.]+)([A-Z0-9_\\-]+)")
+    private val VALID_PREFIXES = setOf("B", "P", "D", "T", "C", "R", "SW", "S")
 
     fun isTag(text: String): Boolean {
         val cleaned = text.trim().trimEnd('.', ',', ';', ':', '_', '|')
@@ -20,8 +21,12 @@ internal object WidgetTagParser {
         return normalizeTagText(cleaned).matches(tagRegex)
     }
 
-    private fun parseTagParts(match: MatchResult): Pair<String, String> {
-        val prefix = normalizePrefix(match.groupValues[1])
+    private fun parseTagParts(match: MatchResult): Pair<String, String>? {
+        val rawPrefix = match.groupValues[1]
+        val prefix = normalizePrefix(rawPrefix)
+
+        if (prefix !in VALID_PREFIXES) return null
+
         var tokenRaw = match.groupValues[3].trim('-')
 
         val upperToken = tokenRaw.uppercase()
@@ -46,8 +51,9 @@ internal object WidgetTagParser {
 
         if (!isValidTagMatch(match)) return cleaned.uppercase()
 
-        val (prefix, token) = parseTagParts(match)
-        return "$prefix-$token"
+        val parts = parseTagParts(match) ?: return cleaned.uppercase()
+
+        return "${parts.first}-${parts.second}"
     }
 
     fun extractTag(text: String): Pair<String, String?>? {
@@ -56,8 +62,9 @@ internal object WidgetTagParser {
 
         if (!isValidTagMatch(match)) return null
 
-        val (prefix, token) = parseTagParts(match)
-        val finalTag = "$prefix-$token"
+        val parts = parseTagParts(match) ?: return null
+
+        val finalTag = "${parts.first}-${parts.second}"
 
         if (!finalTag.matches(tagRegex)) return null
 

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/FuzzyAttributeParser.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/FuzzyAttributeParser.kt
@@ -2,6 +2,7 @@ package org.appdevforall.codeonthego.computervision.domain.parser
 
 import com.itsaky.androidide.fuzzysearch.FuzzySearch
 import org.appdevforall.codeonthego.computervision.domain.grammar.UiGrammarValidator
+import org.appdevforall.codeonthego.computervision.domain.parser.sanitizer.OcrSanitizerFactory
 import java.lang.StringBuilder
 
 object FuzzyAttributeParser {
@@ -9,6 +10,7 @@ object FuzzyAttributeParser {
     private const val PIPE_DELIMITER = "|"
     private val multipleUnderscoresRegex = Regex("_+")
     private val inputTypeValues = InputTypeValueSet.values.map { it.lowercase() }.toSet()
+    private val sanitizer = OcrSanitizerFactory.createDefaultSanitizer()
 
     private val cleaners = mapOf(
         ValueType.TEXT_CONTENT to TextContentCleaner,
@@ -36,10 +38,7 @@ object FuzzyAttributeParser {
     }
 
     private fun tokenizeAnnotation(annotation: String): List<String> {
-        val sanitized = annotation
-            .replace(Regex("(?i)backgroundired"), "background red")
-            .replace(Regex("(?i)backgroundred"), "background red")
-            .replace(Regex("(?i)horizontal\\s+gravity\\s*:\\s*center\\s+layout"), "layout_gravity: center_horizontal")
+        val sanitized = sanitizer.sanitize(annotation)
 
         return if (sanitized.contains(PIPE_DELIMITER)) {
             sanitized.split(PIPE_DELIMITER).map { it.trim() }.filter { it.isNotEmpty() }

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/sanitizer/CompositeOcrSanitizer.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/sanitizer/CompositeOcrSanitizer.kt
@@ -1,0 +1,12 @@
+package org.appdevforall.codeonthego.computervision.domain.parser.sanitizer
+
+
+class CompositeOcrSanitizer(
+    private val sanitizers: List<OcrSanitizer>
+) : OcrSanitizer {
+    override fun sanitize(input: String): String {
+        return sanitizers.fold(input) { acc, sanitizer ->
+            sanitizer.sanitize(acc)
+        }
+    }
+}

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/sanitizer/OcrSanitizer.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/sanitizer/OcrSanitizer.kt
@@ -1,0 +1,22 @@
+package org.appdevforall.codeonthego.computervision.domain.parser.sanitizer
+
+
+interface OcrSanitizer {
+    fun sanitize(input: String): String
+}
+
+abstract class DictionaryRegexSanitizer : OcrSanitizer {
+    protected abstract val rawRules: Map<String, String>
+
+    private val compiledRules: List<Pair<Regex, String>> by lazy {
+        rawRules.map { (pattern, replacement) ->
+            Regex(pattern, RegexOption.IGNORE_CASE) to replacement
+        }
+    }
+
+    override fun sanitize(input: String): String {
+        return compiledRules.fold(input) { acc, (regex, replacement) ->
+            acc.replace(regex, replacement)
+        }
+    }
+}

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/sanitizer/OcrSanitizerFactory.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/sanitizer/OcrSanitizerFactory.kt
@@ -1,0 +1,16 @@
+package org.appdevforall.codeonthego.computervision.domain.parser.sanitizer
+
+
+object OcrSanitizerFactory {
+    fun createDefaultSanitizer(): OcrSanitizer {
+        return CompositeOcrSanitizer(
+            listOf(
+                ColorSanitizer(),
+                TextAttributeSanitizer(),
+                DimensionSanitizer(),
+                MarginPaddingSanitizer(),
+                StructureSanitizer()
+            )
+        )
+    }
+}

--- a/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/sanitizer/OcrSanitizerRules.kt
+++ b/cv-image-to-xml/src/main/java/org/appdevforall/codeonthego/computervision/domain/parser/sanitizer/OcrSanitizerRules.kt
@@ -1,0 +1,36 @@
+package org.appdevforall.codeonthego.computervision.domain.parser.sanitizer
+
+
+class ColorSanitizer : DictionaryRegexSanitizer() {
+    override val rawRules = mapOf(
+        "backgroundired" to "background red",
+        "backgroundred" to "background red"
+    )
+}
+
+class TextAttributeSanitizer : DictionaryRegexSanitizer() {
+    override val rawRules = mapOf(
+        "text\\s*st[yj]l?e?" to "text_style"
+    )
+}
+
+class DimensionSanitizer : DictionaryRegexSanitizer() {
+    override val rawRules = mapOf(
+        "[il]ayout\\.?\\s*w[io]l?[td]h\\.?" to "layout_width:",
+        "layout\\s*hei[sck]+t\\.?" to "layout_height:",
+        "m?w?at[ce]h[-_\\s]?p[ar]+ent" to "match_parent"
+    )
+}
+
+class MarginPaddingSanitizer : DictionaryRegexSanitizer() {
+    override val rawRules = mapOf(
+        "layout_margin\\s+(top|bottom|start|end|left|right)" to "layout_margin_$1",
+        "padding\\s+(top|bottom|start|end|left|right)" to "padding_$1"
+    )
+}
+
+class StructureSanitizer : DictionaryRegexSanitizer() {
+    override val rawRules = mapOf(
+        "horizontal\\s+gravity\\s*:\\s*center\\s+layout" to "layout_gravity: center_horizontal"
+    )
+}

--- a/cv-image-to-xml/src/test/java/org/appdevforall/codeonthego/computervision/domain/parser/sanitizer/OcrSanitizerRulesTest.kt
+++ b/cv-image-to-xml/src/test/java/org/appdevforall/codeonthego/computervision/domain/parser/sanitizer/OcrSanitizerRulesTest.kt
@@ -1,0 +1,68 @@
+package org.appdevforall.codeonthego.computervision.domain.parser.sanitizer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OcrSanitizerRulesTest {
+
+    @Test
+    fun `color sanitizer fixes merged background color tokens`() {
+        val sanitizer = ColorSanitizer()
+
+        assertEquals("background red", sanitizer.sanitize("backgroundired"))
+        assertEquals("background red", sanitizer.sanitize("backgroundred"))
+    }
+
+	@Test
+	fun `text attribute sanitizer normalizes OCR variants of text style`() {
+		val sanitizer = TextAttributeSanitizer()
+
+		assertEquals("text_style", sanitizer.sanitize("text style"))
+		assertEquals("text_style", sanitizer.sanitize("text stjle"))
+	}
+
+    @Test
+	fun `dimension sanitizer fixes width and height OCR mistakes`() {
+		val sanitizer = DimensionSanitizer()
+
+		assertEquals("layout_width: 120dp", sanitizer.sanitize("iayout widh. 120dp"))
+		assertEquals("layout_height: 48dp", sanitizer.sanitize("layout heist. 48dp"))
+	}
+
+    @Test
+	fun `dimension sanitizer normalizes match parent OCR variants`() {
+		val sanitizer = DimensionSanitizer()
+
+		assertEquals("layout_width: match_parent", sanitizer.sanitize("layout_width: match parent"))
+		assertEquals("layout_width: match_parent", sanitizer.sanitize("layout_width: match-parrent"))
+	}
+
+    @Test
+    fun `margin and padding sanitizer preserves edge names`() {
+        val sanitizer = MarginPaddingSanitizer()
+
+        assertEquals("layout_margin_top: 16dp", sanitizer.sanitize("layout_margin top: 16dp"))
+        assertEquals("padding_end: 8dp", sanitizer.sanitize("padding end: 8dp"))
+    }
+
+    @Test
+    fun `structure sanitizer rewrites horizontal center layout phrase`() {
+        val sanitizer = StructureSanitizer()
+
+        assertEquals(
+            "layout_gravity: center_horizontal",
+            sanitizer.sanitize("horizontal gravity: center layout")
+        )
+    }
+
+    @Test
+	fun `default sanitizer applies multiple OCR cleanup rules in sequence`() {
+		val sanitizer = OcrSanitizerFactory.createDefaultSanitizer()
+		val input = "backgroundired | text stjle: bold | iayout widh. match parrent | padding end: 8dp"
+
+        assertEquals(
+            "background red | text_style: bold | layout_width: match_parent | padding_end: 8dp",
+            sanitizer.sanitize(input)
+        )
+    }
+}


### PR DESCRIPTION
## Description

Fixed an issue where Button widget values were being mixed up with Switch widget values due to improper parsing of separator characters. Additionally, centralized and expanded OCR sanitization rules to better handle common misreads (such as "bsld" or "text stjle" to "text_style") to improve overall attribute parsing accuracy.

## Details

* **`WidgetTagParser.kt`**: Added the dot (`.`) character to the separator regex group in `tagExtractRegex` to correctly parse and isolate widget tags, preventing Button/Switch collision.
* **`OcrSanitizationRules.kt`**: Created a new dedicated file containing a list of `OcrCorrectionRule` to centralize regex patterns and replacements for colors, dimensions, margins, and text attributes.
* **`FuzzyAttributeParser.kt`**: Refactored `tokenizeAnnotation` to fold over the new `preTokenizationRules` list instead of using hardcoded chained string replacements.
* **`MarginAnnotationParser.kt`**: Updated margin parsing logic to safely concatenate overlapping right margin annotations using a pipe (`|`) delimiter instead of overwriting existing map keys.

https://github.com/user-attachments/assets/205f2b48-16c4-4e5e-bd8c-12cb0f007a22

## Ticket

[ADFA-3911](https://appdevforall.atlassian.net/browse/ADFA-3911)

## Observation

Moving the OCR sanitization rules into their own file (`OcrSanitizationRules.kt`) significantly cleans up the `FuzzyAttributeParser` and makes it much easier to scale and maintain new OCR correction patterns as more edge cases are discovered in the future.

[ADFA-3911]: https://appdevforall.atlassian.net/browse/ADFA-3911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ