### PR TITLE
ADFA-2786 | Harden structure view drawing

### DIFF
--- a/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/views/StructureView.kt
+++ b/layouteditor/src/main/java/org/appdevforall/codeonthego/layouteditor/views/StructureView.kt
@@ -204,8 +204,8 @@ class StructureView(
         super.dispatchDraw(canvas)
 
         for (text in textViewMap.keys) {
-            val view = textViewMap[text]
-            val parent = text.parent.parent as ViewGroup
+            val view = textViewMap[text] ?: continue
+            val parent = (text.parent?.parent as? ViewGroup) ?: continue
 
             val centerX = parent.x
             val centerY = parent.y + parent.height.toFloat() / 2
@@ -265,7 +265,7 @@ class StructureView(
 
                     val editText = view.editText ?: continue
                     val current = viewTextMap[editText] ?: continue
-                    val currentParent = current.parent.parent as ViewGroup
+                    val currentParent = (current.parent?.parent as? ViewGroup) ?: continue
 
                     drawLine(currentParent)
                 }
@@ -276,7 +276,7 @@ class StructureView(
                     for (i in 0 until view.childCount) {
                         val child = view.getChildAt(i)
                         val current = viewTextMap[child] ?: continue
-                        val currentParent = current.parent.parent as ViewGroup
+                        val currentParent = (current.parent?.parent as? ViewGroup) ?: continue
 
                         drawLine(currentParent)
                     }


### PR DESCRIPTION
## Description

This PR hardens `StructureView.dispatchDraw()` to avoid unsafe assumptions while drawing the LayoutEditor structure connector lines.

The method now skips entries when the mapped view or expected parent hierarchy is not available, instead of directly accessing or casting parent-chain values during the draw cycle.

This helps prevent drawing-related crashes if the structure view contains stale, detached, or partially unavailable rows.

## Details

No UI behavior changes are expected.


https://github.com/user-attachments/assets/c75baacf-3292-4dfb-9042-9356f3648b05


## Ticket

[ADFA-2786](https://appdevforall.atlassian.net/browse/ADFA-2786)

## Observation

The original Sentry crash path is not currently reproducible in `stage`, but this change reduces a remaining latent risk in nearby drawing code by avoiding direct parent-chain casts inside `dispatchDraw()`.

[ADFA-2786]: https://appdevforall.atlassian.net/browse/ADFA-2786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