### PR TITLE
feat(ADFA-4197): add Check All toggle to Git commit UI

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/fragments/git/GitBottomSheetFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/git/GitBottomSheetFragment.kt
@@ -77,6 +77,7 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
             },
             onSelectionChanged = {
                 validateCommitButton()
+                updateCheckAllButton()
             },
             onResolveConflict = { change ->
                 viewModel.resolveConflict(change.path)
@@ -118,6 +119,7 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
                         emptyView.visibility = View.VISIBLE
                         emptyView.text = getString(R.string.not_a_git_repo)
                         recyclerView.visibility = View.GONE
+                        btnCheckAll.visibility = View.GONE
                         commitSection.visibility = View.GONE
                         authorWarning.visibility = View.GONE
                         commitHistoryButton.visibility = View.GONE
@@ -128,6 +130,7 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
                         emptyView.visibility = View.VISIBLE
                         emptyView.text = getString(R.string.no_uncommitted_changes)
                         recyclerView.visibility = View.GONE
+                        btnCheckAll.visibility = View.GONE
                         commitSection.visibility = View.GONE
                         authorWarning.visibility = View.GONE
                         commitHistoryButton.visibility = View.VISIBLE
@@ -138,6 +141,7 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
                         binding.apply {
                             emptyView.visibility = View.GONE
                             recyclerView.visibility = View.VISIBLE
+                            btnCheckAll.visibility = View.VISIBLE
                             commitSection.visibility = View.VISIBLE
                             authorWarning.visibility =
                                 if (hasAuthorInfo()) View.GONE else View.VISIBLE
@@ -145,7 +149,9 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
                             btnAbortMerge.visibility =
                                 if (status.isMerging) View.VISIBLE else View.GONE
                         }
-                        fileChangeAdapter.submitList(allChanges)
+                        fileChangeAdapter.submitList(allChanges) {
+                            updateCheckAllButton()
+                        }
                     }
                 }
             }.collectLatest { }
@@ -185,6 +191,14 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
     private fun setupCommitUI() {
         binding.commitSummary.doAfterTextChanged { validateCommitButton() }
         binding.commitDescription.doAfterTextChanged { validateCommitButton() }
+
+        binding.btnCheckAll.setOnClickListener {
+            if (fileChangeAdapter.areAllSelected()) {
+                fileChangeAdapter.clearSelection()
+            } else {
+                fileChangeAdapter.selectAll()
+            }
+        }
 
         binding.btnAbortMerge.apply {
             setOnClickListener {
@@ -228,6 +242,7 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
                             binding.commitSummary.text?.clear()
                             binding.commitDescription.text?.clear()
                             fileChangeAdapter.selectedFiles.clear()
+                            updateCheckAllButton()
                         }
                     }
                 }
@@ -283,6 +298,12 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
         val hasSelection = fileChangeAdapter.selectedFiles.isNotEmpty()
         val hasAuthor = hasAuthorInfo()
         binding.commitButton.isEnabled = hasSummary && hasSelection && hasAuthor
