### PR TITLE
ADFA-4318 Paper Cut: Change agent disclaimer to fire with onResume so adjacent tabs don't pre-fire it by accident

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/agent/fragments/AgentFragmentContainer.kt
+++ b/app/src/main/java/com/itsaky/androidide/agent/fragments/AgentFragmentContainer.kt
@@ -21,6 +21,13 @@ class AgentFragmentContainer : EmptyStateFragment<FragmentAgentContainerBinding>
 		super.onViewCreated(view, savedInstanceState)
 		emptyStateViewModel.setEmptyMessage("No git actions yet")
 		emptyStateViewModel.setEmpty(false)
+	}
+
+	// Deferred to onResume so the disclaimer only fires when the Agent tab is
+	// actually visible. ViewPager2 + FragmentStateAdapter pre-creates adjacent
+	// pages through onViewCreated; only the visible page reaches onResume.
+	override fun onResume() {
+		super.onResume()
 		showDisclaimerDialogIfNeeded()
 	}
 


### PR DESCRIPTION
The fix is a single change in AgentFragmentContainer.kt: moved showDisclaimerDialogIfNeeded() out of onViewCreated() and into a new onResume() override.

Why this works: ViewPager2 + FragmentStateAdapter creates adjacent pages through onViewCreated, but only the visible page reaches onResume. The disclaimer now only fires when the user actually lands on the Agent tab. SharedPreferences gating in showDisclaimerDialogIfNeeded already ensures one-shot behavior, so resuming the agent tab multiple times is safe.

Plugin robustness: The trigger is lifecycle-based, not position-based, so plugins inserting tabs adjacent to Agent (or removing Git, reordering, etc.) cannot resurface the bug.