### PR TITLE
Update GitHub funding source to appdevforall

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: CodeOnTheGo
+github: appdevforall


### PR DESCRIPTION
Best practice is for GitHub funding.yml to name the organization (appdevforall), not the repo