### PR TITLE
ADFA-3987 | Fix persistent space obscuring Find in File dialog

### DIFF
--- a/app/src/main/res/layout/content_editor.xml
+++ b/app/src/main/res/layout/content_editor.xml
@@ -108,8 +108,7 @@
         <ViewFlipper
             android:id="@+id/editor_container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginBottom="@dimen/editor_sheet_collapsed_height" />
+            android:layout_height="match_parent" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/no_editor_layout"

--- a/editor/src/main/java/com/itsaky/androidide/editor/ui/EditorSearchLayout.kt
+++ b/editor/src/main/java/com/itsaky/androidide/editor/ui/EditorSearchLayout.kt
@@ -31,6 +31,7 @@ import android.widget.PopupMenu
 import android.widget.PopupWindow
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import com.itsaky.androidide.editor.databinding.LayoutFindInFileBinding
 import com.itsaky.androidide.editor.ui.ReplaceAction.doReplace
 import com.itsaky.androidide.idetooltips.TooltipManager
@@ -49,17 +50,16 @@ import java.util.regex.Pattern
  */
 @SuppressLint("ViewConstructor") // Always created dynamically
 class EditorSearchLayout(context: Context, val editor: IDEEditor) : FrameLayout(context) {
+  private val collapsedSheetMargin =
+    context.resources.getDimensionPixelSize(R.dimen.editor_sheet_peek_height)
 
   private var searchInputTextWatcher: TextWatcher? = null
   private var searchOptions = SearchOptions(true, false)
-  private val findInFileBinding: LayoutFindInFileBinding
-  private val optionsMenu: PopupMenu
-
-  private var isSearching = false
+  private val findInFileBinding: LayoutFindInFileBinding = LayoutFindInFileBinding.inflate(LayoutInflater.from(context))
+    private val optionsMenu: PopupMenu
 
   init {
-    findInFileBinding = LayoutFindInFileBinding.inflate(LayoutInflater.from(context))
-    findInFileBinding.prev.setOnClickListener(::onSearchActionClick)
+      findInFileBinding.prev.setOnClickListener(::onSearchActionClick)
     findInFileBinding.next.setOnClickListener(::onSearchActionClick)
     findInFileBinding.replace.setOnClickListener(::onSearchActionClick)
     findInFileBinding.close.setOnClickListener(::onSearchActionClick)
@@ -114,6 +114,10 @@ class EditorSearchLayout(context: Context, val editor: IDEEditor) : FrameLayout(
         )
         true
       }
+    }
+    ViewCompat.setOnApplyWindowInsetsListener(findInFileBinding.root) { _, insets ->
+      updateActionsBottomMargin(insets.isVisible(WindowInsetsCompat.Type.ime()))
+      insets
     }
 
     addView(
@@ -269,7 +273,7 @@ class EditorSearchLayout(context: Context, val editor: IDEEditor) : FrameLayout(
             try {
               Pattern.compile(it)
               it
-            } catch (error: Throwable) {
+            } catch (_: Throwable) {
               ""
             }
           } else {
@@ -280,6 +284,12 @@ class EditorSearchLayout(context: Context, val editor: IDEEditor) : FrameLayout(
       if (query.isNotBlank()) {
         editor.searcher.search(query, searchOptions)
       }
+    }
+  }
+
+  private fun updateActionsBottomMargin(isImeVisible: Boolean) {
+    findInFileBinding.actionsContainer.updateLayoutParams<MarginLayoutParams> {
+      bottomMargin = if (isImeVisible) 0 else collapsedSheetMargin
     }
   }
 }

--- a/editor/src/main/res/layout/layout_find_in_file.xml
+++ b/editor/src/main/res/layout/layout_find_in_file.xml
@@ -62,68 +62,62 @@
       app:layout_constraintTop_toTopOf="@id/search_input" />
 
 
-  <com.google.android.material.button.MaterialButton
-      android:id="@+id/prev"
-      style="@style/Widget.Material3.Button.TextButton"
+  <LinearLayout
+      android:id="@+id/actions_container"
       android:layout_width="0dp"
