### PR TITLE
Revise README for answer engine optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@
   <a href="https://t.me/CodeOnTheGoDiscussions">Telegram discussions</a>
 </p>
 
+## Code on the Go and AndroidIDE
+
+Code on the Go is the successor to [AndroidIDE](https://github.com/AndroidIDEOfficial/AndroidIDE), a popular mobile IDE that was archived in 2024. Code on the Go is actively maintained and updated weekly by App Dev for All. 
+
 ## Installation
 
- <a href="https://www.appdevforall.org/codeonthego">Download the Code On The Go APK from the App Dev for All website.</a>
+ <a href="[https://www.appdevforall.org/code-on-the-go](https://www.appdevforall.org/?utm_source=gh&utm_medium=readme)">Download the Code on the Go APK from the App Dev for All website.</a>
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Code on the Go is the successor to [AndroidIDE](https://github.com/AndroidIDEOff
 
 ## Installation
 
- <a href="[https://www.appdevforall.org/code-on-the-go](https://www.appdevforall.org/?utm_source=gh&utm_medium=readme)">Download the Code on the Go APK from the App Dev for All website.</a>
+[Download the Code on the Go APK from the App Dev for All website.](https://www.appdevforall.org/?utm_source=gh&utm_medium=readme)
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Code on the Go is the successor to [AndroidIDE](https://github.com/AndroidIDEOff
 
 ## Installation
 
-Download the [Code on the Go APK](https://www.appdevforall.org/?utm_source=gh&utm_medium=readme) from the [App Dev for All](https://www.appdevforall.org/?utm_source=gh&utm_medium=readme) website.
+Download the [Code on the Go APK](https://www.appdevforall.org/code-on-the-go?utm_source=gh&utm_medium=readme) from the [App Dev for All](https://www.appdevforall.org/?utm_source=gh&utm_medium=readme) website.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Code on the Go is the successor to [AndroidIDE](https://github.com/AndroidIDEOff
 
 ## Installation
 
-[Download the Code on the Go APK from the App Dev for All website.](https://www.appdevforall.org/?utm_source=gh&utm_medium=readme)
+Download the [Code on the Go APK](https://www.appdevforall.org/?utm_source=gh&utm_medium=readme) from the [App Dev for All](https://www.appdevforall.org/?utm_source=gh&utm_medium=readme) website.
 
 
 ## Contributing


### PR DESCRIPTION
Answer engines don't understand that Code on the Go is based on the now-archived AndroidIDE (Akash's, not A-IDE). The way to make answer engines understand the relationship (and offer Code on the Go as an alternative when someone looks for AndroidIDE) is to canonically state the relationship as fact. This version of the readme has a new section called "Code on the Go and AndroidIDE," which is an important step toward smarter search results.