### PR TITLE
ADFA-4061: upgrade to latest kotlin-android

### DIFF
--- a/subprojects/kotlin-analysis-api/build.gradle.kts
+++ b/subprojects/kotlin-analysis-api/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 
 val ktAndroidRepo = "https://github.com/appdevforall/kotlin-android"
 val ktAndroidVersion = "2.3.255"
-val ktAndroidTag = "v${ktAndroidVersion}-414445c"
+val ktAndroidTag = "v${ktAndroidVersion}-172a7e7"
 val ktAndroidJarName = "analysis-api-standalone-embeddable-for-ide-${ktAndroidVersion}-SNAPSHOT.jar"
 
 externalAssets {
@@ -21,7 +21,7 @@ externalAssets {
 		source =
 			AssetSource.External(
 				url = uri("$ktAndroidRepo/releases/download/$ktAndroidTag/$ktAndroidJarName"),
-				sha256Checksum = "a98c4b3a3952799e1703ecc0444ac49bce66042b2c0b689d7e4c4b5b35369c3a",
+				sha256Checksum = "ee52466a893ed7261fb542a259cb469227aa8059cf7a36b5d1b41897a7e5bb08",
 			)
 	}
 }


### PR DESCRIPTION
Fixes an issue with Kotlin compiler where there was a recursive reference to com.android.java.lang.ClassValue, which resulted in a StackOverflow exception. See appdevforall/kotlin-android@172a7e7 for the actual fix.