### PR TITLE
fix(ADFA-2584): Allow file rename for case-only changes

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/actions/filetree/RenameAction.kt
+++ b/app/src/main/java/com/itsaky/androidide/actions/filetree/RenameAction.kt
@@ -61,10 +61,17 @@ class RenameAction(
 		builder.setPositiveButton(R.string.rename_file) { dialogInterface, _ ->
             val fileManagerViewModel: FileManagerViewModel by context.viewModels()
             val name: String = binding.name.editText?.text.toString().trim()
-            if (name.length !in 1..40) {
-                flashError(R.string.msg_invalid_name)
-                return@setPositiveButton
+            when {
+                name.isEmpty() -> {
+                    flashError(R.string.msg_invalid_name)
+                    return@setPositiveButton
+                }
+                name.length > 40 -> {
+                    flashError(R.string.file_name_too_long)
+                    return@setPositiveButton
+                }
             }
+
             dialogInterface.dismiss()
             fileManagerViewModel.renameFile(file, name, context) { renamed ->
                 if (!renamed) return@renameFile

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/FileManagerViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/FileManagerViewModel.kt
@@ -1,6 +1,7 @@
 package com.itsaky.androidide.viewmodel
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.blankj.utilcode.util.FileUtils
@@ -39,7 +40,7 @@ class FileManagerViewModel : ViewModel() {
                 }
             }
 
-            if (newName.length in 1..40 && renamed) {
+            if (renamed) {
                 // Notify system of the rename
                 val renameEvent = FileRenameEvent(file, File(file.parent, newName))
                 if (context != null) {

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/FileManagerViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/FileManagerViewModel.kt
@@ -31,7 +31,8 @@ class FileManagerViewModel : ViewModel() {
             val destFile = File(file.parentFile, newName)
             val renamed = withContext(Dispatchers.IO) {
                 if (file.name.equals(newName, ignoreCase = true)) {
-                    val tempFile = File(file.parentFile, "$newName.tmp")
+                    val uniqueSuffix = System.currentTimeMillis()
+                    val tempFile = File(file.parentFile, "$newName-$uniqueSuffix.cotg")
                     file.renameTo(tempFile) && tempFile.renameTo(destFile)
                 } else {
                     FileUtils.rename(file, newName)

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/FileManagerViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/FileManagerViewModel.kt
@@ -28,11 +28,17 @@ class FileManagerViewModel : ViewModel() {
 
     fun renameFile(file: File, newName: String, context: Context? = null, onResult: ((Boolean) -> Unit)? = null) {
         viewModelScope.launch {
+            val destFile = File(file.parentFile, newName)
             val renamed = withContext(Dispatchers.IO) {
-                newName.length in 1..40 && FileUtils.rename(file, newName)
+                if (file.name.equals(newName, ignoreCase = true)) {
+                    val tempFile = File(file.parentFile, "$newName.tmp")
+                    file.renameTo(tempFile) && tempFile.renameTo(destFile)
+                } else {
+                    FileUtils.rename(file, newName)
+                }
             }
 
-            if (renamed) {
+            if (newName.length in 1..40 && renamed) {
                 // Notify system of the rename
                 val renameEvent = FileRenameEvent(file, File(file.parent, newName))
                 if (context != null) {

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -255,6 +255,7 @@
 	<string name="msg_rename_file">Enter a new name for the file/folder.</string>
 	<string name="renamed">Renamed successfully</string>
 	<string name="rename_failed">Unable to rename file</string>
+    <string name="file_name_too_long">File name cannot exceed 40 characters</string>
 	<string name="deleted">Deleted successfully</string>
 	<string name="delete_failed">Unable to delete file</string>
 	<string name="copy_path">Copy path</string>


### PR DESCRIPTION
Allow file renaming for case-only changes, e.g "numberFragment" to "NumberFragment"