### PR TITLE
ADFA-4040: Disable misbehaving plugins instead of crashing the IDE

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
@@ -57,6 +57,9 @@ import com.itsaky.androidide.editor.schemes.IDEColorSchemeProvider
 import com.itsaky.androidide.editor.ui.IDEEditor
 import com.itsaky.androidide.eventbus.events.editor.DocumentChangeEvent
 import com.itsaky.androidide.eventbus.events.file.FileRenameEvent
+import com.itsaky.androidide.activities.PluginManagerActivity
+import com.itsaky.androidide.eventbus.events.plugin.PluginCrashedEvent
+import com.itsaky.androidide.ui.CustomSnackbar
 import com.itsaky.androidide.idetooltips.TooltipManager
 import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.interfaces.IEditorHandler
@@ -1095,6 +1098,33 @@ open class EditorHandlerActivity :
 		if (tab.text?.startsWith('*') == true) return
 
 		tab.text = "*${tab.text}"
+	}
+
+	@Subscribe(threadMode = ThreadMode.MAIN)
+	fun onPluginCrashed(event: PluginCrashedEvent) {
+		val message = if (event.wasDisabled) {
+			"'${event.pluginName}' disabled after repeated crashes"
+		} else {
+			"'${event.pluginName}' crashed (${event.crashCount}/3)"
+		}
+
+		val snackbar = CustomSnackbar(this, binding.root)
+		if (event.wasDisabled) {
+			snackbar.show(
+				message = message,
+				textFirstAction = "Settings",
+				textSecondaryAction = "Dismiss",
+				actionFirst = {
+					startActivity(Intent(this, PluginManagerActivity::class.java))
+				}
+			)
+		} else {
+			snackbar.show(
+				message = message,
+				textFirstAction = "Dismiss",
+				textSecondaryAction = null
+			)
+		}
 	}
 
 	private fun updateTabs() {

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
@@ -17,6 +17,8 @@
 
 package com.itsaky.androidide.activities.editor
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
@@ -25,6 +27,7 @@ import android.util.Log
 import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup.LayoutParams
+import android.widget.TextView
 import androidx.collection.MutableIntObjectMap
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.GravityCompat
@@ -33,6 +36,7 @@ import androidx.lifecycle.lifecycleScope
 import com.blankj.utilcode.util.ImageUtils
 import com.google.android.material.tabs.TabLayout
 import com.google.gson.Gson
+import com.itsaky.androidide.R
 import com.itsaky.androidide.R.string
 import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.actions.ActionItem
@@ -59,7 +63,6 @@ import com.itsaky.androidide.eventbus.events.editor.DocumentChangeEvent
 import com.itsaky.androidide.eventbus.events.file.FileRenameEvent
 import com.itsaky.androidide.activities.PluginManagerActivity
 import com.itsaky.androidide.eventbus.events.plugin.PluginCrashedEvent
-import com.itsaky.androidide.ui.CustomSnackbar
 import com.itsaky.androidide.idetooltips.TooltipManager
 import com.itsaky.androidide.idetooltips.TooltipTag
 import com.itsaky.androidide.interfaces.IEditorHandler
@@ -80,8 +83,10 @@ import com.itsaky.androidide.shortcuts.ShortcutExecutionContext
 import com.itsaky.androidide.shortcuts.ShortcutManager
 import com.itsaky.androidide.tasks.executeAsync
 import com.itsaky.androidide.ui.CodeEditorView
+import com.itsaky.androidide.fragments.sidebar.EditorSidebarFragment
 import com.itsaky.androidide.utils.DialogUtils.newMaterialDialogBuilder
 import com.itsaky.androidide.utils.DialogUtils.showConfirmationDialog
+import com.itsaky.androidide.utils.EditorSidebarActions
 import com.itsaky.androidide.utils.IntentUtils.openImage
 import com.itsaky.androidide.utils.UniqueNameBuilder
 import com.itsaky.androidide.utils.flashSuccess
@@ -1102,28 +1107,83 @@ open class EditorHandlerActivity :
 
 	@Subscribe(threadMode = ThreadMode.MAIN)
 	fun onPluginCrashed(event: PluginCrashedEvent) {
-		val message = if (event.wasDisabled) {
-			"'${event.pluginName}' disabled after repeated crashes"
-		} else {
-			"'${event.pluginName}' crashed (${event.crashCount}/3)"
+		if (event.wasDisabled) {
+			tearDownDisabledPluginContributions(event.pluginId)
+		}
+		showPluginCrashDialog(event)
+	}
+
+	private fun showPluginCrashDialog(event: PluginCrashedEvent) {
+		val dialogView = layoutInflater.inflate(R.layout.dialog_plugin_crash, null)
+		dialogView.findViewById<TextView>(R.id.plugin_crash_message).text =
+			if (event.wasDisabled) {
+				getString(string.msg_plugin_crash_disabled, event.pluginName)
+			} else {
+				getString(string.msg_plugin_crash, event.pluginName, event.crashCount)
+			}
+
+		val builder = newMaterialDialogBuilder(this)
+			.setTitle(string.title_plugin_crashed)
+			.setView(dialogView)
+			.setPositiveButton(string.dismiss, null)
+
+		if (event.wasDisabled) {
+			builder.setNegativeButton(string.plugin_manager) { _, _ ->
+				startActivity(Intent(this, PluginManagerActivity::class.java))
+			}
 		}
 
-		val snackbar = CustomSnackbar(this, binding.root)
-		if (event.wasDisabled) {
-			snackbar.show(
-				message = message,
-				textFirstAction = "Settings",
-				textSecondaryAction = "Dismiss",
-				actionFirst = {
-					startActivity(Intent(this, PluginManagerActivity::class.java))
-				}
-			)
-		} else {
-			snackbar.show(
-				message = message,
-				textFirstAction = "Dismiss",
-				textSecondaryAction = null
-			)
+		builder.show()
+
+		dialogView.findViewById<View>(R.id.plugin_crash_view_logs).setOnClickListener {
+			showPluginCrashLogDialog(event)
+		}
+	}
+
+	private fun showPluginCrashLogDialog(event: PluginCrashedEvent) {
+		newMaterialDialogBuilder(this)
+			.setTitle(getString(string.title_plugin_crash_log, event.pluginName))
+			.setMessage(event.stackTrace)
+			.setPositiveButton(string.close, null)
+			.setNeutralButton(string.copy) { _, _ ->
+				val clipboard = getSystemService(ClipboardManager::class.java)
+				clipboard?.setPrimaryClip(
+					ClipData.newPlainText(
+						getString(string.title_plugin_crash_log, event.pluginName),
+						event.stackTrace
+					)
+				)
+				flashSuccess(string.msg_crash_log_copied)
+			}
+			.show()
+	}
+
+	private fun tearDownDisabledPluginContributions(pluginId: String) {
+		runCatching {
+			val pluginManager = IDEApplication.getPluginManager() ?: return
+			val tabManager = PluginEditorTabManager.getInstance()
+
+			val tabsToClose = pluginTabIndices.keys.toList().filter { tabId ->
+				tabManager.getPluginIdForTab(tabId) == pluginId
+			}
+			tabsToClose.forEach { tabId ->
+				val index = pluginTabIndices[tabId] ?: return@forEach
+				closePluginTab(index)
+			}
+
+			tabManager.loadPluginTabs(pluginManager)
+
+			val registry = getInstance()
+			registry.clearActions(ActionItem.Location.EDITOR_SIDEBAR)
+			EditorSidebarActions.registerActions(this)
+			(supportFragmentManager.findFragmentById(R.id.drawer_sidebar) as? EditorSidebarFragment)
+				?.let { EditorSidebarActions.setup(it) }
+
+			invalidateOptionsMenu()
+
+			Log.i("EditorHandlerActivity", "Tore down contributions for disabled plugin: $pluginId")
+		}.onFailure { e ->
+			Log.e("EditorHandlerActivity", "Failed to tear down contributions for disabled plugin: $pluginId", e)
 		}
 	}
 

--- a/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
@@ -155,19 +155,15 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 		runCatching {
 			writeException(exception)
 
-			Sentry.configureScope { scope ->
+			Sentry.withScope { scope ->
 				scope.setTag("plugin_crash", "true")
 				scope.setTag("plugin_id", pluginId)
+				Sentry.captureException(exception)
 			}
-			Sentry.captureException(exception)
 
 			val pluginManager = PluginManager.getInstance() ?: return
 			val result = pluginManager.recordPluginCrash(pluginId)
 
-			val name = when (result) {
-				is PluginManager.CrashResult.Disabled -> result.pluginName
-				is PluginManager.CrashResult.Recorded -> pluginId
-			}
 			val wasDisabled = result is PluginManager.CrashResult.Disabled
 			val crashCount = when (result) {
 				is PluginManager.CrashResult.Recorded -> result.crashCount
@@ -175,7 +171,7 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 			}
 
 			EventBus.getDefault().post(
-				PluginCrashedEvent(pluginId, name, crashCount, wasDisabled, ThrowableUtils.getFullStackTrace(exception))
+				PluginCrashedEvent(pluginId, result.pluginName, crashCount, wasDisabled, ThrowableUtils.getFullStackTrace(exception))
 			)
 			logger.warn("Plugin crash handled without killing process: {} (disabled={})", pluginId, wasDisabled)
 		}.onFailure { e ->
@@ -325,17 +321,13 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 			runCatching {
 				val pm = PluginManager.getInstance() ?: return@runCatching
 				val result = pm.recordPluginCrash(pluginId)
-				val name = when (result) {
-					is PluginManager.CrashResult.Disabled -> result.pluginName
-					is PluginManager.CrashResult.Recorded -> pluginId
-				}
 				val wasDisabled = result is PluginManager.CrashResult.Disabled
 				val crashCount = when (result) {
 					is PluginManager.CrashResult.Recorded -> result.crashCount
 					is PluginManager.CrashResult.Disabled -> pm.crashTracker.getCrashCount(pluginId)
 				}
 				EventBus.getDefault().post(
-					PluginCrashedEvent(pluginId, name, crashCount, wasDisabled, ThrowableUtils.getFullStackTrace(error))
+					PluginCrashedEvent(pluginId, result.pluginName, crashCount, wasDisabled, ThrowableUtils.getFullStackTrace(error))
 				)
 			}
 		}

--- a/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
@@ -174,7 +174,9 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 				is PluginManager.CrashResult.Disabled -> pluginManager.crashTracker.getCrashCount(pluginId)
 			}
 
-			EventBus.getDefault().post(PluginCrashedEvent(pluginId, name, crashCount, wasDisabled))
+			EventBus.getDefault().post(
+				PluginCrashedEvent(pluginId, name, crashCount, wasDisabled, ThrowableUtils.getFullStackTrace(exception))
+			)
 			logger.warn("Plugin crash handled without killing process: {} (disabled={})", pluginId, wasDisabled)
 		}.onFailure { e ->
 			logger.error("Failed to handle plugin crash gracefully for: {}", pluginId, e)
@@ -332,7 +334,9 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 					is PluginManager.CrashResult.Recorded -> result.crashCount
 					is PluginManager.CrashResult.Disabled -> pm.crashTracker.getCrashCount(pluginId)
 				}
-				EventBus.getDefault().post(PluginCrashedEvent(pluginId, name, crashCount, wasDisabled))
+				EventBus.getDefault().post(
+					PluginCrashedEvent(pluginId, name, crashCount, wasDisabled, ThrowableUtils.getFullStackTrace(error))
+				)
 			}
 		}
 	}

