### PR TITLE
ADFA-4272 Add GitHub Sponsor heart icon to level 1+ tooltip windows

### DIFF
--- a/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/ToolTipManager.kt
+++ b/idetooltips/src/main/java/com/itsaky/androidide/idetooltips/ToolTipManager.kt
@@ -31,6 +31,7 @@ import com.itsaky.androidide.activities.editor.HelpActivity
 import com.itsaky.androidide.utils.DatabaseVersionResolver
 import com.itsaky.androidide.utils.Environment
 import com.itsaky.androidide.utils.FeedbackManager
+import com.itsaky.androidide.utils.UrlManager
 import com.itsaky.androidide.utils.isSystemInDarkMode
 import com.itsaky.androidide.utils.toCssHex
 import com.itsaky.androidide.resources.R as ResR
@@ -431,6 +432,16 @@ object TooltipManager {
             setColorFilter(iconTintColor)
         }
 
+        val sponsorButton = popupView.findViewById<ImageButton>(R.id.sponsor_button)
+        sponsorButton.apply {
+            visibility = if (level >= 1) View.VISIBLE else View.GONE
+            setColorFilter(iconTintColor)
+            setOnClickListener {
+                val sponsorUrl = context.getString(ResR.string.github_sponsors_url)
+                UrlManager.openUrl(sponsorUrl, null, context)
+            }
+        }
+
         val hoverGuard: (MotionEvent) -> Unit = label@{ event ->
             if (!event.isFromSource(InputDevice.SOURCE_MOUSE)) return@label
             when (event.actionMasked) {
@@ -452,6 +463,7 @@ object TooltipManager {
             seeMore = seeMore,
             infoButton = infoButton,
             feedbackButton = feedbackButton,
+            sponsorButton = sponsorButton,
         )
 
         cancelScheduledDismiss()
@@ -579,12 +591,14 @@ object TooltipManager {
         seeMore: View,
         infoButton: View,
         feedbackButton: View,
+        sponsorButton: View,
     ) {
         popupView.setOnHoverListener(hoverListener)
         webView.setOnHoverListener(hoverListener)
         seeMore.setOnHoverListener(hoverListener)
         infoButton.setOnHoverListener(hoverListener)
         feedbackButton.setOnHoverListener(hoverListener)
+        sponsorButton.setOnHoverListener(hoverListener)
     }
 
 }

--- a/idetooltips/src/main/res/drawable/ic_heart_outline.xml
+++ b/idetooltips/src/main/res/drawable/ic_heart_outline.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16.5,3C14.76,3 13.09,3.81 12,5.08C10.91,3.81 9.24,3 7.5,3C4.42,3 2,5.41 2,8.5C2,12.27 5.4,15.36 10.55,20.03L12,21.35L13.45,20.03C18.6,15.36 22,12.27 22,8.5C22,5.41 19.58,3 16.5,3ZM12.1,18.55L12,18.65L11.9,18.55C7.14,14.24 4,11.39 4,8.5C4,6.5 5.5,5 7.5,5C9.04,5 10.54,5.99 11.07,7.36H12.93C13.46,5.99 14.96,5 16.5,5C18.5,5 20,6.5 20,8.5C20,11.39 16.86,14.24 12.1,18.55Z" />
+</vector>

--- a/idetooltips/src/main/res/layout/ide_tooltip_window.xml
+++ b/idetooltips/src/main/res/layout/ide_tooltip_window.xml
@@ -34,6 +34,22 @@
         app:tint="?attr/colorOnSurface" />
 
     <ImageButton
+        android:id="@+id/sponsor_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/sponsor_button_description"
+        android:src="@drawable/ic_heart_outline"
+        android:alpha="1.0"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:clickable="true"
+        android:focusable="true"
+        android:scaleType="centerInside"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/feedback_button"
+        android:layout_margin="4dp"
+        android:visibility="gone" />
+
+    <ImageButton
         android:id="@+id/feedback_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -957,6 +957,7 @@
 
 	<string name="info_icon_content_description">Info icon</string>
 	<string name="feedback_button_description">Send feedback about this tooltip</string>
+	<string name="sponsor_button_description">Support us on GitHub Sponsors</string>
 	<string name="cd_more_options">More options</string>
 	<string name="cd_expand_collapse">Expand or collapse</string>
 	<string name="cd_file_icon">File icon</string>


### PR DESCRIPTION
Add to the level 2 tooltip window a heart icon at the top right next to the feedback icon.
When the user taps the heart icon, take the user to our Github sponsor page by opening the default browser.

