### PR TITLE
feat(ADFA-4105): Save new font size on zooming

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/preferences/editorPrefExts.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/editorPrefExts.kt
@@ -94,7 +94,7 @@ private class TextSize(
   override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
     val binding = LayoutTextSizeSliderBinding.inflate(LayoutInflater.from(preference.context))
     var size = EditorPreferences.fontSize
-    if (size !in 6.0..32.0) {
+    if (size !in 6f..32f) {
       size = 14f
     }
     binding.slider.value = kotlin.math.round(size)

--- a/app/src/main/java/com/itsaky/androidide/preferences/editorPrefExts.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/editorPrefExts.kt
@@ -94,27 +94,22 @@ private class TextSize(
   override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
     val binding = LayoutTextSizeSliderBinding.inflate(LayoutInflater.from(preference.context))
     var size = EditorPreferences.fontSize
-    if (size !in 8.0..32.0) {
+    if (size !in 6.0..32.0) {
       size = 14f
     }
-    changeTextSize(binding, size)
+    binding.slider.value = kotlin.math.round(size)
     binding.slider.setLabelFormatter { it.toString() }
 
     dialog.setView(binding.root)
     dialog.setPositiveButton(android.R.string.ok) { iface, _ ->
       iface.dismiss()
-      changeTextSize(binding, binding.slider.value)
+      EditorPreferences.fontSize = binding.slider.value
     }
     dialog.setNegativeButton(android.R.string.cancel, null)
     dialog.setNeutralButton(string.reset) { iface, _ ->
       iface.dismiss()
-      changeTextSize(binding, 14f)
+      EditorPreferences.fontSize = 14f
     }
-  }
-
-  private fun changeTextSize(binding: LayoutTextSizeSliderBinding, size: Float) {
-    EditorPreferences.fontSize = size
-    binding.slider.value = size
   }
 }
 

--- a/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/CodeEditorView.kt
@@ -20,13 +20,14 @@ package com.itsaky.androidide.ui
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
+import android.util.TypedValue
+import android.util.TypedValue.COMPLEX_UNIT_SP
 import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MotionEvent
-import android.view.ScaleGestureDetector
-import android.view.ScaleGestureDetector.SimpleOnScaleGestureListener
 import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.core.view.isVisible
 import com.blankj.utilcode.util.SizeUtils
@@ -58,6 +59,7 @@ import com.itsaky.androidide.tasks.runOnUiThread
 import com.itsaky.androidide.utils.customOrJBMono
 import io.github.rosemoe.sora.event.ClickEvent
 import io.github.rosemoe.sora.event.InterceptTarget
+import io.github.rosemoe.sora.event.TextSizeChangeEvent
 import io.github.rosemoe.sora.text.Content
 import io.github.rosemoe.sora.text.LineSeparator
 import io.github.rosemoe.sora.util.IntPair
@@ -80,8 +82,9 @@ import org.greenrobot.eventbus.ThreadMode
 import org.slf4j.LoggerFactory
 import java.io.Closeable
 import java.io.File
+import kotlin.math.abs
 
-private const val MIN_FONT_SIZE = 8f
+private const val MIN_FONT_SIZE = 6f
 private const val DEFAULT_FONT_SIZE = 14f
 private const val MAX_FONT_SIZE = 32f
 private val ARCHIVE_EXTENSIONS = setOf("apk", "cgp", "zip")
@@ -109,8 +112,6 @@ class CodeEditorView(
 		CoroutineScope(
 			Dispatchers.Default + CoroutineName("CodeEditorView"),
 		)
-
-    private lateinit var scaleGestureDetector: ScaleGestureDetector
 
 	/**
 	 * The [CoroutineContext][kotlin.coroutines.CoroutineContext] used to reading and writing the file
@@ -200,6 +201,27 @@ class CodeEditorView(
 					resetBreakpointsInFile(file)
 				}
 			}
+
+			val displayMetrics = context.resources.displayMetrics
+			val minSizePx = TypedValue.applyDimension(COMPLEX_UNIT_SP, MIN_FONT_SIZE, displayMetrics)
+			val maxSizePx = TypedValue.applyDimension(COMPLEX_UNIT_SP, MAX_FONT_SIZE, displayMetrics)
+			setScaleTextSizes(minSizePx, maxSizePx)
+
+			subscribeEvent(TextSizeChangeEvent::class.java) { event, _ ->
+				val metrics = context.resources.displayMetrics
+				val newFontSize = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+					TypedValue.deriveDimension(COMPLEX_UNIT_SP, event.newTextSize, metrics)
+				} else {
+					@Suppress("DEPRECATION")
+					event.newTextSize / metrics.scaledDensity
+				}
+				
+				val currentFontSize = EditorPreferences.fontSize
+				val diff = abs(newFontSize - currentFontSize)
+				if (newFontSize in MIN_FONT_SIZE..MAX_FONT_SIZE && diff > 0.01f) {
+					EditorPreferences.fontSize = newFontSize
+				}
+			}
 		}
 
 		binding.editor.setOnGenericMotionListener { _, event ->
@@ -238,31 +260,7 @@ class CodeEditorView(
 		addView(searchLayout, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))
 
 		readFileAndApplySelection(file, selection)
-
-        scaleGestureDetector =
-            ScaleGestureDetector(context, object : SimpleOnScaleGestureListener() {
-                override fun onScale(detector: ScaleGestureDetector): Boolean {
-                    val scaleFactor = detector.scaleFactor
-                    val delta = when {
-                        scaleFactor > 1f -> 1f
-                        scaleFactor < 1f -> -1f
-                        else -> 0f
-                    }
-
-                    if (delta != 0f) {
-                        changeFontSizeBy(delta)
-                    }
-
-                    return true
-                }
-            })
-
-    }
-
-    override fun onTouchEvent(event: MotionEvent): Boolean {
-        scaleGestureDetector.onTouchEvent(event)
-        return super.onTouchEvent(event)
-    }
+	}
 
 	override fun onHighlightLine(
 		file: String,

--- a/app/src/main/res/layout/layout_text_size_slider.xml
+++ b/app/src/main/res/layout/layout_text_size_slider.xml
@@ -16,7 +16,7 @@
     android:layout_height="wrap_content"
     android:stepSize="1.0"
     android:value="14.0"
-    android:valueFrom="8.0"
+    android:valueFrom="6.0"
     android:valueTo="32.0"
     app:thumbElevation="4dp" />
 


### PR DESCRIPTION
* Save new font size across the editor on pinch-to-zoom
* Override the sora editor's min and max font sizes
* Avoid premature saving the of the font size just by opening the dialog