--- a/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
@@ -11,6 +11,7 @@ import com.itsaky.androidide.editor.schemes.IDEColorSchemeProvider
 import com.itsaky.androidide.eventbus.events.preferences.PreferenceChangeEvent
 import com.itsaky.androidide.managers.ToolsManager
 import com.itsaky.androidide.plugins.PluginLogger
+import com.itsaky.androidide.plugins.base.PluginFragmentHelper
 import com.itsaky.androidide.plugins.manager.core.PluginManager
 import com.itsaky.androidide.preferences.internal.DevOpsPreferences
 import com.itsaky.androidide.preferences.internal.GeneralPreferences
@@ -21,6 +22,7 @@ import com.itsaky.androidide.utils.Environment
 import com.itsaky.androidide.utils.FeatureFlags
 import com.itsaky.androidide.utils.FileUtil
 import com.itsaky.androidide.utils.VMUtils
+import com.itsaky.androidide.eventbus.events.plugin.PluginCrashedEvent
 import io.sentry.Sentry
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -31,6 +33,8 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.slf4j.LoggerFactory
+import android.os.Handler
+import android.os.Looper
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.exitProcess
@@ -93,6 +97,7 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 		}
 
 		initializePluginSystem()
+		installPluginCrashLooperGuard()
 
 		app.coroutineScope.launch(Dispatchers.IO) {
 			// color schemes are stored in files
@@ -109,10 +114,24 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 		thread: Thread,
 		exception: Throwable,
 	) {
+		val pluginManager = PluginManager.getInstance()
+		val pluginId = runCatching {
+			pluginManager?.let { pm ->
+				pm.crashTracker.findPluginForStackTrace(
+					exception,
+					pm.getLoadedPluginIds()
+				) { pm.getClassLoaderForPluginId(it) }
+			}
+		}.getOrNull()
+
+		if (pluginId != null) {
+			handlePluginCrash(pluginId, exception)
+			return
+		}
+
 		writeException(exception)
 		Sentry.captureException(exception)
 
-		// schedule crash handler activity to be shown
 		runCatching {
 			val intent = Intent()
 			intent.action = CrashHandlerActivity.REPORT_ACTION
@@ -127,12 +146,74 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 			logger.error("Unable to start crash handler activity", error)
 		}
 
-		// notify the original exception handler, if any
 		IDEApplication.instance.uncaughtExceptionHandler?.uncaughtException(thread, exception)
 
-		// finally, exit process
 		exitProcess(EXIT_CODE_CRASH)
 	}
