### PR TITLE
fix(i18n): Indonesian phrasing for success_loaded and new_chat

### DIFF
--- a/layouteditor/src/main/res/values-in/strings.xml
+++ b/layouteditor/src/main/res/values-in/strings.xml
@@ -72,7 +72,7 @@
     <string name="theme_dark">Gelap</string>
     <string name="theme_light">Terang</string>
     <string name="theme_auto">Otomatis</string>
-    <string name="msg_dynamic_colors_dialog">Ini akan menutup aplikasi beserta semua tugasnya!.</string>
+    <string name="msg_dynamic_colors_dialog">Ini akan menutup aplikasi beserta semua tugasnya!</string>
     <string name="export_layout">Ekspor Layout</string>
     <string name="invalid_data_intent">Data yang diterima tidak valid.</string>
     <string name="select_from_storage">Pilih file dari Penyimpanan Utama.</string>

--- a/layouteditor/src/main/res/values-in/strings.xml
+++ b/layouteditor/src/main/res/values-in/strings.xml
@@ -149,7 +149,7 @@
     <string name="info_add_some_views">Tambahkan beberapa tampilan…</string>
     <string name="success_saved_to_gallery">Telah disimpan ke galeri.</string>
     <string name="error_failed_to_save_gallery">Gagal menyimpan…</string>
-    <string name="success_loaded">Memuat!</string>
+    <string name="success_loaded">Dimuat!</string>
     <string name="label_palette">Palette</string>
     <string name="tooltip_layouts">Layouts</string>
     <string name="tooltip_create_new_layout">Buat layout baru</string>
@@ -165,7 +165,7 @@
     <string name="gemini_api_key_saved_on">Kunci API Gemini telah disimpan di %s</string>
 
     <string name="ai_agent">Agen AI</string>
-    <string name="new_chat">Pesan baru</string>
+    <string name="new_chat">Obrolan baru</string>
     <string name="history">Histori</string>
     <string name="ai_settings">Pengaturan AI</string>
     <string name="agent_close">Tutup</string>

--- a/layouteditor/src/main/res/values/strings.xml
+++ b/layouteditor/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
     <string name="theme_dark">Dark</string>
     <string name="theme_light">Light</string>
     <string name="theme_auto">Auto</string>
-    <string name="msg_dynamic_colors_dialog">This will close the application with all tasks!.</string>
+    <string name="msg_dynamic_colors_dialog">This will close the application with all tasks!</string>
     <string name="export_layout">Export Layout</string>
     <string name="invalid_data_intent">Invalid Data returned by Intent.</string>
     <string name="select_from_storage">Select file from Primary Storage.</string>


### PR DESCRIPTION
## Summary

Follow-up to #1375. After back-translation QA (Gemini + Google Cloud Translate), two strings in `layouteditor/values-in/strings.xml` came back with semantic mismatches that both back-translators flagged in the same direction:

- **`success_loaded`**: `Memuat!` (= "Loading!", active present) → `Dimuat!` (= "Loaded!", passive past). This string fires on a successful load, so the past-tense form fits.
- **`new_chat`**: `Pesan baru` (= "New message") → `Obrolan baru` (= "New chat"). The action labels chat creation, not a message draft.

No action needed from @mcikadu-dev — flagging here as context. Thanks again for the broader refresh in #1375.

## Test plan

- [x] Visual diff matches the intent above
- [ ] Build APK on CI passes (no code changed; resource only)