### PR TITLE
ADFA-3534: Fix flickering code when font size is small

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/preferences/editorPrefExts.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/editorPrefExts.kt
@@ -94,7 +94,7 @@ private class TextSize(
   override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
     val binding = LayoutTextSizeSliderBinding.inflate(LayoutInflater.from(preference.context))
     var size = EditorPreferences.fontSize
-    if (size < 6 || size > 32) {
+    if (size !in 8.0..32.0) {
       size = 14f
     }
     changeTextSize(binding, size)

--- a/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -25,6 +25,8 @@ import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MotionEvent
+import android.view.ScaleGestureDetector
+import android.view.ScaleGestureDetector.SimpleOnScaleGestureListener
 import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.core.view.isVisible
 import com.blankj.utilcode.util.SizeUtils
@@ -107,6 +109,8 @@ class CodeEditorView(
 		CoroutineScope(
 			Dispatchers.Default + CoroutineName("CodeEditorView"),
 		)
+
+    private lateinit var scaleGestureDetector: ScaleGestureDetector
 
 	/**
 	 * The [CoroutineContext][kotlin.coroutines.CoroutineContext] used to reading and writing the file
@@ -234,7 +238,31 @@ class CodeEditorView(
 		addView(searchLayout, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))
 
 		readFileAndApplySelection(file, selection)
-	}
+
+        scaleGestureDetector =
+            ScaleGestureDetector(context, object : SimpleOnScaleGestureListener() {
+                override fun onScale(detector: ScaleGestureDetector): Boolean {
+                    val scaleFactor = detector.scaleFactor
+                    val delta = when {
+                        scaleFactor > 1f -> 1f
+                        scaleFactor < 1f -> -1f
+                        else -> 0f
+                    }
+
+                    if (delta != 0f) {
+                        changeFontSizeBy(delta)
+                    }
+
+                    return true
+                }
+            })
+
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        scaleGestureDetector.onTouchEvent(event)
+        return super.onTouchEvent(event)
+    }
 
 	override fun onHighlightLine(
 		file: String,

--- a/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -736,11 +736,9 @@ class CodeEditorView(
 	private fun changeFontSizeBy(delta: Float) {
 		val current = EditorPreferences.fontSize
 		val newSize = computeNewEditorFontSize(current, delta)
-		// HJE 2026-03-03 This works, but it seems weird that we set binding.editor.setTextSize(newSize) every time OUTSIDE the if ()
-		if (newSize != current) {
-			EditorPreferences.fontSize = newSize
-		}
-		binding.editor.setTextSize(newSize)
+        if (newSize == current) return
+        binding.editor.setTextSize(newSize)
+        EditorPreferences.fontSize = newSize
 	}
 }
 

--- a/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -79,7 +79,7 @@ import org.slf4j.LoggerFactory
 import java.io.Closeable
 import java.io.File
 
-private const val MIN_FONT_SIZE = 6f
+private const val MIN_FONT_SIZE = 8f
 private const val DEFAULT_FONT_SIZE = 14f
 private const val MAX_FONT_SIZE = 32f
 private val ARCHIVE_EXTENSIONS = setOf("apk", "cgp", "zip")

--- a/app/src/main/res/layout/layout_text_size_slider.xml
+++ b/app/src/main/res/layout/layout_text_size_slider.xml
@@ -16,7 +16,7 @@
     android:layout_height="wrap_content"
     android:stepSize="1.0"
     android:value="14.0"
-    android:valueFrom="6.0"
+    android:valueFrom="8.0"
     android:valueTo="32.0"
     app:thumbElevation="4dp" />
 

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
@@ -83,7 +83,7 @@ class LineSpansGenerator(internal var tree: TSTree, internal var lineCount: Int,
 
   companion object {
 
-    const val CACHE_THRESHOLD = 60
+    const val CACHE_THRESHOLD = 100
     const val TAG = "LineSpansGenerator"
     /**
      * Delay in milliseconds to batch UI redraws, preventing frame drops


### PR DESCRIPTION
* Increased the minimum font size from 6sp to 8sp to avoid rendering issues
* Save new font size set by zooming