+
+	private fun handlePluginCrash(pluginId: String, exception: Throwable) {
+		runCatching {
+			writeException(exception)
+
+			Sentry.configureScope { scope ->
+				scope.setTag("plugin_crash", "true")
+				scope.setTag("plugin_id", pluginId)
+			}
+			Sentry.captureException(exception)
+
+			val pluginManager = PluginManager.getInstance() ?: return
+			val result = pluginManager.recordPluginCrash(pluginId)
+
+			val name = when (result) {
+				is PluginManager.CrashResult.Disabled -> result.pluginName
+				is PluginManager.CrashResult.Recorded -> pluginId
+			}
+			val wasDisabled = result is PluginManager.CrashResult.Disabled
+			val crashCount = when (result) {
+				is PluginManager.CrashResult.Recorded -> result.crashCount
+				is PluginManager.CrashResult.Disabled -> pluginManager.crashTracker.getCrashCount(pluginId)
+			}
+
+			EventBus.getDefault().post(PluginCrashedEvent(pluginId, name, crashCount, wasDisabled))
+			logger.warn("Plugin crash handled without killing process: {} (disabled={})", pluginId, wasDisabled)
+		}.onFailure { e ->
+			logger.error("Failed to handle plugin crash gracefully for: {}", pluginId, e)
+		}
+	}
+
+	private var lastPluginCrashTime = 0L
+
+	private fun installPluginCrashLooperGuard() {
+		Handler(Looper.getMainLooper()).post {
+			while (true) {
+				try {
+					Looper.loop()
+					break
+				} catch (e: Throwable) {
+					val pluginId = runCatching {
+						PluginManager.getInstance()?.let { pm ->
+							pm.crashTracker.findPluginForStackTrace(
+								e, pm.getLoadedPluginIds()
+							) { pm.getClassLoaderForPluginId(it) }
+						}
+					}.getOrNull()
+
+					if (pluginId != null) {
+						lastPluginCrashTime = System.currentTimeMillis()
+						handlePluginCrash(pluginId, e)
+					} else if (System.currentTimeMillis() - lastPluginCrashTime < COLLATERAL_CRASH_WINDOW_MS) {
+						logger.warn("Suppressing collateral crash after recent plugin crash: {}", e.message)
+					} else {
+						handleUncaughtException(Thread.currentThread(), e)
+						break
+					}
+				}
+			}
+		}
+		logger.info("Plugin crash Looper guard installed on main thread")
+	}
+
+	private const val COLLATERAL_CRASH_WINDOW_MS = 3000L
 
 	private fun writeException(throwable: Throwable?) =
 		runCatching {
@@ -209,6 +290,7 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 
 			// Set up plugin service providers
 			setupPluginServices()
+			setupPluginInflationErrorHandler()
 
 			// Load plugins asynchronously
 			GlobalScope.launch {
@@ -232,6 +314,26 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 		pluginManager?.let { manager ->
 			manager.setActivityProvider { application.foregroundActivity }
 			logger.info("Plugin services configured successfully")
+		}
+	}
+
+	private fun setupPluginInflationErrorHandler() {
+		PluginFragmentHelper.onPluginInflationError = { pluginId, error ->
+			logger.error("Plugin layout inflation failed for: {}", pluginId, error)
+			runCatching {
+				val pm = PluginManager.getInstance() ?: return@runCatching
+				val result = pm.recordPluginCrash(pluginId)
+				val name = when (result) {
+					is PluginManager.CrashResult.Disabled -> result.pluginName
+					is PluginManager.CrashResult.Recorded -> pluginId
+				}
+				val wasDisabled = result is PluginManager.CrashResult.Disabled
+				val crashCount = when (result) {
+					is PluginManager.CrashResult.Recorded -> result.crashCount
+					is PluginManager.CrashResult.Disabled -> pm.crashTracker.getCrashCount(pluginId)
+				}
+				EventBus.getDefault().post(PluginCrashedEvent(pluginId, name, crashCount, wasDisabled))
+			}
 		}
 	}
 

--- a/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
@@ -274,7 +274,9 @@ internal object EditorSidebarActions {
                         is PluginManager.CrashResult.Recorded -> result.crashCount
                         is PluginManager.CrashResult.Disabled -> pluginManager.crashTracker.getCrashCount(pluginId)
                     }
-                    EventBus.getDefault().post(PluginCrashedEvent(pluginId, name, crashCount, wasDisabled))
+                    EventBus.getDefault().post(
+                        PluginCrashedEvent(pluginId, name, crashCount, wasDisabled, Log.getStackTraceString(e))
+                    )
                 }
             }
     }

--- a/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
@@ -19,6 +19,7 @@ package com.itsaky.androidide.utils
 
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.annotation.IdRes
 import androidx.core.view.forEach
@@ -51,6 +52,8 @@ import com.itsaky.androidide.plugins.extensions.UIExtension
 import com.itsaky.androidide.actions.PluginSidebarActionItem
 import com.itsaky.androidide.actions.SidebarSlotManager
 import com.itsaky.androidide.plugins.manager.core.PluginManager
