### PR TITLE
ADFA-4306 Constrain GitHub Actions cache growth in analyze.yml

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -70,9 +70,16 @@ jobs:
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/libs.versions.toml') }}
-          restore-keys: ${{ runner.os }}-gradle
+          # Exclude ~/.gradle/caches/build-cache-1 (Gradle's task-output build
+          # cache) — it ballooned the stage-branch entry to ~26 GB.
+          path: |
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/transforms-*
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Assemble V8 Debug
         run: |
@@ -89,21 +96,26 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
+          # Branch-scoped + content-hashed so the key rolls over and old
+          # entries age out under GitHub's 7-day LRU instead of pinning forever.
+          key: ${{ runner.os }}-sonar-${{ github.ref_name }}-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-sonar-${{ github.ref_name }}-
+            ${{ runner.os }}-sonar-
 
       - name: Build and analyze
         timeout-minutes: 60
         env:
           GRADLE_OPTS: "-Xmx10g -XX:MaxMetaspaceSize=512m"
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: flox activate -d flox/base -- ./gradlew :testing:tooling:assemble :testing:common:assemble sonarqube --info -x lint --continue
+        run: flox activate -d flox/base -- ./gradlew :testing:tooling:assemble :testing:common:assemble sonarqube --info --no-build-cache -x lint --continue
 
       - name: Upload JaCoCo report
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-report
           path: build/reports/jacoco/jacocoAggregateReport/
+          retention-days: 7
 
       - name: Cleanup google-services.json
         if: always()


### PR DESCRIPTION
## Summary
- The daily Jacoco/SonarQube job's `Linux-gradle` cache on `stage` had grown to ~26 GB (vs. GitHub's 10 GB limit), evicting useful caches across the repo.
- Narrows the Gradle cache to dependency/wrapper dirs only, excluding `~/.gradle/caches/build-cache-1` (Gradle's task-output build cache — the actual driver of the bloat). Adds `gradle-wrapper.properties` to the `hashFiles()` key.
- Branch-scopes and content-hashes the SonarQube cache key so it rolls over under GitHub's 7-day LRU instead of pinning forever on `stage`.
- Passes `--no-build-cache` to the `sonarqube` invocation so the build cache stays empty even if the directory reappears.
- Sets `retention-days: 7` on the JaCoCo report artifact (was the 90-day default).

## Test plan
- [ ] Trigger `analyze.yml` manually via `workflow_dispatch` on this branch.
- [ ] Confirm new `Linux-gradle-<hash>` entry in Actions → Caches is < 2 GB.
- [ ] Confirm new `Linux-sonar-<branch>-<hash>` entry is < 500 MB.
- [ ] Re-run the workflow with no code changes and verify both caches show `Cache restored successfully`.
- [ ] Confirm the JaCoCo artifact in the run shows a 7-day expiry.
- [ ] After 24h of daily `stage` runs, confirm total cache usage stays well under 10 GB.
