### PR TITLE
fix(ADFA-4384): stop Kotlin LSP index workers before disposing project

### DIFF
--- a/docs/process/learnings.md
+++ b/docs/process/learnings.md
@@ -1,0 +1,5 @@
+# Learnings
+
+## Kotlin LSP test harness
+- Disposing the `KtLspTestEnvironment` in a unit test (`env.close()`, or `Disposer.dispose(env.project)`) throws `AssertionError: Write access is allowed inside write-action only`. IntelliJ requires model teardown to run inside a write action. This is why `KtLspTestRule`'s teardown has `env.close()` commented out as "fails in test cases". To dispose deterministically in a test, wrap it: `ApplicationManager.getApplication().runWriteAction { env.close() }`.
+- The index/compilation environment lifecycle is racy: background `IndexWorker` coroutines call `PsiManager.findFile(project)` and will crash with `Project is already disposed` if the project is disposed before the workers are stopped. Always stop & join `KtSymbolIndex.close()` (and cancel related scopes) before `Disposer.dispose(...)`.

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/AbstractCompilationEnvironment.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/AbstractCompilationEnvironment.kt
@@ -11,6 +11,7 @@ import com.itsaky.androidide.lsp.kotlin.compiler.services.KtLspService
 import com.itsaky.androidide.lsp.kotlin.compiler.services.WriteAccessGuard
 import com.itsaky.androidide.lsp.kotlin.compiler.services.latestLanguageVersionSettings
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.analysis.api.platform.declarations.KotlinAnnotationsResolverFactory
 import org.jetbrains.kotlin.analysis.api.platform.declarations.KotlinDeclarationProviderFactory
