### PR TITLE
ADFA-3492 | Fix ProjectFile NPE in resource fragments

### DIFF
--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/activities/ResourceManagerActivity.kt
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/activities/ResourceManagerActivity.kt
@@ -61,15 +61,17 @@ class ResourceManagerActivity : BaseActivity() {
         lifecycleScope.launch {
             try {
                 val projectExtra = IntentCompat.getParcelableExtra(intent, Constants.EXTRA_KEY_PROJECT, ProjectFile::class.java)
-                project = ProjectManager.instance.openedProject ?: projectExtra
+                project = projectExtra ?: ProjectManager.instance.openedProject
 
                 if (project == null) {
                     finish()
                     return@launch
                 }
 
-                if (ProjectManager.instance.openedProject == null) {
-                    ProjectManager.instance.openProject(project)
+                project?.let { resolvedProject ->
+                    if (ProjectManager.instance.openedProject?.path != resolvedProject.path) {
+                        ProjectManager.instance.openProject(resolvedProject)
+                    }
                 }
 
                 setupViewPager()
@@ -204,6 +206,8 @@ class ResourceManagerActivity : BaseActivity() {
                     0 -> xmlPicker!!.launch("text/xml")
                     1 -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                         launchPhotoPicker()
+                    } else {
+                        photoPicker?.launch("image/*")
                     }
                 }
             }

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/activities/ResourceManagerActivity.kt
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/activities/ResourceManagerActivity.kt
@@ -17,15 +17,16 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.Companion.isPhotoPickerAvailable
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageOnly
 import androidx.annotation.RequiresApi
+import androidx.core.content.IntentCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
 import com.blankj.utilcode.util.ToastUtils
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.launch
 import org.appdevforall.codeonthego.layouteditor.BaseActivity
+import org.appdevforall.codeonthego.layouteditor.ProjectFile
 import org.appdevforall.codeonthego.layouteditor.R
 import org.appdevforall.codeonthego.layouteditor.adapters.PagerAdapter
-import org.appdevforall.codeonthego.layouteditor.adapters.models.DrawableFile
 import org.appdevforall.codeonthego.layouteditor.databinding.ActivityResourceManagerBinding
 import org.appdevforall.codeonthego.layouteditor.fragments.resources.ColorFragment
 import org.appdevforall.codeonthego.layouteditor.fragments.resources.DrawableFragment
@@ -40,260 +41,283 @@ import org.appdevforall.codeonthego.vectormaster.VectorMasterDrawable
 import java.io.FileNotFoundException
 
 class ResourceManagerActivity : BaseActivity() {
-  private var binding: ActivityResourceManagerBinding? = null
-  private var drawableList: List<DrawableFile> = ArrayList()
-  private var photoPicker: FilePicker? = null
-  private var fontPicker: FilePicker? = null
-  private var xmlPicker: FilePicker? = null
-  private var pickMedia: ActivityResultLauncher<PickVisualMediaRequest>? = null
-  private var requestPermission: ActivityResultLauncher<String>? = null
+    private var binding: ActivityResourceManagerBinding? = null
+    private var project: ProjectFile? = null
+    private var photoPicker: FilePicker? = null
+    private var fontPicker: FilePicker? = null
+    private var xmlPicker: FilePicker? = null
+    private var pickMedia: ActivityResultLauncher<PickVisualMediaRequest>? = null
+    private var requestPermission: ActivityResultLauncher<String>? = null
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    binding = ActivityResourceManagerBinding.inflate(
-      layoutInflater
-    )
-    setContentView(binding!!.getRoot())
-    setSupportActionBar(binding!!.topAppBar)
-    supportActionBar!!.setTitle(R.string.res_manager)
-    binding!!.topAppBar.setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
-    lifecycleScope.launch {
-      try {
-        if (ProjectManager.instance.openedProject == null) {
-          val extras = intent.extras
-          if (extras != null && extras.containsKey(Constants.EXTRA_KEY_PROJECT)) {
-            ProjectManager.instance
-              .openProject(extras.getParcelable(Constants.EXTRA_KEY_PROJECT))
-          }
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityResourceManagerBinding.inflate(
+            layoutInflater
+        )
+        setContentView(binding!!.getRoot())
+        setSupportActionBar(binding!!.topAppBar)
+        supportActionBar!!.setTitle(R.string.res_manager)
+        binding!!.topAppBar.setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
+        lifecycleScope.launch {
+            try {
+                val projectExtra = IntentCompat.getParcelableExtra(intent, Constants.EXTRA_KEY_PROJECT, ProjectFile::class.java)
+                project = ProjectManager.instance.openedProject ?: projectExtra
+
+                if (project == null) {
+                    finish()
+                    return@launch
+                }
+
+                if (ProjectManager.instance.openedProject == null) {
+                    ProjectManager.instance.openProject(project)
+                }
+
+                setupViewPager()
+            } catch (e: Exception) {
+                ToastUtils.showShort(R.string.msg_error_opening_project)
+                Log.e("ResourcesManagerActivity", "Error loading project", e)
+                finish()
+            }
         }
-        if (ProjectManager.instance.openedProject == null) return@launch
-        setupViewPager()
-      } catch (e: Exception) {
-        ToastUtils.showShort(R.string.msg_error_opening_project)
-        Log.e("ResourcesManagerActivity", "Error loading project", e)
-        finish()
-      }
+        requestPermission = registerForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { onRequestPermission(it) }
+        photoPicker = object : FilePicker(this) {
+            override fun onPickFile(uri: Uri?) {
+                onPickPhoto(uri)
+            }
+        }
+        fontPicker = object : FilePicker(this) {
+            override fun onPickFile(uri: Uri?) {
+                onPickFont(uri)
+            }
+        }
+        xmlPicker = object : FilePicker(this) {
+            override fun onPickFile(uri: Uri?) {
+                onPickXml(uri)
+            }
+        }
+        pickMedia =
+            registerForActivityResult<PickVisualMediaRequest, Uri>(ActivityResultContracts.PickVisualMedia()) { uri: Uri? ->
+                onPickPhoto(uri)
+            }
     }
-    requestPermission = registerForActivityResult(
-      ActivityResultContracts.RequestPermission()
-    ) { onRequestPermission(it) }
-    photoPicker = object : FilePicker(this) {
-      override fun onPickFile(uri: Uri?) {
-        onPickPhoto(uri)
-      }
-    }
-    fontPicker = object : FilePicker(this) {
-      override fun onPickFile(uri: Uri?) {
-        onPickFont(uri)
-      }
-    }
-    xmlPicker = object : FilePicker(this) {
-      override fun onPickFile(uri: Uri?) {
-        onPickXml(uri)
-      }
-    }
-    pickMedia =
-      registerForActivityResult<PickVisualMediaRequest, Uri>(ActivityResultContracts.PickVisualMedia()) { uri: Uri? ->
-        onPickPhoto(uri)
-      }
-  }
 
-  @SuppressLint("UseCompatLoadingForDrawables")
+    @SuppressLint("UseCompatLoadingForDrawables")
 	private fun setupViewPager() {
+        val currentProject = project ?: return
 		val adapter = PagerAdapter(supportFragmentManager, lifecycle)
-    adapter.setup(binding!!.pager, binding!!.tabLayout)
-    adapter.addFragmentToAdapter(
-      DrawableFragment(drawableList.toMutableList()),
-      getString(R.string.drawable),
-      getDrawable(R.drawable.image_outline)!!
-    )
-    adapter.addFragmentToAdapter(
-      ColorFragment(),
-      getString(R.string.color),
-      getDrawable(R.drawable.palette_outline)!!
-    )
-    adapter.addFragmentToAdapter(
-      StringFragment(),
-      getString(R.string.string),
-      getDrawable(R.drawable.format_letter_case)!!
-    )
-    adapter.addFragmentToAdapter(
-      FontFragment(),
-      getString(R.string.font),
-      getDrawable(R.drawable.format_font)!!
-    )
-    adapter.setupPager(ViewPager2.ORIENTATION_HORIZONTAL)
-    adapter.setupMediatorWithIcon()
+        adapter.setup(binding!!.pager, binding!!.tabLayout)
+        adapter.addFragmentToAdapter(
+            DrawableFragment.newInstance(currentProject),
+            getString(R.string.drawable),
+            getDrawable(R.drawable.image_outline)!!
+        )
+        adapter.addFragmentToAdapter(
+            ColorFragment.newInstance(currentProject),
+            getString(R.string.color),
+            getDrawable(R.drawable.palette_outline)!!
+        )
+        adapter.addFragmentToAdapter(
+            StringFragment.newInstance(currentProject),
+            getString(R.string.string),
+            getDrawable(R.drawable.format_letter_case)!!
+        )
+        adapter.addFragmentToAdapter(
+            FontFragment.newInstance(currentProject),
+            getString(R.string.font),
+            getDrawable(R.drawable.format_font)!!
+        )
+        adapter.setupPager(ViewPager2.ORIENTATION_HORIZONTAL)
+        adapter.setupMediatorWithIcon()
 	}
 
-  override fun onCreateOptionsMenu(menu: Menu): Boolean {
-    menuInflater.inflate(R.menu.menu_resource_manager, menu)
-    return super.onCreateOptionsMenu(menu)
-  }
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_resource_manager, menu)
+        return super.onCreateOptionsMenu(menu)
+    }
 
-  override fun onOptionsItemSelected(item: MenuItem): Boolean {
-    val id = item.itemId
-    val fragment = supportFragmentManager.findFragmentByTag("f" + binding!!.pager.currentItem)
-    if (id == R.id.menu_add) {
-      if (fragment != null) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        val fragment = supportFragmentManager.findFragmentByTag("f" + binding!!.pager.currentItem)
+
+        return when (item.itemId) {
+            R.id.menu_add -> {
+                handleAddResourceAction(fragment)
+                true
+            }
+            R.id.menu_viewxml -> {
+                handleViewXmlAction(fragment)
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun handleAddResourceAction(fragment: androidx.fragment.app.Fragment?) {
+        if (fragment == null) {
+            showErrorState("Something went wrong..")
+            return
+        }
+
         when (fragment) {
-          is DrawableFragment -> {
-            MaterialAlertDialogBuilder(this)
-              .setTitle(R.string.select_drawable_type)
-              .setAdapter(
+            is DrawableFragment -> showDrawableTypePicker()
+            is ColorFragment -> fragment.addColor()
+            is StringFragment -> fragment.addString()
+            is FontFragment -> fontPicker!!.launch("font/*")
+        }
+    }
+
+    private fun handleViewXmlAction(fragment: androidx.fragment.app.Fragment?) {
+        val currentProject = project
+        if (currentProject == null) {
+            showErrorState(R.string.msg_error_opening_project)
+            return
+        }
+
+        if (fragment == null) {
+            showErrorState("Something went wrong..")
+            return
+        }
+
+        when (fragment) {
+            is ColorFragment -> launchXmlViewer(currentProject.colorsPath)
+            is StringFragment -> launchXmlViewer(currentProject.stringsPath)
+            else -> {
+                SBUtils.make(binding!!.getRoot(), "Unavailable for this fragment..")
+                    .setSlideAnimation()
+                    .showAsSuccess()
+            }
+        }
+    }
+
+    private fun showDrawableTypePicker() {
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.select_drawable_type)
+            .setAdapter(
                 ArrayAdapter(
-                  this,
-                  android.R.layout.simple_list_item_1, arrayOf("Vector Drawable", "Image Drawable")
+                    this,
+                    android.R.layout.simple_list_item_1,
+                    arrayOf("Vector Drawable", "Image Drawable")
                 )
-              ) { _, w: Int ->
+            ) { _, w: Int ->
                 when (w) {
-                  0 -> xmlPicker!!.launch("text/xml")
-                  1 -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    launchPhotoPicker()
-                  }
+                    0 -> xmlPicker!!.launch("text/xml")
+                    1 -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        launchPhotoPicker()
+                    }
                 }
-              }
-              .show()
-          }
-
-          is ColorFragment -> {
-            fragment.addColor()
-          }
-
-          is StringFragment -> {
-            fragment.addString()
-          }
-
-          is FontFragment -> {
-            fontPicker!!.launch("font/*")
-          }
-        }
-      } else {
-        SBUtils.make(binding!!.getRoot(), "Something went wrong..")
-          .setSlideAnimation()
-          .showAsError()
-      }
-    } else if (id == R.id.menu_viewxml) {
-      if (fragment != null) {
-        when (fragment) {
-          is ColorFragment -> {
-            val it = Intent().setClass(this, ShowXMLActivity::class.java)
-            it.putExtra(ShowXMLActivity.EXTRA_KEY_XML, ProjectManager.instance.colorsXml)
-            startActivity(it)
-          }
-
-          is StringFragment -> {
-            val it = Intent().setClass(this, ShowXMLActivity::class.java)
-            it.putExtra(
-              ShowXMLActivity.EXTRA_KEY_XML, ProjectManager.instance.stringsXml
-            )
-            startActivity(it)
-          }
-
-          else -> {
-            SBUtils.make(binding!!.getRoot(), "Unavailable for this fragment..")
-              .setSlideAnimation()
-              .showAsSuccess()
-          }
-        }
-      } else {
-        SBUtils.make(binding!!.getRoot(), "Something went wrong..")
-          .setSlideAnimation()
-          .showAsError()
-      }
-    }
-    return super.onOptionsItemSelected(item)
-  }
-
-  @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
-  private fun launchPhotoPicker() {
-    if (isPhotoPickerAvailable(this)) {
-      if (checkSelfPermission(Manifest.permission.READ_MEDIA_IMAGES)
-        == PackageManager.PERMISSION_DENIED
-      ) {
-        requestPermission!!.launch(Manifest.permission.READ_MEDIA_IMAGES)
-        return
-      }
-      // Launch the photo picker and allow the user to choose only images.
-      pickMedia!!.launch(
-        PickVisualMediaRequest.Builder()
-          .setMediaType(ImageOnly)
-          .build()
-      )
-    } else {
-      photoPicker!!.launch("image/*")
-    }
-  }
-
-  private fun onPickPhoto(uri: Uri?) {
-    if (uri != null) {
-      Log.d("PhotoPicker", "Selected URI: $uri")
-      if (FileUtil.isDownloadsDocument(uri)) {
-        SBUtils.make(binding!!.getRoot(), R.string.select_from_storage).showAsError()
-        return
-      }
-      val fragment = supportFragmentManager.findFragmentByTag("f" + binding!!.pager.currentItem)
-      if (fragment is DrawableFragment) {
-        fragment.addDrawable(uri)
-      }
-    } else {
-      Log.d("PhotoPicker", "No media selected")
-      SBUtils.make(binding!!.getRoot(), "No image selected").setFadeAnimation().show()
-    }
-  }
-
-  private fun onPickFont(uri: Uri?) {
-    if (uri != null) {
-      Log.d("FontPicker", "Selected URI: $uri")
-      if (FileUtil.isDownloadsDocument(uri)) {
-        SBUtils.make(binding!!.getRoot(), R.string.select_from_storage).showAsError()
-        return
-      }
-      val fragment = supportFragmentManager.findFragmentByTag("f" + binding!!.pager.currentItem)
-      if (fragment is FontFragment) {
-        fragment.addFont(uri)
-      }
-    } else {
-      Log.d("FontPicker", "No font selected")
-      SBUtils.make(binding!!.getRoot(), "No font selected").setFadeAnimation().show()
-    }
-  }
-
-  private fun onPickXml(uri: Uri?) {
-    if (uri != null) {
-      Log.d("DrawablePicker", "Selected URI: $uri")
-      if (FileUtil.isDownloadsDocument(uri)) {
-        SBUtils.make(binding!!.getRoot(), R.string.select_from_storage).showAsError()
-        return
-      }
-      val fragment = supportFragmentManager.findFragmentByTag("f" + binding!!.pager.currentItem)
-      if (fragment is DrawableFragment) {
-        try {
-          val drawable = VectorMasterDrawable(this)
-          drawable.setInputStream(contentResolver.openInputStream(uri))
-          if (drawable.isVector) fragment.addDrawable(uri) else SBUtils.make(
-            binding!!.getRoot(), "Not a valid vector drawable"
-          )
-            .setFadeAnimation()
-            .setType(SBUtils.Type.INFO)
+            }
             .show()
-        } catch (e: FileNotFoundException) {
-          e.printStackTrace()
-          ToastUtils.showShort(e.toString())
-        }
-      }
-    } else {
-      Log.d("DrawablePicker", "No drawable selected")
-      SBUtils.make(binding!!.getRoot(), "No drawable selected").setFadeAnimation().show()
     }