+    }
+
+    private fun updateCheckAllButton() {
+        binding.btnCheckAll.setText(
+            if (fileChangeAdapter.areAllSelected()) R.string.uncheck_all else R.string.check_all
+        )
     }
 
     private fun setupPullUI() {

--- a/app/src/main/java/com/itsaky/androidide/fragments/git/GitBottomSheetFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/git/GitBottomSheetFragment.kt
@@ -298,6 +298,8 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
     }
 
     private fun validateCommitButton() {
+        // May be invoked from async adapter callbacks; bail if the view is gone.
+        val binding = _binding ?: return
         val hasSummary = !binding.commitSummary.text.isNullOrBlank()
         val hasSelection = fileChangeAdapter.selectedFiles.isNotEmpty()
         val hasAuthor = hasAuthorInfo()
@@ -305,6 +307,8 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
     }
 
     private fun updateCheckAllButton() {
+        // May be invoked from the async submitList commit callback; bail if the view is gone.
+        val binding = _binding ?: return
         binding.btnCheckAll.setText(
             if (fileChangeAdapter.areAllSelected()) R.string.uncheck_all else R.string.check_all
         )

--- a/app/src/main/java/com/itsaky/androidide/fragments/git/GitBottomSheetFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/git/GitBottomSheetFragment.kt
@@ -138,10 +138,14 @@ class GitBottomSheetFragment : Fragment(R.layout.fragment_git_bottom_sheet) {
                     }
 
                     else -> {
+                        // Only offer "Check All" when there is at least one
+                        // non-conflicted file; conflicted files can't be staged.
+                        val hasSelectable = allChanges.any { it.type != ChangeType.CONFLICTED }
                         binding.apply {
                             emptyView.visibility = View.GONE
                             recyclerView.visibility = View.VISIBLE
-                            btnCheckAll.visibility = View.VISIBLE
+                            btnCheckAll.visibility =
+                                if (hasSelectable) View.VISIBLE else View.GONE
                             commitSection.visibility = View.VISIBLE
                             authorWarning.visibility =
                                 if (hasAuthorInfo()) View.GONE else View.VISIBLE

--- a/app/src/main/java/com/itsaky/androidide/fragments/git/adapter/GitFileChangeAdapter.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/git/adapter/GitFileChangeAdapter.kt
@@ -31,15 +31,28 @@ class GitFileChangeAdapter(
     /** Select every non-conflicted file. */
     fun selectAll() {
         selectedFiles.addAll(selectablePaths)
-        notifyDataSetChanged()
+        notifyItemRangeChanged(0, itemCount)
         onSelectionChanged(selectedFiles.size)
     }
 
     /** Clear the entire selection. */
     fun clearSelection() {
         selectedFiles.clear()
-        notifyDataSetChanged()
+        notifyItemRangeChanged(0, itemCount)
         onSelectionChanged(selectedFiles.size)
+    }
+
+    override fun onCurrentListChanged(
+        previousList: List<FileChange>,
+        currentList: List<FileChange>
+    ) {
+        super.onCurrentListChanged(previousList, currentList)
+        // Drop selections for files that are no longer in the change set so they
+        // aren't committed and don't skew areAllSelected()/the commit button.
+        val currentPaths = currentList.mapTo(HashSet()) { it.path }
+        if (selectedFiles.retainAll(currentPaths)) {
+            onSelectionChanged(selectedFiles.size)
+        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {

--- a/app/src/main/java/com/itsaky/androidide/fragments/git/adapter/GitFileChangeAdapter.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/git/adapter/GitFileChangeAdapter.kt
@@ -20,6 +20,28 @@ class GitFileChangeAdapter(
     // Keep track of which files are selected to be committed
     val selectedFiles = mutableSetOf<String>()
 
+    // Conflicted files can't be staged, so they are excluded from "select all".
+    private val selectablePaths: List<String>
+        get() = currentList.filter { it.type != ChangeType.CONFLICTED }.map { it.path }
+
+    /** True when every selectable (non-conflicted) file is currently selected. */
+    fun areAllSelected(): Boolean =
+        selectablePaths.isNotEmpty() && selectedFiles.containsAll(selectablePaths)
+
+    /** Select every non-conflicted file. */
+    fun selectAll() {
+        selectedFiles.addAll(selectablePaths)
+        notifyDataSetChanged()
+        onSelectionChanged(selectedFiles.size)
+    }
+
+    /** Clear the entire selection. */
+    fun clearSelection() {
+        selectedFiles.clear()
+        notifyDataSetChanged()
+        onSelectionChanged(selectedFiles.size)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = ItemGitFileChangeBinding.inflate(
             LayoutInflater.from(parent.context), parent, false

--- a/app/src/main/res/layout/fragment_git_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_git_bottom_sheet.xml
@@ -20,7 +20,7 @@
             android:textAppearance="?attr/textAppearanceSubtitle1"
             android:textStyle="bold"
             android:visibility="gone"
-            app:layout_constraintEnd_toStartOf="@id/btnPull"
+            app:layout_constraintEnd_toStartOf="@id/btnCheckAll"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -68,12 +68,29 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_branch_name" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnCheckAll"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="0dp"
+            android:paddingHorizontal="8dp"
+            android:text="@string/check_all"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@id/tv_branch_name"
+            app:layout_constraintEnd_toStartOf="@id/btnPull"
+            app:layout_constraintTop_toTopOf="@id/tv_branch_name" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerView"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:clipToPadding="false"
+            android:paddingEnd="8dp"
             android:paddingVertical="8dp"
+            android:fadeScrollbars="false"
+            android:scrollbarStyle="outsideOverlay"
+            android:scrollbars="vertical"
             app:layout_constraintBottom_toTopOf="@id/guideline_limit"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_git_file_change.xml
+++ b/app/src/main/res/layout/item_git_file_change.xml
@@ -13,7 +13,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="8dp"
-        android:checked="true"
         android:minWidth="0dp"
         android:minHeight="0dp" />
 

--- a/app/src/main/res/layout/item_git_file_change.xml
+++ b/app/src/main/res/layout/item_git_file_change.xml
@@ -6,7 +6,7 @@
     android:background="?attr/selectableItemBackground"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingVertical="8dp">
+    android:paddingVertical="4dp">
 
     <com.google.android.material.checkbox.MaterialCheckBox
         android:id="@+id/checkbox"

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -1296,6 +1296,8 @@
     <string name="no_save_before_git_action">Proceed without saving</string>
     <string name="save_before_git_action">Save before proceeding</string>
     <string name="mark_as_resolved">Mark resolved</string>
+    <string name="check_all">Check All</string>
+    <string name="uncheck_all">Uncheck All</string>
 
 	<!-- Templates -->
 	<string name="template_exec_info_basepath">Starting project creation for %1$s</string>


### PR DESCRIPTION
## Summary

Implements [ADFA-4197](https://appdevforall.atlassian.net/browse/ADFA-4197) / #1355 — a user-requested "Check All button for git branch" to make committing a large changeset easier.

Today the Git bottom-sheet lists every changed file with an individual checkbox, all starting **unchecked**, so committing many files means ticking each one by hand. This adds a single toggle to stage/unstage everything at once, plus a few quality-of-life fixes to the changes list.

## Changes

- **Check All / Uncheck All toggle** in the branch/PULL header row. Label reads "Check All"; tapping selects every non-conflicted file and flips to "Uncheck All"; tapping again clears the selection. The label tracks selection state, so manually ticking the last box also flips it. Conflicted files (which can't be staged) are excluded.
- **Defaults unchanged** — the sheet still opens with everything unchecked.
- **Persistent vertical scrollbar** on the changes list so it's clear how much of a long list is off-screen (no longer fades out).
- **Status icons no longer overlap the scrollbar** — list content is inset and the scrollbar uses `outsideOverlay`.
- **Tighter row spacing** in the file-change rows.

## Files

- `GitFileChangeAdapter.kt` — `selectAll()` / `clearSelection()` / `areAllSelected()` helpers reusing the existing selection callback.
- `GitBottomSheetFragment.kt` — wire the toggle, sync its label, reset after commit, and show it only when there are changes.
- `fragment_git_bottom_sheet.xml` — toggle button in the header row; scrollbar attributes on the RecyclerView.
- `item_git_file_change.xml` — reduced vertical padding.
- `resources/.../values/strings.xml` — `check_all` / `uncheck_all`.

## Testing

- `:app:assembleV8Debug` builds clean.
- Manual on-device verification of the toggle / scrollbar / spacing against a repo with many changed files is still pending.


[ADFA-4197]: https://appdevforall.atlassian.net/browse/ADFA-4197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