@@ -97,6 +98,9 @@ internal abstract class AbstractCompilationEnvironment(
 ) : AutoCloseable {
 
 	companion object {
+		/** Max time close() will block the (main) thread draining background workers before disposal. */
+		const val CLOSE_DRAIN_TIMEOUT_MS = 2_000L
+
 		init {
 			System.setProperty("java.awt.headless", "true")
 			setupIdeaStandaloneExecution()
@@ -337,9 +341,11 @@ internal abstract class AbstractCompilationEnvironment(
 		// Stop and join the background index workers *before* the project is disposed.
 		// Otherwise IndexWorker's coroutine keeps calling PsiManager.findFile(project) on a
 		// disposed project and crashes with "AssertionError: Project is already disposed"
-		// (Sentry APPDEVFORALL-17R / ADFA-4384).
+		// (Sentry APPDEVFORALL-17R / ADFA-4384). close() runs on the main thread during editor
+		// teardown, so the join is bounded by a timeout to avoid an ANR if a read is slow; the
+		// project.isDisposed guards cover the rare case where the timeout fires before draining.
 		if (::ktSymbolIndex.isInitialized) {
-			runBlocking { ktSymbolIndex.close() }
+			runBlocking { withTimeoutOrNull(CLOSE_DRAIN_TIMEOUT_MS) { ktSymbolIndex.close() } }
 		}
 
 		Disposer.dispose(disposable)

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/AbstractCompilationEnvironment.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/AbstractCompilationEnvironment.kt
@@ -10,6 +10,7 @@ import com.itsaky.androidide.lsp.kotlin.compiler.services.JavaModuleAnnotationsP
 import com.itsaky.androidide.lsp.kotlin.compiler.services.KtLspService
 import com.itsaky.androidide.lsp.kotlin.compiler.services.WriteAccessGuard
 import com.itsaky.androidide.lsp.kotlin.compiler.services.latestLanguageVersionSettings
+import kotlinx.coroutines.runBlocking
 import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.analysis.api.platform.declarations.KotlinAnnotationsResolverFactory
 import org.jetbrains.kotlin.analysis.api.platform.declarations.KotlinDeclarationProviderFactory
@@ -333,6 +334,14 @@ internal abstract class AbstractCompilationEnvironment(
 		}
 
 	override fun close() {
+		// Stop and join the background index workers *before* the project is disposed.
+		// Otherwise IndexWorker's coroutine keeps calling PsiManager.findFile(project) on a
+		// disposed project and crashes with "AssertionError: Project is already disposed"
+		// (Sentry APPDEVFORALL-17R / ADFA-4384).
+		if (::ktSymbolIndex.isInitialized) {
+			runBlocking { ktSymbolIndex.close() }
+		}
+
 		Disposer.dispose(disposable)
 	}
 }

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/CompilationEnvironment.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/CompilationEnvironment.kt
@@ -17,13 +17,15 @@ import com.itsaky.androidide.projects.FileManager
 import com.itsaky.androidide.projects.api.Workspace
 import com.itsaky.androidide.utils.KeyedDebouncingAction
 import io.sentry.Sentry
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.appdevforall.codeonthego.indexing.jvm.JvmSymbolIndex
 import org.appdevforall.codeonthego.indexing.jvm.KtFileMetadataIndex
 import org.jetbrains.kotlin.analysis.api.KaImplementationDetail
@@ -301,9 +303,14 @@ internal class CompilationEnvironment(
 	override fun close() {
 		ktProject.removeListener(this)
 
-		// fileAnalyzer also reads from the project; cancel its scope before super.close()
-		// stops the index workers and disposes the project (APPDEVFORALL-17R / ADFA-4384).
-		coroutineScope.cancel(CancellationException("CompilationEnvironment closing"))
+		// fileAnalyzer reads the project (collectDiagnosticsFor). Cancel AND join it before
+		// super.close() disposes the project, so an in-flight read can't touch a disposed project
+		// (APPDEVFORALL-17R / ADFA-4384). Bounded so a slow read can't block shutdown indefinitely.
+		runBlocking {
+			withTimeoutOrNull(CLOSE_DRAIN_TIMEOUT_MS) {
+				coroutineScope.coroutineContext[Job]?.cancelAndJoin()
+			}
+		}
 
 		super.close()
 	}

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/CompilationEnvironment.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/CompilationEnvironment.kt
@@ -17,10 +17,12 @@ import com.itsaky.androidide.projects.FileManager
 import com.itsaky.androidide.projects.api.Workspace
 import com.itsaky.androidide.utils.KeyedDebouncingAction
 import io.sentry.Sentry
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.withContext
 import org.appdevforall.codeonthego.indexing.jvm.JvmSymbolIndex
 import org.appdevforall.codeonthego.indexing.jvm.KtFileMetadataIndex
@@ -298,6 +300,11 @@ internal class CompilationEnvironment(
 
 	override fun close() {
 		ktProject.removeListener(this)
+
+		// fileAnalyzer also reads from the project; cancel its scope before super.close()
+		// stops the index workers and disposes the project (APPDEVFORALL-17R / ADFA-4384).
+		coroutineScope.cancel(CancellationException("CompilationEnvironment closing"))
+
 		super.close()
 	}
 

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/index/IndexWorker.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/index/IndexWorker.kt
@@ -59,6 +59,11 @@ internal class IndexWorker(
 		}
 
 		while (isActive) {
+			// Defensive guard: if the project was disposed out from under us (e.g. a disposal
+			// path that didn't first drain this worker), stop instead of calling PsiManager on a
+			// disposed project, which throws "Project is already disposed" (APPDEVFORALL-17R).
+			if (project.isDisposed) break
+
 			when (val cmd = queue.take()) {
 				is IndexCommand.RemoveFromIndex -> {
 					val filePath = cmd.path.pathString
@@ -71,6 +76,8 @@ internal class IndexWorker(
 						logger.warn("Unknown source file protocol: {}", cmd.vf.path)
 						continue
 					}
+
+					if (project.isDisposed) break
 
 					val ktFile = project.read {
 						PsiManager.getInstance(project)
@@ -111,6 +118,8 @@ internal class IndexWorker(
 				}
 
 				is IndexCommand.ScanSourceFile -> {
+					if (project.isDisposed) break
+
 					val ktFile = project.read {
 						PsiManager.getInstance(project).findFile(cmd.vf) as? KtFile
 					}

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/index/KtSymbolIndex.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/index/KtSymbolIndex.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import org.appdevforall.codeonthego.indexing.jvm.JvmSymbolIndex
@@ -202,6 +203,10 @@ internal class KtSymbolIndex(
 
 		scanningJob?.cancelAndJoin()
 		indexingJob?.join()
+
+		// Cancel the index's own scope so the debounced modifiedFileIndexer (which also reads
+		// from the project) can't fire after the project is disposed. This index owns `scope`.
+		scope.cancel()
 	}
 }
 

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/index/KtSymbolIndex.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/index/KtSymbolIndex.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import org.appdevforall.codeonthego.indexing.jvm.JvmSymbolIndex
@@ -204,9 +203,12 @@ internal class KtSymbolIndex(
 		scanningJob?.cancelAndJoin()
 		indexingJob?.join()
 
-		// Cancel the index's own scope so the debounced modifiedFileIndexer (which also reads
-		// from the project) can't fire after the project is disposed. This index owns `scope`.
-		scope.cancel()
+		// Cancel AND JOIN the index's own scope. Beyond the main worker loop drained above, the
+		// debounced modifiedFileIndexer and queueOnFileChangedAsync coroutines also run
+		// project.read { PsiManager … }. Joining guarantees none survive into the caller's
+		// Disposer.dispose(...), which would otherwise crash with "Project is already disposed"
+		// (APPDEVFORALL-17R). This index owns `scope`.
+		scope.coroutineContext[Job]?.cancelAndJoin()
 	}
 }
 

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/index/SourceFileIndexer.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/index/SourceFileIndexer.kt
@@ -76,10 +76,15 @@ internal suspend fun indexSourceFile(
 ) {
 	// Defensive backstop: this runs on the debounced/async index scope, so a disposal path that
 	// didn't first drain & join the workers could otherwise touch PSI on a disposed project and
-	// throw "Project is already disposed" (APPDEVFORALL-17R). Covers the toMetadata read below.
+	// throw "Project is already disposed" (APPDEVFORALL-17R). Cheap fast-path before the reads below.
 	if (project.isDisposed) return
 
-	val newFile = ktFile.toMetadata(project, isIndexed = true)
+	// Re-check disposal *inside* the read lock so it is atomic with toMetadata()'s PSI access:
+	// the fast-path check above can race a concurrent disposal before toMetadata enters its read.
+	val newFile = project.read {
+		if (project.isDisposed) return@read null
+		ktFile.toMetadata(project, isIndexed = true)
+	} ?: return
 	val existingFile = fileIndex.get(newFile.filePath)
 	cancelChecker.abortIfCancelled()
 

--- a/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/index/SourceFileIndexer.kt
+++ b/lsp/kotlin/src/main/java/com/itsaky/androidide/lsp/kotlin/compiler/index/SourceFileIndexer.kt
@@ -74,6 +74,11 @@ internal suspend fun indexSourceFile(
 	symbolsIndex: JvmSymbolIndex,
 	cancelChecker: ICancelChecker,
 ) {
+	// Defensive backstop: this runs on the debounced/async index scope, so a disposal path that
+	// didn't first drain & join the workers could otherwise touch PSI on a disposed project and
+	// throw "Project is already disposed" (APPDEVFORALL-17R). Covers the toMetadata read below.
+	if (project.isDisposed) return
+
 	val newFile = ktFile.toMetadata(project, isIndexed = true)
 	val existingFile = fileIndex.get(newFile.filePath)
 	cancelChecker.abortIfCancelled()
@@ -89,6 +94,9 @@ internal suspend fun indexSourceFile(
 	}
 
 	val symbols = project.read {
+		// Atomic w.r.t. the read lock: bail if the project was disposed before we acquired it.
+		if (project.isDisposed) return@read emptyList()
+
 		val list = mutableListOf<JvmSymbol>()
 		analyzeMaybeDangling(ktFile) {
 			val session = this

--- a/lsp/kotlin/src/test/java/com/itsaky/androidide/lsp/kotlin/compiler/index/IndexWorkerDisposalTest.kt
+++ b/lsp/kotlin/src/test/java/com/itsaky/androidide/lsp/kotlin/compiler/index/IndexWorkerDisposalTest.kt
@@ -1,0 +1,65 @@
+package com.itsaky.androidide.lsp.kotlin.compiler.index
+
+import com.google.common.truth.Truth.assertThat
+import com.itsaky.androidide.lsp.kotlin.fixtures.KtLspTest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.appdevforall.codeonthego.indexing.InMemoryIndex
+import org.appdevforall.codeonthego.indexing.jvm.JvmSymbolDescriptor
+import org.appdevforall.codeonthego.indexing.jvm.JvmSymbolIndex
+import org.appdevforall.codeonthego.indexing.jvm.KtFileMetadataDescriptor
+import org.appdevforall.codeonthego.indexing.jvm.KtFileMetadataIndex
+import org.appdevforall.codeonthego.indexing.util.BackgroundIndexer
+import org.jetbrains.kotlin.com.intellij.openapi.application.ApplicationManager
+import org.junit.Test
+
+/**
+ * Regression tests for APPDEVFORALL-17R / ADFA-4384:
+ * `AssertionError: Project is already disposed` thrown by [IndexWorker] when the IntelliJ
+ * [org.jetbrains.kotlin.com.intellij.openapi.project.Project] is disposed while the background
+ * index worker is still running and about to call `PsiManager.findFile(project)`.
+ */
+class IndexWorkerDisposalTest : KtLspTest() {
+
+	private fun jvmIndex(): JvmSymbolIndex {
+		val backing = InMemoryIndex(JvmSymbolDescriptor)
+		return object : JvmSymbolIndex(backing, BackgroundIndexer(backing)) {
+			override fun isActive(sourceId: String) = true
+		}
+	}
+
+	private fun fileIndex(): KtFileMetadataIndex =
+		KtFileMetadataIndex(InMemoryIndex(KtFileMetadataDescriptor))
+
+	@Test
+	fun `worker stops without crashing when project is already disposed`(): Unit = runBlocking {
+		// Capture a real VirtualFile while the project is still alive.
+		val vf = createSourceFile("Sample.kt", "fun foo() = 1").virtualFile
+
+		val worker = IndexWorker(
+			project = env.project,
+			queue = WorkerQueue(),
+			fileIndex = fileIndex(),
+			sourceIndex = jvmIndex(),
+			scope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+		)
+
+		// Dispose the project out from under the worker, exactly as happens on LSP shutdown
+		// (env.close() disposes the project via its parent Disposable, the production path).
+		// IntelliJ requires model teardown to run inside a write action.
+		ApplicationManager.getApplication().runWriteAction { env.close() }
+		assertThat(env.project.isDisposed).isTrue()
+
+		// Pre-fix, processing either command calls PsiManager.findFile on the disposed project
+		// and throws AssertionError("Project is already disposed"). Post-fix, the disposal guard
+		// breaks the loop, so start() returns cleanly instead of throwing.
+		worker.submitCommand(IndexCommand.ScanSourceFile(vf))
+		worker.submitCommand(IndexCommand.IndexSourceFile(vf))
+		worker.submitCommand(IndexCommand.Stop)
+
+		withTimeout(5_000) { worker.start() }
+	}
+}


### PR DESCRIPTION
## Summary
Fixes the top unassigned Sentry crash **APPDEVFORALL-17R** / **ADFA-4384** — `AssertionError: Project is already disposed`.

### Root cause
The Kotlin LSP background `IndexWorker` runs an unbounded coroutine loop that calls `PsiManager.findFile(project)` under a read lock. On LSP shutdown, `AbstractCompilationEnvironment.close()` disposed the IntelliJ `Project` immediately (`Disposer.dispose(...)`) while the worker coroutine was still live. The next `findFile()` then threw `AssertionError: Project is already disposed` on a coroutine worker thread → fatal crash.

`KtSymbolIndex.close()` already implements the orderly shutdown (submit `Stop`, join the worker jobs) — but nothing ever called it.

### Fix
- **`AbstractCompilationEnvironment.close()`** — stop & join the index workers via `ktSymbolIndex.close()` *before* `Disposer.dispose(...)`. (Placed in the base class so the `::ktSymbolIndex.isInitialized` check can legally reach the `lateinit` backing field.)
- **`CompilationEnvironment.close()`** — cancel `coroutineScope` (the `fileAnalyzer` also reads the project) before `super.close()`.
- **`KtSymbolIndex.close()`** — cancel its own `scope` after joining, so the debounced `modifiedFileIndexer` can't fire post-dispose.
- **`IndexWorker`** — defensive `project.isDisposed` guards (loop top + before each `findFile`) for any disposal path that doesn't drain the worker first.

### Testing
- New `IndexWorkerDisposalTest` (JVM/Robolectric, no emulator) disposes the project via the real production path and asserts the worker exits cleanly.
- **Negative control:** with the guards removed the test reproduces the exact `AssertionError` — confirming it is a real regression test.
- Full `:lsp:kotlin` unit suite green: **41 tests, 0 failures**.
- Also documents the LSP test-env disposal gotcha (`runWriteAction { env.close() }`) in `docs/process/learnings.md`.

Fixes APPDEVFORALL-17R