-  }
 
-  private fun onRequestPermission(isGranted: Boolean) {
-    if (isGranted) SBUtils.make(findViewById(android.R.id.content), R.string.permission_granted)
-      .setSlideAnimation()
-      .showAsSuccess() else SBUtils.make(
-      findViewById(android.R.id.content),
-      R.string.permission_denied
-    ).setSlideAnimation().showAsError()
-  }
+    private fun launchXmlViewer(filePath: String) {
+        val intent = Intent(this, ShowXMLActivity::class.java).apply {
+            putExtra(ShowXMLActivity.EXTRA_KEY_XML, FileUtil.readFile(filePath))
+        }
+        startActivity(intent)
+    }
+
+    private fun showErrorState(message: String) {
+        SBUtils.make(binding!!.getRoot(), message)
+            .setSlideAnimation()
+            .showAsError()
+    }
+
+    private fun showErrorState(messageResId: Int) {
+        SBUtils.make(binding!!.getRoot(), messageResId)
+            .setSlideAnimation()
+            .showAsError()
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    private fun launchPhotoPicker() {
+        if (isPhotoPickerAvailable(this)) {
+            if (checkSelfPermission(Manifest.permission.READ_MEDIA_IMAGES)
+                == PackageManager.PERMISSION_DENIED
+            ) {
+                requestPermission!!.launch(Manifest.permission.READ_MEDIA_IMAGES)
+                return
+            }
+            // Launch the photo picker and allow the user to choose only images.
+            pickMedia!!.launch(
+                PickVisualMediaRequest.Builder()
+                    .setMediaType(ImageOnly)
+                    .build()
+            )
+        } else {
+            photoPicker!!.launch("image/*")
+        }
+    }
+
+    private fun onPickPhoto(uri: Uri?) {
+        if (uri != null) {
+            Log.d("PhotoPicker", "Selected URI: $uri")
+            if (FileUtil.isDownloadsDocument(uri)) {
+                SBUtils.make(binding!!.getRoot(), R.string.select_from_storage).showAsError()
+                return
+            }
+            val fragment = supportFragmentManager.findFragmentByTag("f" + binding!!.pager.currentItem)
+            if (fragment is DrawableFragment) {
+                fragment.addDrawable(uri)
+            }
+        } else {
+            Log.d("PhotoPicker", "No media selected")
+            SBUtils.make(binding!!.getRoot(), "No image selected").setFadeAnimation().show()
+        }
+    }
+
+    private fun onPickFont(uri: Uri?) {
+        if (uri != null) {
+            Log.d("FontPicker", "Selected URI: $uri")
+            if (FileUtil.isDownloadsDocument(uri)) {
+                SBUtils.make(binding!!.getRoot(), R.string.select_from_storage).showAsError()
+                return
+            }
+            val fragment = supportFragmentManager.findFragmentByTag("f" + binding!!.pager.currentItem)
+            if (fragment is FontFragment) {
+                fragment.addFont(uri)
+            }
+        } else {
+            Log.d("FontPicker", "No font selected")
+            SBUtils.make(binding!!.getRoot(), "No font selected").setFadeAnimation().show()
+        }
+    }
+
+    private fun onPickXml(uri: Uri?) {
+        if (uri != null) {
+            Log.d("DrawablePicker", "Selected URI: $uri")
+            if (FileUtil.isDownloadsDocument(uri)) {
+                SBUtils.make(binding!!.getRoot(), R.string.select_from_storage).showAsError()
+                return
+            }
+            val fragment = supportFragmentManager.findFragmentByTag("f" + binding!!.pager.currentItem)
+            if (fragment is DrawableFragment) {
+                try {
+                    val drawable = VectorMasterDrawable(this)
+                    drawable.setInputStream(contentResolver.openInputStream(uri))
+                    if (drawable.isVector) fragment.addDrawable(uri) else SBUtils.make(
+                        binding!!.getRoot(), "Not a valid vector drawable"
+                    )
+                        .setFadeAnimation()
+                        .setType(SBUtils.Type.INFO)
+                        .show()
+                } catch (e: FileNotFoundException) {
+                    e.printStackTrace()
+                    ToastUtils.showShort(e.toString())
+                }
+            }
+        } else {
+            Log.d("DrawablePicker", "No drawable selected")
+            SBUtils.make(binding!!.getRoot(), "No drawable selected").setFadeAnimation().show()
+        }
+    }
+
+    private fun onRequestPermission(isGranted: Boolean) {
+        if (isGranted) SBUtils.make(findViewById(android.R.id.content), R.string.permission_granted)
+            .setSlideAnimation()
+            .showAsSuccess() else SBUtils.make(
+            findViewById(android.R.id.content),
+            R.string.permission_denied
+        ).setSlideAnimation().showAsError()
+    }
 }

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/ColorFragment.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/ColorFragment.java
@@ -28,10 +28,11 @@ import org.appdevforall.codeonthego.layouteditor.adapters.ColorResourceAdapter;
 import org.appdevforall.codeonthego.layouteditor.adapters.models.ValuesItem;
 import org.appdevforall.codeonthego.layouteditor.databinding.FragmentResourcesBinding;
 import org.appdevforall.codeonthego.layouteditor.databinding.LayoutValuesItemDialogBinding;
