### PR TITLE
ADFA-4263: keep Kotlin LSP application environment alive across project close

### DIFF
--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/AbstractCompilationEnvironment.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/AbstractCompilationEnvironment.kt
@@ -172,11 +172,16 @@ internal abstract class AbstractCompilationEnvironment(
 			libraryRoots: List<JavaRoot>,
 		) -> KtSymbolIndex,
 	) {
+		val configuration = createCompilerConfiguration()
 		projectEnv = StandaloneProjectFactory.createProjectEnvironment(
 			projectDisposable = disposable,
 			applicationEnvironmentMode = applicationEnvironmentMode,
-			compilerConfiguration = createCompilerConfiguration(),
+			compilerConfiguration = configuration,
 		)
+
+		if (applicationEnvironmentMode == KotlinCoreApplicationEnvironmentMode.Production) {
+			KotlinApplicationEnvironmentPin.ensure(configuration)
+		}
 
 		project.registerRWLock()
 
@@ -197,8 +202,14 @@ internal abstract class AbstractCompilationEnvironment(
 			ClassTypePointerFactory::class.java,
 		)
 
-		appExtArea.getExtensionPoint(ClassTypePointerFactory.EP_NAME)
-			.registerExtension(PsiClassReferenceTypePointerFactory(), application)
+		val classTypePointerFactoryEp =
+			appExtArea.getExtensionPoint(ClassTypePointerFactory.EP_NAME)
+		if (classTypePointerFactoryEp.extensionList.isEmpty()) {
+			classTypePointerFactoryEp.registerExtension(
+				PsiClassReferenceTypePointerFactory(),
+				application,
+			)
+		}
 
 		CoreApplicationEnvironment.registerExtensionPoint(
 			appExtArea,

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/KotlinApplicationEnvironmentPin.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/KotlinApplicationEnvironmentPin.kt
@@ -1,0 +1,21 @@
+package com.itsaky.androidide.lsp.kotlin.compiler
+
+import org.jetbrains.kotlin.K1Deprecation
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment.Companion.getOrCreateApplicationEnvironmentForProduction as acquireApplicationEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+@OptIn(K1Deprecation::class)
+internal object KotlinApplicationEnvironmentPin {
+
+	private var pinned = false
+
+	private val pin = Disposer.newDisposable("kotlin-lsp-application-environment-pin")
+
+	@Synchronized
+	fun ensure(configuration: CompilerConfiguration) {
+		if (pinned) return
+		acquireApplicationEnvironment(pin, configuration)
+		pinned = true
+	}
+}


### PR DESCRIPTION
Closing a project disposed the ref-counted IntelliJ application environment singleton, nulling ApplicationManager; a teardown task deferred to the main thread then dereferenced it on the next loop tick and crashed the IDE. Pin the singleton for the process lifetime so it is reused across projects instead of torn down on every close.