### PR TITLE
ADFA-4305 Add Sentry MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Registers the Sentry MCP server at project scope so contributors can query Sentry issues/events through Claude Code's MCP integration. Per-user OAuth is performed via /mcp authenticate; no shared secrets.