### PR TITLE
fix(ADFA-2148): Do not truncate swipe hint text

### DIFF
--- a/app/src/main/res/layout/layout_editor_build_status.xml
+++ b/app/src/main/res/layout/layout_editor_build_status.xml
@@ -20,12 +20,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/build_status_layout"
     android:layout_width="match_parent"
-    android:layout_height="56dp">
+    android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/statusText"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:gravity="center"
         android:maxLines="1"
         android:paddingStart="16dp"
@@ -40,9 +40,8 @@
     <TextView
         android:id="@+id/swipe_hint"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:gravity="center"
-        android:maxLines="1"
         android:text="@string/msg_swipe_up"
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="?attr/colorOnBackground"


### PR DESCRIPTION
Remove `maxLines` from swipe hint text to fix truncated text