+import com.itsaky.androidide.eventbus.events.plugin.PluginCrashedEvent
+import org.greenrobot.eventbus.EventBus
 import java.lang.ref.WeakReference
 
 /**
@@ -241,21 +244,37 @@ internal object EditorSidebarActions {
             .filterIsInstance<UIExtension>()
             .forEach { plugin ->
                 val pluginId = pluginManager.getPluginIdForInstance(plugin as com.itsaky.androidide.plugins.IPlugin)
-                val declaredSlots = SidebarSlotManager.getDeclaredSlots(pluginId ?: "")
-                val sideMenuItems = plugin.getSideMenuItems()
+                    ?: return@forEach
 
-                if (sideMenuItems.isEmpty()) return@forEach
+                try {
+                    val declaredSlots = SidebarSlotManager.getDeclaredSlots(pluginId)
+                    val sideMenuItems = plugin.getSideMenuItems()
 
-                if (sideMenuItems.size > declaredSlots) {
-                    throw IllegalStateException(
-                        "Plugin '$pluginId' returned ${sideMenuItems.size} sidebar items " +
-                        "but only declared $declaredSlots in manifest"
-                    )
-                }
+                    if (sideMenuItems.isEmpty()) return@forEach
 
-                sideMenuItems.forEach { navItem ->
-                    val action = PluginSidebarActionItem(context, navItem, order++, pluginId ?: "")
-                    registry.registerAction(action)
+                    if (sideMenuItems.size > declaredSlots) {
+                        Log.w("EditorSidebarActions",
+                            "Plugin '$pluginId' returned ${sideMenuItems.size} sidebar items " +
+                            "but only declared $declaredSlots in manifest — skipping"
+                        )
+                        return@forEach
+                    }
+
+                    sideMenuItems.forEach { navItem ->
+                        val action = PluginSidebarActionItem(context, navItem, order++, pluginId)
+                        registry.registerAction(action)
+                    }
+                } catch (e: Throwable) {
+                    Log.e("EditorSidebarActions", "Plugin '$pluginId' crashed in getSideMenuItems()", e)
+                    val result = pluginManager.recordPluginCrash(pluginId)
+                    val name = (result as? PluginManager.CrashResult.Disabled)?.pluginName
+                        ?: pluginId
+                    val wasDisabled = result is PluginManager.CrashResult.Disabled
+                    val crashCount = when (result) {
+                        is PluginManager.CrashResult.Recorded -> result.crashCount
+                        is PluginManager.CrashResult.Disabled -> pluginManager.crashTracker.getCrashCount(pluginId)
+                    }
+                    EventBus.getDefault().post(PluginCrashedEvent(pluginId, name, crashCount, wasDisabled))
                 }
             }
     }

--- a/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/EditorSidebarActions.kt
@@ -68,6 +68,10 @@ object ContactDetails {
 }
 
 internal object EditorSidebarActions {
+
+    private var previousDestinationListener: NavController.OnDestinationChangedListener? = null
+    private var previousNavController: WeakReference<NavController>? = null
+
     @JvmStatic
     fun registerActions(context: Context) {
         val registry = ActionsRegistry.getInstance()
@@ -177,27 +181,33 @@ internal object EditorSidebarActions {
             }
         }
 
+        previousDestinationListener?.let { stale ->
+            previousNavController?.get()?.removeOnDestinationChangedListener(stale)
+        }
+
         val railRef = WeakReference(rail)
-        controller.addOnDestinationChangedListener(
-            object : NavController.OnDestinationChangedListener {
-                override fun onDestinationChanged(
-                    controller: NavController,
-                    destination: NavDestination,
-                    arguments: Bundle?
-                ) {
-                    val railView = railRef.get()
-                    if (railView == null) {
-                        controller.removeOnDestinationChangedListener(this)
-                        return
-                    }
-                    railView.menu.forEach { item ->
-                        if (destination.matchDestination(item.itemId)) {
-                            item.isChecked = true
-                            titleRef.get()?.text = item.title
-                        }
+        val destinationListener = object : NavController.OnDestinationChangedListener {
+            override fun onDestinationChanged(
+                controller: NavController,
+                destination: NavDestination,
+                arguments: Bundle?
+            ) {
+                val railView = railRef.get()
+                if (railView == null) {
+                    controller.removeOnDestinationChangedListener(this)
+                    return
+                }
+                railView.menu.forEach { item ->
+                    if (destination.matchDestination(item.itemId)) {
+                        item.isChecked = true
+                        titleRef.get()?.text = item.title
                     }
                 }
-            })
+            }
+        }
+        controller.addOnDestinationChangedListener(destinationListener)
+        previousDestinationListener = destinationListener
+        previousNavController = WeakReference(controller)
 
         rail.menu.findItem(FileTreeSidebarAction.ID.hashCode())?.also {
             it.isChecked = true
@@ -264,18 +274,16 @@ internal object EditorSidebarActions {
                         val action = PluginSidebarActionItem(context, navItem, order++, pluginId)
                         registry.registerAction(action)
                     }
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
                     Log.e("EditorSidebarActions", "Plugin '$pluginId' crashed in getSideMenuItems()", e)
                     val result = pluginManager.recordPluginCrash(pluginId)
-                    val name = (result as? PluginManager.CrashResult.Disabled)?.pluginName
-                        ?: pluginId
                     val wasDisabled = result is PluginManager.CrashResult.Disabled
                     val crashCount = when (result) {
                         is PluginManager.CrashResult.Recorded -> result.crashCount
                         is PluginManager.CrashResult.Disabled -> pluginManager.crashTracker.getCrashCount(pluginId)
                     }
                     EventBus.getDefault().post(
-                        PluginCrashedEvent(pluginId, name, crashCount, wasDisabled, Log.getStackTraceString(e))
+                        PluginCrashedEvent(pluginId, result.pluginName, crashCount, wasDisabled, Log.getStackTraceString(e))
                     )
                 }
             }

--- a/app/src/main/res/layout/dialog_plugin_crash.xml
+++ b/app/src/main/res/layout/dialog_plugin_crash.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="4dp"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:id="@+id/plugin_crash_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:lineSpacingMultiplier="1.2"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="14sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/plugin_crash_dev_hint"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:lineSpacingMultiplier="1.2"
+            android:text="@string/msg_plugin_crash_dev_hint"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="12sp" />
+
+        <ImageButton
+            android:id="@+id/plugin_crash_view_logs"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="12dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/cd_plugin_crash_view_logs"
+            android:src="@drawable/ic_info"
+            android:tint="?attr/colorPrimary" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/snackbar_custom.xml
+++ b/app/src/main/res/layout/snackbar_custom.xml
@@ -18,8 +18,7 @@
         android:text="@string/msg_action_open_application"
         android:textColor="@android:color/white"
         android:textSize="14sp"
-        android:maxLines="1"
-        android:singleLine="true"
+        android:maxLines="3"
         android:ellipsize="end"/>
 
     <Button

--- a/eventbus-events/src/main/java/com/itsaky/androidide/eventbus/events/plugin/PluginCrashedEvent.kt
+++ b/eventbus-events/src/main/java/com/itsaky/androidide/eventbus/events/plugin/PluginCrashedEvent.kt
@@ -1,0 +1,10 @@
+package com.itsaky.androidide.eventbus.events.plugin
+
+import com.itsaky.androidide.eventbus.events.Event
+
+class PluginCrashedEvent(
+    val pluginId: String,
+    val pluginName: String,
+    val crashCount: Int,
+    val wasDisabled: Boolean
+) : Event()

--- a/eventbus-events/src/main/java/com/itsaky/androidide/eventbus/events/plugin/PluginCrashedEvent.kt
+++ b/eventbus-events/src/main/java/com/itsaky/androidide/eventbus/events/plugin/PluginCrashedEvent.kt
@@ -6,5 +6,6 @@ class PluginCrashedEvent(
     val pluginId: String,
     val pluginName: String,
     val crashCount: Int,
-    val wasDisabled: Boolean
+    val wasDisabled: Boolean,
+    val stackTrace: String
 ) : Event()

--- a/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/base/PluginFragment.kt
+++ b/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/base/PluginFragment.kt
@@ -15,6 +15,9 @@ import java.lang.ref.WeakReference
  */
 object PluginFragmentHelper {
 
+    @JvmStatic
+    var onPluginInflationError: ((pluginId: String, error: Throwable) -> Unit)? = null
+
     private val pluginContexts = mutableMapOf<String, Context>()
     private val serviceRegistries = mutableMapOf<String, ServiceRegistry>()
     private val legacyPlugins = mutableSetOf<String>()
@@ -107,10 +110,12 @@ object PluginFragmentHelper {
             contextRef = WeakReference(defaultInflater.context),
             themeRef = WeakReference(defaultInflater.context.theme)
         )
-        if (pluginId in legacyPlugins) {
-            return pluginContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as? LayoutInflater
+        val inflater = if (pluginId in legacyPlugins) {
+            pluginContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as? LayoutInflater
                 ?: defaultInflater.cloneInContext(pluginContext)
+        } else {
+            defaultInflater.cloneInContext(pluginContext)
         }
-        return defaultInflater.cloneInContext(pluginContext)
+        return SafePluginLayoutInflater.wrap(inflater, pluginId)
     }
 }

--- a/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/base/SafePluginLayoutInflater.kt
+++ b/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/base/SafePluginLayoutInflater.kt
@@ -1,0 +1,69 @@
+package com.itsaky.androidide.plugins.base
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+
+class SafePluginLayoutInflater private constructor(
+    original: LayoutInflater,
+    context: Context,
+    private val pluginId: String
+) : LayoutInflater(original, context) {
+
+    override fun onCreateView(name: String, attrs: AttributeSet): View {
+        return createView(name, "android.widget.", attrs)
+    }
+
+    override fun cloneInContext(newContext: Context): LayoutInflater {
+        return SafePluginLayoutInflater(this, newContext, pluginId)
+    }
+
+    override fun inflate(resource: Int, root: ViewGroup?, attachToRoot: Boolean): View {
+        return try {
+            super.inflate(resource, root, attachToRoot)
+        } catch (e: Throwable) {
+            PluginFragmentHelper.onPluginInflationError?.invoke(pluginId, e)
+            createErrorView(root)
+        }
+    }
+
+    private fun createErrorView(root: ViewGroup?): View {
+        val ctx = context
+        return LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            setPadding(dp(24), dp(48), dp(24), dp(48))
+
+            addView(TextView(ctx).apply {
+                text = "This plugin encountered an error and could not load its view."
+                setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+                setTextColor(0xFF737373.toInt())
+                gravity = Gravity.CENTER
+            })
+        }
+    }
+
+    private fun dp(value: Int): Int {
+        return TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            value.toFloat(),
+            context.resources.displayMetrics
+        ).toInt()
+    }
+
+    companion object {
+        fun wrap(inflater: LayoutInflater, pluginId: String): SafePluginLayoutInflater {
+            return SafePluginLayoutInflater(inflater, inflater.context, pluginId)
+        }
+    }
+}