-      android:layout_height="40dp"
-      android:text="@string/previous"
-      android:textAllCaps="true"
-      android:minWidth="0dp"
-      android:paddingHorizontal="4dp"
-      app:layout_constraintEnd_toStartOf="@+id/next"
-      app:layout_constraintHorizontal_weight="0.25"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/search_input"
-      app:layout_constraintBottom_toBottomOf="parent" />
-
-
-  <com.google.android.material.button.MaterialButton
-      android:id="@+id/next"
-      style="@style/Widget.Material3.Button.TextButton"
-      android:layout_width="0dp"
-      android:layout_height="40dp"
-      android:text="@string/next"
-      android:textAllCaps="true"
-      android:minWidth="0dp"
-      android:paddingHorizontal="4dp"
-      app:layout_constraintEnd_toStartOf="@+id/replace"
-      app:layout_constraintHorizontal_bias="0.5"
-      app:layout_constraintHorizontal_weight="0.25"
-      app:layout_constraintStart_toEndOf="@+id/prev"
-      app:layout_constraintTop_toBottomOf="@+id/search_input"
-      app:layout_constraintBottom_toBottomOf="parent" />
-
-  <com.google.android.material.button.MaterialButton
-      android:id="@+id/replace"
-      style="@style/Widget.Material3.Button.TextButton"
-      android:layout_width="0dp"
-      android:layout_height="40dp"
-      android:text="@string/replace"
-      android:textAllCaps="true"
-      android:minWidth="0dp"
-      android:paddingHorizontal="4dp"
-      app:layout_constraintEnd_toStartOf="@+id/close"
-      app:layout_constraintHorizontal_bias="0.5"
-      app:layout_constraintHorizontal_weight="0.25"
-      app:layout_constraintStart_toEndOf="@+id/next"
-      app:layout_constraintTop_toBottomOf="@+id/search_input"
-      app:layout_constraintBottom_toBottomOf="parent" />
-
-  <com.google.android.material.button.MaterialButton
-      android:id="@+id/close"
-      style="@style/Widget.Material3.Button.TextButton"
-      android:layout_width="0dp"
-      android:layout_height="40dp"
-      android:text="@string/btn_close"
-      android:textAllCaps="true"
-      android:minWidth="0dp"
-      android:paddingHorizontal="4dp"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="0dp"
+      android:orientation="horizontal"
+      android:weightSum="4"
+      app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintHorizontal_bias="0.5"
-      app:layout_constraintHorizontal_weight="0.25"
-      app:layout_constraintStart_toEndOf="@+id/replace"
-      app:layout_constraintTop_toBottomOf="@+id/search_input"
-      app:layout_constraintBottom_toBottomOf="parent" />
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/search_input">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/prev"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="0dp"
+        android:layout_height="40dp"
+        android:layout_weight="1"
+        android:minWidth="0dp"
+        android:paddingHorizontal="4dp"
+        android:text="@string/previous"
+        android:textAllCaps="true" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/next"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="0dp"
+        android:layout_height="40dp"
+        android:layout_weight="1"
+        android:minWidth="0dp"
+        android:paddingHorizontal="4dp"
+        android:text="@string/next"
+        android:textAllCaps="true" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/replace"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="0dp"
+        android:layout_height="40dp"
+        android:layout_weight="1"
+        android:minWidth="0dp"
+        android:paddingHorizontal="4dp"
+        android:text="@string/replace"
+        android:textAllCaps="true" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/close"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="0dp"
+        android:layout_height="40dp"
+        android:layout_weight="1"
+        android:minWidth="0dp"
+        android:paddingHorizontal="4dp"
+        android:text="@string/btn_close"
+        android:textAllCaps="true" />
+
+  </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Description

Fixed an issue where a persistent white space between the user keyboard and the code character toolbar wasted screen real estate and obscured the Find in File dialog in portrait mode. The layout has been updated to dynamically adjust the bottom margin when the keyboard (IME) is visible, ensuring the search input and action buttons remain fully accessible.

## Details

* Wrapped action buttons (Previous, Next, Replace, Close) into a horizontal `LinearLayout` within `layout_find_in_file.xml` to manage their margins collectively.
* Added a `WindowInsetsCompat` listener in `EditorSearchLayout.kt` to detect when the keyboard (IME) is open and dynamically set the bottom margin of the actions container to `0` (or `collapsedSheetMargin` when closed).
* Removed the hardcoded `layout_marginBottom` from the `editor_container` in `content_editor.xml`.


https://github.com/user-attachments/assets/7e0937d8-932a-47a8-b918-8eec64ed76b6


## Ticket

[ADFA-3987](https://appdevforall.atlassian.net/browse/ADFA-3987)

## Observation

Refactoring the individual action buttons into a `LinearLayout` with weights simplifies the layout structure and makes it much easier to apply margin changes to the entire button group at once when the keyboard is toggled.

[ADFA-3987]: https://appdevforall.atlassian.net/browse/ADFA-3987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