### PR TITLE
ADFA-4412-Redirect-string-in-CoGo-app-for-customer-support

### DIFF
--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
 	<string name="about_footer">Code on the Go %1$s for %2$s</string>
 	<string name="about_subtitle">No computer? No Internet? No problem. Code apps anywhere.</string>
 	<string name="msg_get_package_failed">Failed to extract package name.</string>
-	<string name="msg_need_help">If you\'re facing issues while using Code on the Go or with building Android apps, you can join the our Discussions forum and ask for help there.\n\nYou can also send suggestions on our email.</string>
+	<string name="msg_need_help">If you\'re facing issues while using Code on the Go or with building Android apps, you can join our Discussions forum and ask for help there.\n\nYou can also send suggestions on our email.</string>
 	<string name="download_codeonthego_message">Download Code on the Go from the official website to get the latest features and updates.</string>
 	<string name="download_codeonthego_url">https://appdevforall.org/codeonthego</string>
 	<string name="msg_invalid_url">Invalid URL provided.</string>

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -1151,7 +1151,7 @@
 	<string name="title_alert">Send feedback</string>
 
 	<!-- Strings from BaseApplication.java -->
-	<string name="telegram_group_url">https://t.me/CodeOnTheGoDiscussions</string>
+	<string name="telegram_group_url">https://github.com/appdevforall/CodeOnTheGo/discussions</string>
 	<string name="telegram_channel_url">https://t.me/CodeOnTheGoOfficial</string>
 	<string name="sponsor_url">https://m.androidide.com/donate</string>
 	<string name="support_our_work">Support our work</string>

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -12,14 +12,14 @@
 	<string name="about_footer">Code on the Go %1$s for %2$s</string>
 	<string name="about_subtitle">No computer? No Internet? No problem. Code apps anywhere.</string>
 	<string name="msg_get_package_failed">Failed to extract package name.</string>
-	<string name="msg_need_help">If you\'re facing issues while using Code on the Go or with building Android apps, you can join the Telegram Group and ask for help there.\n\nYou can also send suggestions on our email.</string>
+	<string name="msg_need_help">If you\'re facing issues while using Code on the Go or with building Android apps, you can join the our Discussions forum and ask for help there.\n\nYou can also send suggestions on our email.</string>
 	<string name="download_codeonthego_message">Download Code on the Go from the official website to get the latest features and updates.</string>
 	<string name="download_codeonthego_url">https://appdevforall.org/codeonthego</string>
 	<string name="msg_invalid_url">Invalid URL provided.</string>
 	<string name="msg_no_browser_found">No browser found to handle the request.</string>
 	<string name="need_help">Need Help?</string>
 	<string name="ide_preferences">IDE preferences</string>
-	<string name="discussions_on_telegram">Discussions on Telegram</string>
+	<string name="discussions_on_telegram">Support and discussions forum</string>
 	<string name="official_tg_channel">Official Telegram channel</string>
 	<string name="msg_empty_view">No data</string>
 	<string name="title_terminal">Terminal</string>


### PR DESCRIPTION
In Preferences/About Code on the Go, text and URL previously for Telegram support are now text and URL for GitHub Discussions. 