### PR TITLE
ADFA-3018 | Harden WorkManager startup initialization

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -188,6 +188,18 @@
                 android:resource="@xml/ide_file_provider_paths" />
         </provider>
 
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
         <receiver
             android:name=".services.InstallationResultReceiver"
             android:enabled="true"

--- a/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
@@ -35,6 +35,8 @@ import org.greenrobot.eventbus.ThreadMode
 import org.slf4j.LoggerFactory
 import android.os.Handler
 import android.os.Looper
+import android.os.UserManager
+import androidx.work.WorkManager
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.exitProcess
@@ -74,6 +76,13 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 		logger.info("Loading credential protected storage context components...")
 		application = app
 
+		if (!isCredentialStorageReady(app)) {
+            logger.error("Credential protected storage is not ready. Skipping credential protected initialization.")
+            return
+        }
+
+        initializeWorkManagerSafely(app)
+
 		Environment.init(app)
 
 		FeatureFlags.initialize()
@@ -109,6 +118,32 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 			ToolsManager.init(app, null)
 		}
 	}
+
+    private fun isCredentialStorageReady(app: IDEApplication): Boolean {
+        val userManager = app.getSystemService(UserManager::class.java)
+
+        if (!userManager.isUserUnlocked) return false
+
+        val filesDir = app.filesDir
+        val noBackupDir = app.noBackupFilesDir
+
+        if (!filesDir.exists()) filesDir.mkdirs()
+        if (!noBackupDir.exists()) noBackupDir.mkdirs()
+
+        return filesDir.exists() &&
+            filesDir.isDirectory &&
+            noBackupDir.exists() &&
+            noBackupDir.isDirectory
+    }
+
+    private fun initializeWorkManagerSafely(app: IDEApplication) {
+        runCatching {
+            WorkManager.getInstance(app)
+        }.onFailure { error ->
+            logger.error("Failed to get WorkManager instance after storage validation", error)
+            Sentry.captureException(error)
+        }
+    }
 
 	fun handleUncaughtException(
 		thread: Thread,

--- a/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/IDEApplication.kt
@@ -25,6 +25,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.work.Configuration
 import com.itsaky.androidide.BuildConfig
 import com.itsaky.androidide.di.coreModule
 import com.itsaky.androidide.di.pluginModule
@@ -58,6 +59,7 @@ const val EXIT_CODE_CRASH = 1
 
 class IDEApplication :
 	BaseApplication(),
+	Configuration.Provider,
 	Application.ActivityLifecycleCallbacks by ActivityLifecycleCallbacksDelegate() {
 	val coroutineScope = MainScope() + CoroutineName("ApplicationScope")
 
@@ -192,6 +194,9 @@ class IDEApplication :
 			}
 		}
 	}
+
+	override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder().build()
 
 	private fun ensureKoinStarted() {
 		runCatching { GlobalContext.get() }.getOrNull()?.let { return }


### PR DESCRIPTION
## Description

This PR adds a defensive startup hardening change for WorkManager initialization.

WorkManager auto-initialization is removed from AndroidX Startup, and the application now provides WorkManager configuration on demand through `Configuration.Provider`. WorkManager access is then triggered only after credential-protected storage is available and the required app-private storage directories are valid.

## Details

https://github.com/user-attachments/assets/3ad9f290-e839-46bd-807d-fab7a14f6154


## Ticket

[ADFA-3018](https://appdevforall.atlassian.net/browse/ADFA-3018)

## Observation

This is a defensive mitigation based on Sentry crash evidence, not a fix for a locally reproduced issue. The original crash could not be reproduced on the current `stage` branch, but this change reduces the risk of WorkManager accessing credential-protected storage too early during startup.

[ADFA-3018]: https://appdevforall.atlassian.net/browse/ADFA-3018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