--- a/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/base/SafePluginLayoutInflater.kt
+++ b/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/base/SafePluginLayoutInflater.kt
@@ -17,7 +17,14 @@ class SafePluginLayoutInflater private constructor(
 ) : LayoutInflater(original, context) {
 
     override fun onCreateView(name: String, attrs: AttributeSet): View {
-        return createView(name, "android.widget.", attrs)
+        for (prefix in FRAMEWORK_PREFIXES) {
+            try {
+                return createView(name, prefix, attrs)
+            } catch (_: ClassNotFoundException) {
+                // try the next framework prefix
+            }
+        }
+        return super.onCreateView(name, attrs)
     }
 
     override fun cloneInContext(newContext: Context): LayoutInflater {
@@ -27,7 +34,7 @@ class SafePluginLayoutInflater private constructor(
     override fun inflate(resource: Int, root: ViewGroup?, attachToRoot: Boolean): View {
         return try {
             super.inflate(resource, root, attachToRoot)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             PluginFragmentHelper.onPluginInflationError?.invoke(pluginId, e)
             createErrorView(root)
         }
@@ -62,6 +69,12 @@ class SafePluginLayoutInflater private constructor(
     }
 
     companion object {
+        private val FRAMEWORK_PREFIXES = arrayOf(
+            "android.widget.",
+            "android.webkit.",
+            "android.view.",
+        )
+
         fun wrap(inflater: LayoutInflater, pluginId: String): SafePluginLayoutInflater {
             return SafePluginLayoutInflater(inflater, inflater.context, pluginId)
         }

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginCrashTracker.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginCrashTracker.kt
@@ -1,0 +1,120 @@
+package com.itsaky.androidide.plugins.manager.core
+
+import android.content.Context
+import com.itsaky.androidide.plugins.PluginLogger
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+class PluginCrashTracker(
+    private val context: Context,
+    private val logger: PluginLogger
+) {
+
+    private val crashCounts = ConcurrentHashMap<String, AtomicInteger>()
+    private val crashCountsFile get() = File(context.filesDir, "plugin_crash_counts.properties")
+
+    init {
+        loadCrashCounts()
+    }
+
+    fun recordCrash(pluginId: String): Int {
+        val count = crashCounts
+            .getOrPut(pluginId) { AtomicInteger(0) }
+            .incrementAndGet()
+        persistCrashCounts()
+        logger.warn("Plugin crash recorded: $pluginId (count: $count/$MAX_CRASH_COUNT)")
+        return count
+    }
+
+    fun shouldDisable(pluginId: String): Boolean {
+        return getCrashCount(pluginId) >= MAX_CRASH_COUNT
+    }
+
+    fun getCrashCount(pluginId: String): Int {
+        return crashCounts[pluginId]?.get() ?: 0
+    }
+
+    fun resetCrashCount(pluginId: String) {
+        crashCounts.remove(pluginId)
+        persistCrashCounts()
+        logger.info("Reset crash count for plugin: $pluginId")
+    }
+
+    fun removeCrashCount(pluginId: String) {
+        crashCounts.remove(pluginId)
+        persistCrashCounts()
+    }
+
+    fun findPluginForStackTrace(
+        throwable: Throwable,
+        pluginIds: Set<String>,
+        classLoaderProvider: (String) -> ClassLoader?
+    ): String? {
+        val classLoaders = pluginIds.mapNotNull { id ->
+            classLoaderProvider(id)?.let { id to it }
+        }
+        if (classLoaders.isEmpty()) return null
+
+        var current: Throwable? = throwable
+        while (current != null) {
+            for (frame in current.stackTrace) {
+                for ((pluginId, classLoader) in classLoaders) {
+                    val loaded = runCatching {
+                        Class.forName(frame.className, false, classLoader)
+                    }.getOrNull() ?: continue
+
+                    if (loaded.classLoader === classLoader) {
+                        logger.info("Identified plugin $pluginId from stack trace class: ${frame.className}")
+                        return pluginId
+                    }
+                }
+            }
+            current = current.cause
+        }
+
+        return null
+    }
+
+    private fun loadCrashCounts() {
+        runCatching {
+            val file = crashCountsFile
+            if (!file.exists()) return
+
+            val properties = java.util.Properties()
+            file.inputStream().use { properties.load(it) }
+
+            properties.forEach { key, value ->
+                val pluginId = key as String
+                val count = (value as String).toIntOrNull() ?: 0
+                if (count > 0) {
+                    crashCounts[pluginId] = AtomicInteger(count)
+                }
+            }
+        }.onFailure { e ->
+            logger.error("Failed to load plugin crash counts", e)
+        }
+    }
+
+    @Synchronized
+    private fun persistCrashCounts() {
+        runCatching {
+            val properties = java.util.Properties()
+            crashCounts.forEach { (pluginId, count) ->
+                val value = count.get()
+                if (value > 0) {
+                    properties.setProperty(pluginId, value.toString())
+                }
+            }
+            crashCountsFile.outputStream().use { output ->
+                properties.store(output, "Plugin crash counts")
+            }
+        }.onFailure { e ->
+            logger.error("Failed to persist plugin crash counts", e)
+        }
+    }
+
+    companion object {
+        private const val MAX_CRASH_COUNT = 3
+    }
+}

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginCrashTracker.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginCrashTracker.kt
@@ -65,24 +65,26 @@ class PluginCrashTracker(
         }
         if (classLoaders.isEmpty()) return null
 
-        var current: Throwable? = throwable
-        while (current != null) {
-            for (frame in current.stackTrace) {
-                for ((pluginId, classLoader) in classLoaders) {
-                    val loaded = runCatching {
-                        Class.forName(frame.className, false, classLoader)
-                    }.getOrNull() ?: continue
-
-                    if (loaded.classLoader === classLoader) {
-                        logger.info("Identified plugin $pluginId from stack trace class: ${frame.className}")
-                        return pluginId
-                    }
+        return generateSequence(throwable) { it.cause }
+            .flatMap { it.stackTrace.asSequence() }
+            .firstNotNullOfOrNull { frame ->
+                matchPluginForFrame(frame, classLoaders)?.also { pluginId ->
+                    logger.info("Identified plugin $pluginId from stack trace class: ${frame.className}")
                 }
             }
-            current = current.cause
-        }
+    }
 
-        return null
+    private fun matchPluginForFrame(
+        frame: StackTraceElement,
+        classLoaders: List<Pair<String, ClassLoader>>
+    ): String? {
+        return classLoaders.firstNotNullOfOrNull { (pluginId, classLoader) ->
+            val loaded = runCatching {
+                Class.forName(frame.className, false, classLoader)
+            }.getOrNull() ?: return@firstNotNullOfOrNull null
+
+            pluginId.takeIf { loaded.classLoader === classLoader }
+        }
     }
 
     private fun loadCrashCounts() {

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginCrashTracker.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginCrashTracker.kt
@@ -1,7 +1,13 @@
 package com.itsaky.androidide.plugins.manager.core
 
-import android.content.Context
 import com.itsaky.androidide.plugins.PluginLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import android.content.Context
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -13,6 +19,9 @@ class PluginCrashTracker(
 
     private val crashCounts = ConcurrentHashMap<String, AtomicInteger>()
     private val crashCountsFile get() = File(context.filesDir, "plugin_crash_counts.properties")
+
+    private val persistScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val persistMutex = Mutex()
 
     init {
         loadCrashCounts()
@@ -96,21 +105,24 @@ class PluginCrashTracker(
         }
     }
 
-    @Synchronized
     private fun persistCrashCounts() {
-        runCatching {
-            val properties = java.util.Properties()
-            crashCounts.forEach { (pluginId, count) ->
-                val value = count.get()
-                if (value > 0) {
-                    properties.setProperty(pluginId, value.toString())
+        persistScope.launch {
+            persistMutex.withLock {
+                runCatching {
+                    val properties = java.util.Properties()
+                    crashCounts.forEach { (pluginId, count) ->
+                        val value = count.get()
+                        if (value > 0) {
+                            properties.setProperty(pluginId, value.toString())
+                        }
+                    }
+                    crashCountsFile.outputStream().use { output ->
+                        properties.store(output, "Plugin crash counts")
+                    }
+                }.onFailure { e ->
+                    logger.error("Failed to persist plugin crash counts", e)
                 }
             }
-            crashCountsFile.outputStream().use { output ->
-                properties.store(output, "Plugin crash counts")
-            }
-        }.onFailure { e ->
-            logger.error("Failed to persist plugin crash counts", e)
         }
     }
 

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
@@ -882,6 +882,9 @@ class PluginManager private constructor(
 
     fun forceDisablePlugin(pluginId: String) {
         val loadedPlugin = loadedPlugins[pluginId] ?: return
+        runCatching { loadedPlugin.plugin.deactivate() }.onFailure { e ->
+            logger.error("Plugin deactivate threw during force-disable: $pluginId", e)
+        }
         loadedPlugin.isEnabled = false
         savePluginState(pluginId, false)
         logger.warn("Force-disabled plugin due to crashes: $pluginId")

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
@@ -50,6 +50,7 @@ import com.itsaky.androidide.plugins.manager.services.IdeEnvironmentServiceImpl
 import com.itsaky.androidide.plugins.manager.services.IdeArchiveServiceImpl
 import com.itsaky.androidide.plugins.manager.services.IdeSidebarServiceImpl
 import com.itsaky.androidide.plugins.manager.services.IdeEditorServiceImpl
+import com.itsaky.androidide.plugins.manager.ui.PluginEditorTabManager
 import com.itsaky.androidide.plugins.manager.services.IdeThemeServiceImpl
 import com.itsaky.androidide.plugins.services.IdeThemeService
 import com.itsaky.androidide.plugins.services.IdeFeatureFlagService
@@ -62,9 +63,12 @@ import com.itsaky.androidide.actions.SidebarSlotManager
 import com.itsaky.androidide.actions.SidebarSlotExceededException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
@@ -188,6 +192,9 @@ class PluginManager private constructor(
     private var templateReloadListener: (() -> Unit)? = null
     private var snippetRefreshListener: ((String) -> Unit)? = null
     val crashTracker = PluginCrashTracker(context, logger)
+
+    private val statePersistScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val statePersistMutex = Mutex()
 
     fun setTemplateReloadListener(listener: (() -> Unit)?) {
         this.templateReloadListener = listener
@@ -883,6 +890,10 @@ class PluginManager private constructor(
 
     fun forceDisablePlugin(pluginId: String) {
         val loadedPlugin = loadedPlugins[pluginId] ?: return
+        cleanupSidebarActions(pluginId)
+        runCatching { PluginEditorTabManager.getInstance().removePluginTabs(pluginId) }.onFailure { e ->
+            logger.error("Failed to remove plugin tabs during force-disable: $pluginId", e)
+        }
         cleanupPluginContributions(loadedPlugin)
         runCatching { loadedPlugin.plugin.deactivate() }.onFailure { e ->
             logger.error("Plugin deactivate threw during force-disable: $pluginId", e)
@@ -984,27 +995,28 @@ class PluginManager private constructor(
      * Save plugin enabled state to persistent storage
      */
     private fun savePluginState(pluginId: String, enabled: Boolean) {
-        executeWithErrorHandling("save plugin state", pluginId) {
-            pluginStates[pluginId] = enabled
-            val prefsFile = File(context.filesDir, "plugin_states.properties")
-            val properties = java.util.Properties()
+        pluginStates[pluginId] = enabled
+        statePersistScope.launch {
+            statePersistMutex.withLock {
+                executeWithErrorHandling("save plugin state", pluginId) {
+                    val prefsFile = File(context.filesDir, "plugin_states.properties")
+                    val properties = java.util.Properties()
 
-            // Load existing states
-            if (prefsFile.exists()) {
-                prefsFile.inputStream().use { input ->
-                    properties.load(input)
+                    if (prefsFile.exists()) {
+                        prefsFile.inputStream().use { input ->
+                            properties.load(input)
+                        }
+                    }
+
+                    properties.setProperty(pluginId, enabled.toString())
+
+                    prefsFile.outputStream().use { output ->
+                        properties.store(output, "Plugin enabled/disabled states")
+                    }
+
+                    logger.debug("Saved plugin state: $pluginId = $enabled")
                 }
             }
-
-            // Update the state
-            properties.setProperty(pluginId, enabled.toString())
-
-            // Save back to file
-            prefsFile.outputStream().use { output ->
-                properties.store(output, "Plugin enabled/disabled states")
-            }
-
-            logger.debug("Saved plugin state: $pluginId = $enabled")
         }
     }
     
@@ -1038,15 +1050,19 @@ class PluginManager private constructor(
     }
 
     private fun removePluginState(pluginId: String) {
-        executeWithErrorHandling("remove plugin state", pluginId) {
-            pluginStates.remove(pluginId)
-            val prefsFile = File(context.filesDir, "plugin_states.properties")
-            if (prefsFile.exists()) {
-                val properties = java.util.Properties()
-                properties.load(prefsFile.inputStream())
-                properties.remove(pluginId)
-                properties.store(prefsFile.outputStream(), "Plugin states")
-                logger.debug("Removed plugin state: $pluginId")
+        pluginStates.remove(pluginId)
+        statePersistScope.launch {
+            statePersistMutex.withLock {
+                executeWithErrorHandling("remove plugin state", pluginId) {
+                    val prefsFile = File(context.filesDir, "plugin_states.properties")
+                    if (prefsFile.exists()) {
+                        val properties = java.util.Properties()
+                        properties.load(prefsFile.inputStream())
+                        properties.remove(pluginId)
+                        properties.store(prefsFile.outputStream(), "Plugin states")
+                        logger.debug("Removed plugin state: $pluginId")
+                    }
+                }
             }
         }
     }

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
@@ -187,6 +187,7 @@ class PluginManager private constructor(
     private val documentationManager = PluginDocumentationManager(context)
     private var templateReloadListener: (() -> Unit)? = null
     private var snippetRefreshListener: ((String) -> Unit)? = null
+    val crashTracker = PluginCrashTracker(context, logger)
 
     fun setTemplateReloadListener(listener: (() -> Unit)?) {
         this.templateReloadListener = listener
@@ -631,8 +632,12 @@ class PluginManager private constructor(
                 templateService.cleanupAllTemplates()
             }
 
-            loadedPlugin.plugin.deactivate()
-            loadedPlugin.plugin.dispose()
+            runCatching { loadedPlugin.plugin.deactivate() }.onFailure { e ->
+                logger.error("Plugin deactivate threw during unload: $pluginId", e)
+            }
+            runCatching { loadedPlugin.plugin.dispose() }.onFailure { e ->
+                logger.error("Plugin dispose threw during unload: $pluginId", e)
+            }
 
             val themeService = loadedPlugin.context.services.get(IdeThemeService::class.java)
             if (themeService is IdeThemeServiceImpl) {
@@ -728,6 +733,7 @@ class PluginManager private constructor(
         // Remove plugin state and cleanup contributions
         if (deleted) {
             removePluginState(pluginId)
+            crashTracker.removeCrashCount(pluginId)
             cleanupPluginCacheFiles(pluginId)
             logger.info("Plugin uninstall completed successfully: $pluginId")
         } else {
@@ -844,7 +850,7 @@ class PluginManager private constructor(
             loadedPlugin.plugin.activate()
             loadedPlugin.isEnabled = true
             savePluginState(pluginId, true)
-
+            crashTracker.resetCrashCount(pluginId)
             logger.info("Enabled plugin: $pluginId")
             true
         } catch (e: Exception) {
@@ -873,7 +879,32 @@ class PluginManager private constructor(
             false
         }
     }
-    
+
+    fun forceDisablePlugin(pluginId: String) {
+        val loadedPlugin = loadedPlugins[pluginId] ?: return
+        loadedPlugin.isEnabled = false
+        savePluginState(pluginId, false)
+        logger.warn("Force-disabled plugin due to crashes: $pluginId")
+    }
+
+    sealed class CrashResult {
+        data class Recorded(val pluginId: String, val crashCount: Int) : CrashResult()
+        data class Disabled(val pluginId: String, val pluginName: String) : CrashResult()
+    }
+
+    fun recordPluginCrash(pluginId: String): CrashResult {
+        val count = crashTracker.recordCrash(pluginId)
+        return if (crashTracker.shouldDisable(pluginId)) {
+            forceDisablePlugin(pluginId)
+            val name = loadedPlugins[pluginId]?.manifest?.name ?: pluginId
+            CrashResult.Disabled(pluginId, name)
+        } else {
+            CrashResult.Recorded(pluginId, count)
+        }
+    }
+
+    fun getLoadedPluginIds(): Set<String> = loadedPlugins.keys.toSet()
+
     fun getServiceRegistry(): ServiceRegistry = serviceRegistry
     
     /**

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
@@ -840,21 +840,21 @@ class PluginManager private constructor(
 
     fun enablePlugin(pluginId: String): Boolean {
         val loadedPlugin = loadedPlugins[pluginId] ?: return false
-        
+
         if (loadedPlugin.isEnabled) {
             logger.info("Plugin $pluginId is already enabled")
             return true
         }
-        
-        return try {
-            loadedPlugin.plugin.activate()
-            loadedPlugin.isEnabled = true
+
+        loadedPlugin.isEnabled = true
+        activateLoadedPlugin(loadedPlugin)
+        return if (loadedPlugin.isEnabled) {
             savePluginState(pluginId, true)
             crashTracker.resetCrashCount(pluginId)
             logger.info("Enabled plugin: $pluginId")
             true
-        } catch (e: Exception) {
-            logger.error("Failed to enable plugin: $pluginId", e)
+        } else {
+            logger.error("Failed to enable plugin: $pluginId (activation failed)")
             false
         }
     }
@@ -868,6 +868,7 @@ class PluginManager private constructor(
         }
 
         return try {
+            cleanupPluginContributions(loadedPlugin)
             loadedPlugin.plugin.deactivate()
             loadedPlugin.isEnabled = false
             savePluginState(pluginId, false)
@@ -882,6 +883,7 @@ class PluginManager private constructor(
 
     fun forceDisablePlugin(pluginId: String) {
         val loadedPlugin = loadedPlugins[pluginId] ?: return
+        cleanupPluginContributions(loadedPlugin)
         runCatching { loadedPlugin.plugin.deactivate() }.onFailure { e ->
             logger.error("Plugin deactivate threw during force-disable: $pluginId", e)
         }
@@ -890,19 +892,50 @@ class PluginManager private constructor(
         logger.warn("Force-disabled plugin due to crashes: $pluginId")
     }
 
+    private fun cleanupPluginContributions(loadedPlugin: LoadedPlugin) {
+        val pluginId = loadedPlugin.manifest.id
+        runCatching { PluginProjectManager.getInstance().cleanupPluginTemplates(pluginId) }
+            .onFailure { logger.error("Failed to clean project templates for: $pluginId", it) }
+        runCatching {
+            PluginSnippetManager.getInstance().cleanupPlugin(pluginId)
+            snippetRefreshListener?.invoke(pluginId)
+        }.onFailure { logger.error("Failed to clean snippets for: $pluginId", it) }
+        runCatching { PluginBuildActionManager.getInstance().cleanupPlugin(pluginId) }
+            .onFailure { logger.error("Failed to clean build actions for: $pluginId", it) }
+        runCatching {
+            val commandService = loadedPlugin.context.services.get(IdeCommandService::class.java)
+            if (commandService is IdeCommandServiceImpl) commandService.cancelAllCommands()
+        }.onFailure { logger.error("Failed to cancel commands for: $pluginId", it) }
+        runCatching {
+            val templateService = loadedPlugin.context.services.get(IdeTemplateService::class.java)
+            if (templateService is IdeTemplateServiceImpl) templateService.cleanupAllTemplates()
+        }.onFailure { logger.error("Failed to cleanup templates for: $pluginId", it) }
+    }
+
     sealed class CrashResult {
-        data class Recorded(val pluginId: String, val crashCount: Int) : CrashResult()
-        data class Disabled(val pluginId: String, val pluginName: String) : CrashResult()
+        abstract val pluginId: String
+        abstract val pluginName: String
+
+        data class Recorded(
+            override val pluginId: String,
+            override val pluginName: String,
+            val crashCount: Int,
+        ) : CrashResult()
+
+        data class Disabled(
+            override val pluginId: String,
+            override val pluginName: String,
+        ) : CrashResult()
     }
 
     fun recordPluginCrash(pluginId: String): CrashResult {
         val count = crashTracker.recordCrash(pluginId)
+        val name = loadedPlugins[pluginId]?.manifest?.name ?: pluginId
         return if (crashTracker.shouldDisable(pluginId)) {
             forceDisablePlugin(pluginId)
-            val name = loadedPlugins[pluginId]?.manifest?.name ?: pluginId
             CrashResult.Disabled(pluginId, name)
         } else {
-            CrashResult.Recorded(pluginId, count)
+            CrashResult.Recorded(pluginId, name, count)
         }
     }
 

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/documentation/PluginDocumentationManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/documentation/PluginDocumentationManager.kt
@@ -124,7 +124,9 @@ class PluginDocumentationManager(private val context: Context) {
         plugin: DocumentationExtension? = null
     ): Boolean = withContext(Dispatchers.IO) {
 
-        plugin?.onDocumentationUninstall()
+        runCatching { plugin?.onDocumentationUninstall() }.onFailure { e ->
+            Log.e(TAG, "Plugin onDocumentationUninstall() threw during removal: $pluginId", e)
+        }
 
         val db = getPluginDatabase()
         if (db == null) {

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/documentation/PluginDocumentationManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/documentation/PluginDocumentationManager.kt
@@ -124,7 +124,10 @@ class PluginDocumentationManager(private val context: Context) {
         plugin: DocumentationExtension? = null
     ): Boolean = withContext(Dispatchers.IO) {
 
-        runCatching { plugin?.onDocumentationUninstall() }.onFailure { e ->
+        try {
+            plugin?.onDocumentationUninstall()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Log.e(TAG, "Plugin onDocumentationUninstall() threw during removal: $pluginId", e)
         }
 

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/ui/PluginEditorTabManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/ui/PluginEditorTabManager.kt
@@ -56,7 +56,6 @@ class PluginEditorTabManager {
         logger.error("Plugin '{}' crashed in {}", pluginId, context, error)
         val pm = pluginManagerRef ?: return
         val result = pm.recordPluginCrash(pluginId)
-        val name = (result as? PluginManager.CrashResult.Disabled)?.pluginName ?: pluginId
         val wasDisabled = result is PluginManager.CrashResult.Disabled
         val crashCount = when (result) {
             is PluginManager.CrashResult.Recorded -> result.crashCount
@@ -64,7 +63,7 @@ class PluginEditorTabManager {
         }
         runCatching {
             EventBus.getDefault().post(
-                PluginCrashedEvent(pluginId, name, crashCount, wasDisabled, Log.getStackTraceString(error))
+                PluginCrashedEvent(pluginId, result.pluginName, crashCount, wasDisabled, Log.getStackTraceString(error))
             )
         }
     }

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/ui/PluginEditorTabManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/ui/PluginEditorTabManager.kt
@@ -276,6 +276,33 @@ class PluginEditorTabManager {
     }
 
     /**
+     * Drop all tab and fragment registrations belonging to a single plugin.
+     * Used when a plugin is force-disabled so its tabs don't linger in the registry
+     * even if the editor activity is not currently registered for events.
+     */
+    fun removePluginTabs(pluginId: String) {
+        synchronized(this) {
+            val pluginManager = pluginManagerRef ?: return
+            val toRemove = pluginTabs
+                .filterValues { info ->
+                    pluginManager.getPluginIdForInstance(info.extension) == pluginId
+                }
+                .keys
+                .toList()
+
+            if (toRemove.isEmpty()) {
+                return
+            }
+
+            toRemove.forEach { tabId ->
+                pluginTabs.remove(tabId)
+                tabFragments.remove(tabId)
+            }
+            logger.info("Removed {} tab(s) for plugin: {}", toRemove.size, pluginId)
+        }
+    }
+
+    /**
      * Reload plugin tabs.
      */
     fun reloadPluginTabs(pluginManager: PluginManager) {

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/ui/PluginEditorTabManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/ui/PluginEditorTabManager.kt
@@ -2,10 +2,13 @@ package com.itsaky.androidide.plugins.manager.ui
 
 import android.util.Log
 import androidx.fragment.app.Fragment
+import com.itsaky.androidide.plugins.IPlugin
 import com.itsaky.androidide.plugins.extensions.EditorTabExtension
 import com.itsaky.androidide.plugins.extensions.EditorTabItem
 import com.itsaky.androidide.plugins.manager.core.PluginManager
 import com.itsaky.androidide.plugins.manager.fragment.PluginFragmentFactory
+import com.itsaky.androidide.eventbus.events.plugin.PluginCrashedEvent
+import org.greenrobot.eventbus.EventBus
 import org.slf4j.LoggerFactory
 
 /**
@@ -45,6 +48,23 @@ class PluginEditorTabManager {
         this.tabSelectionListener = listener
     }
 
+    private fun resolvePluginId(extension: EditorTabExtension): String? {
+        return pluginManagerRef?.getPluginIdForInstance(extension as IPlugin)
+    }
+
+    private fun handlePluginCrash(pluginId: String, context: String, error: Throwable) {
+        logger.error("Plugin '{}' crashed in {}", pluginId, context, error)
+        val pm = pluginManagerRef ?: return
+        val result = pm.recordPluginCrash(pluginId)
+        val name = (result as? PluginManager.CrashResult.Disabled)?.pluginName ?: pluginId
+        val wasDisabled = result is PluginManager.CrashResult.Disabled
+        val crashCount = when (result) {
+            is PluginManager.CrashResult.Recorded -> result.crashCount
+            is PluginManager.CrashResult.Disabled -> pm.crashTracker.getCrashCount(pluginId)
+        }
+        runCatching { EventBus.getDefault().post(PluginCrashedEvent(pluginId, name, crashCount, wasDisabled)) }
+    }
+
     /**
      * Load and register plugin editor tabs from all available plugins.
      */
@@ -62,8 +82,14 @@ class PluginEditorTabManager {
 
         editorTabExtensions.forEach { plugin ->
             logger.debug("Processing plugin: {}", plugin.javaClass.name)
+            val pluginId = resolvePluginId(plugin)
 
-            val tabItems = plugin.getMainEditorTabs()
+            val tabItems = try {
+                plugin.getMainEditorTabs()
+            } catch (e: Throwable) {
+                if (pluginId != null) handlePluginCrash(pluginId, "getMainEditorTabs()", e)
+                return@forEach
+            }
             logger.debug("Plugin {} returned {} main editor tabs", plugin.javaClass.name, tabItems.size)
 
             val filteredTabItems = tabItems
@@ -130,7 +156,13 @@ class PluginEditorTabManager {
         return synchronized(this) {
             tabFragments[tabId] ?: run {
                 val tabInfo = pluginTabs[tabId] ?: return null
-                val fragment = tabInfo.tabItem.fragmentFactory()
+                val fragment = try {
+                    tabInfo.tabItem.fragmentFactory()
+                } catch (e: Throwable) {
+                    val pluginId = resolvePluginId(tabInfo.extension)
+                    if (pluginId != null) handlePluginCrash(pluginId, "fragmentFactory()", e)
+                    return null
+                }
                 tabFragments[tabId] = fragment
                 logger.debug("Created fragment for plugin tab: {}", tabId)
 
@@ -170,7 +202,13 @@ class PluginEditorTabManager {
             val tabInfo = pluginTabs[tabId] ?: return
             val fragment = tabFragments[tabId] ?: return
 
-            tabInfo.extension.onEditorTabSelected(tabId, fragment)
+            try {
+                tabInfo.extension.onEditorTabSelected(tabId, fragment)
+            } catch (e: Throwable) {
+                val pluginId = resolvePluginId(tabInfo.extension)
+                if (pluginId != null) handlePluginCrash(pluginId, "onEditorTabSelected()", e)
+                return
+            }
             tabSelectionListener?.onTabSelected(tabId, fragment)
             logger.debug("Tab selection handled for plugin tab: {}", tabId)
         }
@@ -182,7 +220,14 @@ class PluginEditorTabManager {
     fun canCloseTab(tabId: String): Boolean {
         return synchronized(this) {
             val tabInfo = pluginTabs[tabId] ?: return true
-            tabInfo.extension.canCloseEditorTab(tabId) && tabInfo.tabItem.isCloseable
+            val canClose = try {
+                tabInfo.extension.canCloseEditorTab(tabId)
+            } catch (e: Throwable) {
+                val pluginId = resolvePluginId(tabInfo.extension)
+                if (pluginId != null) handlePluginCrash(pluginId, "canCloseEditorTab()", e)
+                true
+            }
+            canClose && tabInfo.tabItem.isCloseable
         }
     }
 
@@ -193,7 +238,12 @@ class PluginEditorTabManager {
         synchronized(this) {
             val tabInfo = pluginTabs[tabId] ?: return
 
-            tabInfo.extension.onEditorTabClosed(tabId)
+            try {
+                tabInfo.extension.onEditorTabClosed(tabId)
+            } catch (e: Throwable) {
+                val pluginId = resolvePluginId(tabInfo.extension)
+                if (pluginId != null) handlePluginCrash(pluginId, "onEditorTabClosed()", e)
+            }
             tabFragments.remove(tabId)
             tabSelectionListener?.onTabClosed(tabId)
             logger.debug("Closed plugin tab: {}", tabId)

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/ui/PluginEditorTabManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/ui/PluginEditorTabManager.kt
@@ -62,7 +62,11 @@ class PluginEditorTabManager {
             is PluginManager.CrashResult.Recorded -> result.crashCount
             is PluginManager.CrashResult.Disabled -> pm.crashTracker.getCrashCount(pluginId)
         }
-        runCatching { EventBus.getDefault().post(PluginCrashedEvent(pluginId, name, crashCount, wasDisabled)) }
+        runCatching {
+            EventBus.getDefault().post(
+                PluginCrashedEvent(pluginId, name, crashCount, wasDisabled, Log.getStackTraceString(error))
+            )
+        }
     }
 
     /**

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -881,6 +881,15 @@
 	<string name="plugin_permissions">Permissions</string>
 	<string name="plugin_dependencies">Dependencies</string>
 
+	<!-- Plugin crash dialog -->
+	<string name="title_plugin_crashed">Plugin crashed</string>
+	<string name="msg_plugin_crash">\"%1$s\" crashed (%2$d of 3).</string>
+	<string name="msg_plugin_crash_disabled">\"%1$s\" was disabled after repeated crashes.</string>
+	<string name="msg_plugin_crash_dev_hint">If you\'re the plugin developer, tap the info icon to view the crash logs.</string>
+	<string name="cd_plugin_crash_view_logs">View crash logs</string>
+	<string name="title_plugin_crash_log">Crash log: %1$s</string>
+	<string name="msg_crash_log_copied">Crash log copied to clipboard</string>
+
 	<!-- Message shown when the bootstrap installer is extract a file from the zip -->
 	<!-- The first parameter is the name of the zip entry -->
 	<string name="bootstrap_installer_unzipping">Unzipping %1$s</string>


### PR DESCRIPTION
When a plugin crashes, the crash is attributed to the offending plugin and absorbed rather than taking down the IDE. After three crashes the plugin is force-disabled and its UI contributions are removed.

  - forceDisablePlugin() now deactivates the plugin before disabling it
  - EditorHandlerActivity tears down a disabled plugin's editor tabs,
    sidebar items and menu entries so its features stop working
  - Replace the plugin-crash snackbar with a dialog; an info icon opens
    a scrollable view of the crash stack trace with copy-to-clipboard
  - PluginCrashedEvent now carries the stack trace from all crash sites

[Screen_recording_20260519_171543.webm](https://github.com/user-attachments/assets/9d7e661f-7147-4348-8adf-1ed299e97173)

