### PR TITLE
ADFA-3840 | Hide fullscreen button behind bottom sheet

### DIFF
--- a/app/src/main/res/layout-land/content_editor.xml
+++ b/app/src/main/res/layout-land/content_editor.xml
@@ -153,18 +153,6 @@
 
     </ViewFlipper>
 
-    <com.itsaky.androidide.ui.EditorBottomSheet
-        android:id="@+id/bottom_sheet"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:behavior_hideable="false"
-        app:behavior_peekHeight="@dimen/editor_sheet_collapsed_height"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
-
-    <include
-        android:id="@+id/diagnosticInfo"
-        layout="@layout/layout_diagnostic_info" />
-
     <ImageButton
         android:id="@+id/btn_fullscreen_toggle"
         android:layout_width="48dp"
@@ -177,5 +165,17 @@
         android:src="@drawable/ic_fullscreen"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/desc_enter_fullscreen" />
+
+    <com.itsaky.androidide.ui.EditorBottomSheet
+        android:id="@+id/bottom_sheet"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:behavior_hideable="false"
+        app:behavior_peekHeight="@dimen/editor_sheet_collapsed_height"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
+
+    <include
+        android:id="@+id/diagnosticInfo"
+        layout="@layout/layout_diagnostic_info" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_editor.xml
+++ b/app/src/main/res/layout/content_editor.xml
@@ -150,18 +150,6 @@
 
     </ViewFlipper>
 
-    <com.itsaky.androidide.ui.EditorBottomSheet
-        android:id="@+id/bottom_sheet"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:behavior_hideable="false"
-        app:behavior_peekHeight="@dimen/editor_sheet_collapsed_height"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
-
-    <include
-        android:id="@+id/diagnosticInfo"
-        layout="@layout/layout_diagnostic_info" />
-
     <ImageButton
         android:id="@+id/btn_fullscreen_toggle"
         android:layout_width="48dp"
@@ -174,5 +162,17 @@
         android:src="@drawable/ic_fullscreen"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/desc_enter_fullscreen" />
+
+    <com.itsaky.androidide.ui.EditorBottomSheet
+        android:id="@+id/bottom_sheet"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:behavior_hideable="false"
+        app:behavior_peekHeight="@dimen/editor_sheet_collapsed_height"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
+
+    <include
+        android:id="@+id/diagnosticInfo"
+        layout="@layout/layout_diagnostic_info" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Description

Reordered the views within the `CoordinatorLayout` in both portrait and landscape `content_editor.xml` files. By moving the `EditorBottomSheet` and `diagnosticInfo` definitions after `btn_fullscreen_toggle`, the bottom sheet will now draw on top of the fullscreen button. This ensures the editor's fullscreen button is no longer visible or clickable when the bottom sheet is active.

## Details

https://github.com/user-attachments/assets/d6400f66-7be8-4e88-985c-f5fefd5cbf44


## Ticket

[ADFA-3840](https://appdevforall.atlassian.net/browse/ADFA-3840)

## Observation

This fix relies on Android's default drawing order (last declared view is drawn on top) to naturally obscure the button without needing to programmatically toggle its visibility state in the code.

[ADFA-3840]: https://appdevforall.atlassian.net/browse/ADFA-3840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