-import org.appdevforall.codeonthego.layouteditor.managers.ProjectManager;
+import org.appdevforall.codeonthego.layouteditor.utils.Constants;
 import org.appdevforall.codeonthego.layouteditor.tools.ColorPickerDialogFlag;
 import org.appdevforall.codeonthego.layouteditor.tools.ValuesResourceParser;
 import org.appdevforall.codeonthego.layouteditor.utils.NameErrorChecker;
+import org.appdevforall.codeonthego.layouteditor.utils.ProjectResolver;
 import org.appdevforall.codeonthego.layouteditor.utils.SBUtils;
 
 import java.io.FileInputStream;
@@ -52,6 +53,14 @@ public class ColorFragment extends Fragment {
     private List<ValuesItem> colorList = new ArrayList<>();
     ValuesResourceParser colorParser;
 
+    public static ColorFragment newInstance(ProjectFile project) {
+        ColorFragment fragment = new ColorFragment();
+        Bundle args = new Bundle();
+        args.putParcelable(Constants.EXTRA_KEY_PROJECT, project);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
     @Override
     public android.view.View onCreateView(
             @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -62,7 +71,9 @@ public class ColorFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        ProjectFile project = ProjectManager.getInstance().getOpenedProject();
+        ProjectFile project = ProjectResolver.getValidProjectOrShowError(getArguments(), view);
+        if (project == null) return;
+
         try {
             loadColorsFromXML(project.getColorsPath());
         } catch (FileNotFoundException e) {

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/DrawableFragment.kt
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/DrawableFragment.kt
@@ -33,31 +33,40 @@ import org.appdevforall.codeonthego.layouteditor.adapters.models.DrawableFile
 import org.appdevforall.codeonthego.layouteditor.databinding.DialogSelectDpisBinding
 import org.appdevforall.codeonthego.layouteditor.databinding.FragmentResourcesBinding
 import org.appdevforall.codeonthego.layouteditor.databinding.TextinputlayoutBinding
-import org.appdevforall.codeonthego.layouteditor.managers.ProjectManager.Companion.instance
 import org.appdevforall.codeonthego.layouteditor.tools.ImageConverter
+import org.appdevforall.codeonthego.layouteditor.utils.Constants
 import org.appdevforall.codeonthego.layouteditor.utils.FileUtil
 import org.appdevforall.codeonthego.layouteditor.utils.FileUtil.getLastSegmentFromPath
 import org.appdevforall.codeonthego.layouteditor.utils.NameErrorChecker
-import org.appdevforall.codeonthego.layouteditor.utils.SBUtils
+import org.appdevforall.codeonthego.layouteditor.utils.ProjectResolver
 import org.appdevforall.codeonthego.layouteditor.utils.Utils
 import org.greenrobot.eventbus.EventBus
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.IOException
 
-class DrawableFragment(
-    private var drawableList: MutableList<DrawableFile>
-) : Fragment() {
+class DrawableFragment : Fragment() {
     private var binding: FragmentResourcesBinding? = null
     private var mRecyclerView: RecyclerView? = null
 
     private var project: ProjectFile? = null
+    private var drawableList: MutableList<DrawableFile> = mutableListOf()
 
     private var adapter: DrawableResourceAdapter? = null
     var dpiAdapter: DPIsListAdapter? = null
     private var dpiList = mutableListOf("ldpi", "mdpi", "hdpi", "xhdpi", "xxhdpi", "xxxhdpi")
 
     private val logger = LoggerFactory.getLogger(DrawableFragment::class.java)
+
+    companion object {
+        fun newInstance(project: ProjectFile): DrawableFragment {
+            val fragment = DrawableFragment()
+            val args = Bundle()
+            args.putParcelable(Constants.EXTRA_KEY_PROJECT, project)
+            fragment.arguments = args
+            return fragment
+        }
+    }
 
 
     override fun onCreateView(
@@ -69,7 +78,9 @@ class DrawableFragment(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        project = instance.openedProject
+        project = ProjectResolver.getValidProjectOrShowError(arguments, view)
+        if (project == null) return
+
         loadDrawables()
         mRecyclerView = binding!!.recyclerView
         // Create the adapter and set it to the RecyclerView

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/FontFragment.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/FontFragment.java
@@ -31,9 +31,10 @@ import org.appdevforall.codeonthego.layouteditor.adapters.FontResourceAdapter;
 import org.appdevforall.codeonthego.layouteditor.adapters.models.FontItem;
 import org.appdevforall.codeonthego.layouteditor.databinding.FragmentResourcesBinding;
 import org.appdevforall.codeonthego.layouteditor.databinding.LayoutFontItemDialogBinding;
-import org.appdevforall.codeonthego.layouteditor.managers.ProjectManager;
+import org.appdevforall.codeonthego.layouteditor.utils.Constants;
 import org.appdevforall.codeonthego.layouteditor.utils.FileUtil;
 import org.appdevforall.codeonthego.layouteditor.utils.NameErrorChecker;
+import org.appdevforall.codeonthego.layouteditor.utils.ProjectResolver;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -49,17 +50,27 @@ public class FontFragment extends Fragment {
   private List<FontItem> fontList = new ArrayList<>();
   private ExecutorService executor;
 
+  public static FontFragment newInstance(ProjectFile project) {
+    FontFragment fragment = new FontFragment();
+    Bundle args = new Bundle();
+    args.putParcelable(Constants.EXTRA_KEY_PROJECT, project);
+    fragment.setArguments(args);
+    return fragment;
+  }
+
   @Override
   public android.view.View onCreateView(
     @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     binding = FragmentResourcesBinding.inflate(inflater, container, false);
-    project = ProjectManager.getInstance().getOpenedProject();
     return binding.getRoot();
   }
 
   @Override
   public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
+    project = ProjectResolver.getValidProjectOrShowError(getArguments(), view);
+    if (project == null) return;
+
     executor = Executors.newSingleThreadExecutor();
     adapter = new FontResourceAdapter(fontList);
     RecyclerView mRecyclerView = binding.recyclerView;

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/FontFragment.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/FontFragment.java
@@ -83,8 +83,10 @@ public class FontFragment extends Fragment {
   @Override
   public void onDestroyView() {
     super.onDestroyView();
-    executor.shutdownNow();
-    binding = null;
+    if (executor != null) {
+      executor.shutdownNow();
+      binding = null;
+    }
   }
 
   private void loadFonts() {

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/StringFragment.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/fragments/resources/StringFragment.java
@@ -24,9 +24,10 @@ import org.appdevforall.codeonthego.layouteditor.adapters.StringResourceAdapter;
 import org.appdevforall.codeonthego.layouteditor.adapters.models.ValuesItem;
 import org.appdevforall.codeonthego.layouteditor.databinding.FragmentResourcesBinding;
 import org.appdevforall.codeonthego.layouteditor.databinding.LayoutValuesItemDialogBinding;
-import org.appdevforall.codeonthego.layouteditor.managers.ProjectManager;
+import org.appdevforall.codeonthego.layouteditor.utils.Constants;
 import org.appdevforall.codeonthego.layouteditor.tools.ValuesResourceParser;
 import org.appdevforall.codeonthego.layouteditor.utils.NameErrorChecker;
+import org.appdevforall.codeonthego.layouteditor.utils.ProjectResolver;
 import org.appdevforall.codeonthego.layouteditor.utils.SBUtils;
 
 import java.io.FileInputStream;
@@ -46,6 +47,14 @@ public class StringFragment extends Fragment {
   private List<ValuesItem> stringList = new ArrayList<>();
   ValuesResourceParser stringParser;
 
+  public static StringFragment newInstance(ProjectFile project) {
+    StringFragment fragment = new StringFragment();
+    Bundle args = new Bundle();
+    args.putParcelable(Constants.EXTRA_KEY_PROJECT, project);
+    fragment.setArguments(args);
+    return fragment;
+  }
+
   @Override
   public android.view.View onCreateView(
       @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -56,7 +65,9 @@ public class StringFragment extends Fragment {
   @Override
   public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
-    ProjectFile project = ProjectManager.getInstance().getOpenedProject();
+    ProjectFile project = ProjectResolver.getValidProjectOrShowError(getArguments(), view);
+    if (project == null) return;
+
     try {
       loadStringsFromXML(project.getStringsPath());
     } catch (FileNotFoundException e) {

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/utils/ProjectResolver.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/utils/ProjectResolver.java
@@ -12,12 +12,10 @@ import org.appdevforall.codeonthego.layouteditor.managers.ProjectManager;
 public class ProjectResolver {
     @Nullable
     public static ProjectFile resolveProject(@Nullable Bundle arguments) {
-        ProjectFile openedProject = ProjectManager.getInstance().getOpenedProject();
-
-        if (openedProject != null) return openedProject;
-        if (arguments != null) return arguments.getParcelable(Constants.EXTRA_KEY_PROJECT);
-
-        return null;
+        if (arguments != null && arguments.containsKey(Constants.EXTRA_KEY_PROJECT)) {
+            return arguments.getParcelable(Constants.EXTRA_KEY_PROJECT);
+        }
+        return ProjectManager.getInstance().getOpenedProject();
     }
 
     @Nullable

--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/utils/ProjectResolver.java
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/utils/ProjectResolver.java
@@ -1,0 +1,31 @@
+package org.appdevforall.codeonthego.layouteditor.utils;
+
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.annotation.Nullable;
+
+import org.appdevforall.codeonthego.layouteditor.ProjectFile;
+import org.appdevforall.codeonthego.layouteditor.R;
+import org.appdevforall.codeonthego.layouteditor.managers.ProjectManager;
+
+public class ProjectResolver {
+    @Nullable
+    public static ProjectFile resolveProject(@Nullable Bundle arguments) {
+        ProjectFile openedProject = ProjectManager.getInstance().getOpenedProject();
+
+        if (openedProject != null) return openedProject;
+        if (arguments != null) return arguments.getParcelable(Constants.EXTRA_KEY_PROJECT);
+
+        return null;
+    }
+
+    @Nullable
+    public static ProjectFile getValidProjectOrShowError(@Nullable Bundle arguments, @Nullable View view) {
+        ProjectFile project = resolveProject(arguments);
+        if (project == null && view != null) {
+            SBUtils.make(view, R.string.msg_error_opening_project).showAsError();
+        }
+        return project;
+    }
+}


### PR DESCRIPTION
## Description

Resolves a `NullPointerException` occurring in `ColorFragment` (and other resource fragments) when attempting to access `ProjectFile` methods like `getColorsPath()` on a null object reference. This PR introduces a `ProjectResolver` to safely resolve the project instance from `ProjectManager` or the fragment arguments. Additionally, it transitions the resource fragments to use the `newInstance` pattern, ensuring the `ProjectFile` is securely passed and retained across the fragment's lifecycle.

## Details

* Created `ProjectResolver.java` to handle safe project data extraction and display graceful error states if the project is null.
* Updated `ColorFragment`, `DrawableFragment`, `FontFragment`, and `StringFragment` to use a `newInstance(ProjectFile)` method instead of relying solely on the singleton or non-default constructors.
* Refactored `ResourceManagerActivity` to handle project intent loading correctly using `IntentCompat` and cleaned up its options menu action logic.

### Before

https://github.com/user-attachments/assets/574b4835-4acc-40d1-9a3c-d24f850fc76e

### After

https://github.com/user-attachments/assets/41f1934e-d265-467b-95e3-114deaa283ec


## Ticket

[ADFA-3492](https://appdevforall.atlassian.net/browse/ADFA-3492)

[ADFA-3492]: https://appdevforall.atlassian.net/browse/ADFA-3492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