### PR TITLE
ADFA-4436 Add a generic editor decoration provider extension point

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
@@ -329,6 +329,7 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 			GlobalScope.launch {
 				try {
 					pluginManager?.loadPlugins()
+					com.itsaky.androidide.utils.EditorDecorationBridge.init()
 					logger.info("Plugin system initialized successfully")
 				} catch (e: Exception) {
 					logger.error("Failed to load plugins", e)
@@ -380,6 +381,7 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 			}
 		} else if (event.key == GeneralPreferences.UI_MODE && GeneralPreferences.uiMode != AppCompatDelegate.getDefaultNightMode()) {
 			AppCompatDelegate.setDefaultNightMode(GeneralPreferences.uiMode)
+			com.itsaky.androidide.utils.EditorDecorationBridge.refresh()
 		} else if (event.key == GeneralPreferences.SELECTED_LOCALE) {
 			// Use empty locale list if the locale has been reset to 'System Default'
 			val selectedLocale = GeneralPreferences.selectedLocale

--- a/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
+++ b/app/src/main/java/com/itsaky/androidide/app/CredentialProtectedApplicationLoader.kt
@@ -18,6 +18,7 @@ import com.itsaky.androidide.preferences.internal.GeneralPreferences
 import com.itsaky.androidide.resources.localization.LocaleProvider
 import com.itsaky.androidide.ui.themes.IDETheme
 import com.itsaky.androidide.ui.themes.IThemeManager
+import com.itsaky.androidide.utils.EditorDecorationBridge
 import com.itsaky.androidide.utils.Environment
 import com.itsaky.androidide.utils.FeatureFlags
 import com.itsaky.androidide.utils.FileUtil
@@ -329,7 +330,7 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 			GlobalScope.launch {
 				try {
 					pluginManager?.loadPlugins()
-					com.itsaky.androidide.utils.EditorDecorationBridge.init()
+					EditorDecorationBridge.init()
 					logger.info("Plugin system initialized successfully")
 				} catch (e: Exception) {
 					logger.error("Failed to load plugins", e)
@@ -381,7 +382,7 @@ internal object CredentialProtectedApplicationLoader : ApplicationLoader {
 			}
 		} else if (event.key == GeneralPreferences.UI_MODE && GeneralPreferences.uiMode != AppCompatDelegate.getDefaultNightMode()) {
 			AppCompatDelegate.setDefaultNightMode(GeneralPreferences.uiMode)
-			com.itsaky.androidide.utils.EditorDecorationBridge.refresh()
+			EditorDecorationBridge.refresh()
 		} else if (event.key == GeneralPreferences.SELECTED_LOCALE) {
 			// Use empty locale list if the locale has been reset to 'System Default'
 			val selectedLocale = GeneralPreferences.selectedLocale

--- a/app/src/main/java/com/itsaky/androidide/utils/EditorDecorationBridge.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/EditorDecorationBridge.kt
@@ -1,0 +1,111 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.utils
+
+import android.content.ComponentCallbacks
+import android.content.res.Configuration
+import androidx.appcompat.app.AppCompatDelegate
+import com.itsaky.androidide.app.BaseApplication
+import com.itsaky.androidide.eventbus.events.editor.ColorSchemeInvalidatedEvent
+import com.itsaky.androidide.plugins.manager.core.PluginManager
+import com.itsaky.androidide.syntax.decoration.EditorDecorationRegistry
+import org.greenrobot.eventbus.EventBus
+import org.slf4j.LoggerFactory
+
+/**
+ * Bridges editor decoration providers contributed by enabled plugins into the editor's
+ * [EditorDecorationRegistry].
+ *
+ * Keeps the dependency direction clean: the app depends on both the plugin manager and `common`,
+ * so it populates the registry that the low-level editor pipeline reads — the editor never depends
+ * on the plugin manager. The bridge is feature-agnostic; it knows nothing about what any provider
+ * decorates.
+ *
+ * Call [refresh] whenever plugins are (re)loaded/enabled/disabled. [init] additionally tracks the
+ * day/night theme so decorations repaint with the right colors the moment the theme flips.
+ */
+object EditorDecorationBridge {
+
+    private val log = LoggerFactory.getLogger(EditorDecorationBridge::class.java)
+
+    @Volatile
+    private var registered = false
+
+    /** Last seen UI night-mode bit, so we only react when day/night actually flips. */
+    private var lastNightMode = Int.MIN_VALUE
+
+    /**
+     * One-time setup: register a configuration listener so a system (or in-app) day/night flip
+     * repaints editor decorations with the matching theme immediately — no restart required — then
+     * do an initial [refresh]. Safe to call more than once; only the first call registers.
+     */
+    @JvmStatic
+    fun init() {
+        if (!registered) {
+            registered = true
+            try {
+                val app = BaseApplication.baseInstance
+                lastNightMode = app.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                app.registerComponentCallbacks(object : ComponentCallbacks {
+                    override fun onConfigurationChanged(newConfig: Configuration) {
+                        val night = newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                        if (night != lastNightMode) {
+                            lastNightMode = night
+                            refresh()
+                        }
+                    }
+
+                    override fun onLowMemory() {}
+                })
+            } catch (t: Throwable) {
+                log.error("Failed to register editor decoration theme listener", t)
+            }
+        }
+        refresh()
+    }
+
+    /**
+     * Recompute the active decoration providers and current theme, then force open editors to
+     * re-highlight.
+     */
+    @JvmStatic
+    fun refresh() {
+        try {
+            val providers = PluginManager.getInstance()
+                ?.getEnabledEditorDecorationProviders()
+                ?: emptyList()
+
+            EditorDecorationRegistry.isDark = isDarkTheme()
+            EditorDecorationRegistry.update(providers)
+            EventBus.getDefault().post(ColorSchemeInvalidatedEvent())
+        } catch (t: Throwable) {
+            log.error("Failed to refresh editor decoration providers", t)
+        }
+    }
+
+    private fun isDarkTheme(): Boolean {
+        // Honor an explicit user theme choice immediately (config may not have propagated yet
+        // right after a theme toggle); fall back to the resource config for "follow system".
+        when (AppCompatDelegate.getDefaultNightMode()) {
+            AppCompatDelegate.MODE_NIGHT_YES -> return true
+            AppCompatDelegate.MODE_NIGHT_NO -> return false
+        }
+        val uiMode = BaseApplication.baseInstance.resources.configuration.uiMode
+        return (uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+    }
+}

--- a/app/src/main/java/com/itsaky/androidide/utils/EditorDecorationBridge.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/EditorDecorationBridge.kt
@@ -26,6 +26,7 @@ import com.itsaky.androidide.plugins.manager.core.PluginManager
 import com.itsaky.androidide.syntax.decoration.EditorDecorationRegistry
 import org.greenrobot.eventbus.EventBus
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Bridges editor decoration providers contributed by enabled plugins into the editor's
@@ -43,8 +44,7 @@ object EditorDecorationBridge {
 
     private val log = LoggerFactory.getLogger(EditorDecorationBridge::class.java)
 
-    @Volatile
-    private var registered = false
+    private val registered = AtomicBoolean(false)
 
     /** Last seen UI night-mode bit, so we only react when day/night actually flips. */
     private var lastNightMode = Int.MIN_VALUE
@@ -56,27 +56,27 @@ object EditorDecorationBridge {
      */
     @JvmStatic
     fun init() {
-        if (registered) {
-            refresh()
-            return
-        }
-        registered = true
-        try {
-            val app = BaseApplication.baseInstance
-            lastNightMode = app.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-            app.registerComponentCallbacks(object : ComponentCallbacks {
-                override fun onConfigurationChanged(newConfig: Configuration) {
-                    val night = newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK
-                    if (night != lastNightMode) {
-                        lastNightMode = night
-                        refresh()
+        // Atomically claim the one-time registration. Only the winning thread registers; if it
+        // fails, reset the flag so a later init() can retry.
+        if (registered.compareAndSet(false, true)) {
+            try {
+                val app = BaseApplication.baseInstance
+                lastNightMode = app.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                app.registerComponentCallbacks(object : ComponentCallbacks {
+                    override fun onConfigurationChanged(newConfig: Configuration) {
+                        val night = newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                        if (night != lastNightMode) {
+                            lastNightMode = night
+                            refresh()
+                        }
                     }
-                }
 
-                override fun onLowMemory() {}
-            })
-        } catch (t: Throwable) {
-            log.error("Failed to register editor decoration theme listener", t)
+                    override fun onLowMemory() {}
+                })
+            } catch (t: Throwable) {
+                registered.set(false)
+                log.error("Failed to register editor decoration theme listener", t)
+            }
         }
         refresh()
     }

--- a/app/src/main/java/com/itsaky/androidide/utils/EditorDecorationBridge.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/EditorDecorationBridge.kt
@@ -56,25 +56,27 @@ object EditorDecorationBridge {
      */
     @JvmStatic
     fun init() {
-        if (!registered) {
-            registered = true
-            try {
-                val app = BaseApplication.baseInstance
-                lastNightMode = app.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-                app.registerComponentCallbacks(object : ComponentCallbacks {
-                    override fun onConfigurationChanged(newConfig: Configuration) {
-                        val night = newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK
-                        if (night != lastNightMode) {
-                            lastNightMode = night
-                            refresh()
-                        }
+        if (registered) {
+            refresh()
+            return
+        }
+        registered = true
+        try {
+            val app = BaseApplication.baseInstance
+            lastNightMode = app.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+            app.registerComponentCallbacks(object : ComponentCallbacks {
+                override fun onConfigurationChanged(newConfig: Configuration) {
+                    val night = newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                    if (night != lastNightMode) {
+                        lastNightMode = night
+                        refresh()
                     }
+                }
 
-                    override fun onLowMemory() {}
-                })
-            } catch (t: Throwable) {
-                log.error("Failed to register editor decoration theme listener", t)
-            }
+                override fun onLowMemory() {}
+            })
+        } catch (t: Throwable) {
+            log.error("Failed to register editor decoration theme listener", t)
         }
         refresh()
     }

--- a/app/src/main/java/com/itsaky/androidide/viewmodels/PluginManagerViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodels/PluginManagerViewModel.kt
@@ -122,6 +122,9 @@ class PluginManagerViewModel(
                     )
                 }
 
+            // Keep the editor decoration providers in sync with the enabled plugin set.
+            com.itsaky.androidide.utils.EditorDecorationBridge.refresh()
+
             _currentOperation.value = PluginOperation.None
         }
     }

--- a/app/src/main/java/com/itsaky/androidide/viewmodels/PluginManagerViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodels/PluginManagerViewModel.kt
@@ -13,6 +13,7 @@ import com.itsaky.androidide.ui.models.PluginManagerUiEffect
 import com.itsaky.androidide.ui.models.PluginManagerUiEvent
 import com.itsaky.androidide.ui.models.PluginManagerUiState
 import com.itsaky.androidide.ui.models.PluginOperation
+import com.itsaky.androidide.utils.EditorDecorationBridge
 import com.itsaky.androidide.utils.UriFileImporter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -123,7 +124,7 @@ class PluginManagerViewModel(
                 }
 
             // Keep the editor decoration providers in sync with the enabled plugin set.
-            com.itsaky.androidide.utils.EditorDecorationBridge.refresh()
+            EditorDecorationBridge.refresh()
 
             _currentOperation.value = PluginOperation.None
         }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 	api(projects.eventbusAndroid)
 	api(projects.eventbusEvents)
 	api(projects.lexers)
+	api(projects.pluginApi)
 	api(projects.resources)
 
 	api(projects.shared)

--- a/common/src/main/java/com/itsaky/androidide/syntax/decoration/EditorDecorationRegistry.kt
+++ b/common/src/main/java/com/itsaky/androidide/syntax/decoration/EditorDecorationRegistry.kt
@@ -1,0 +1,50 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.syntax.decoration
+
+import com.itsaky.androidide.plugins.extensions.EditorDecorationProvider
+
+/**
+ * Process-wide holder for the editor decoration providers contributed by enabled plugins.
+ *
+ * The app populates this from the plugin manager; the editor's tree-sitter span pipeline reads it
+ * and merges each provider's spans into the rendered styling. It lives in `common` — a module the
+ * editor pipeline already depends on — so the editor stays decoupled from the plugin manager while
+ * still being plugin-driven. The IDE side is entirely feature-agnostic: it knows nothing about what
+ * any provider decorates.
+ */
+object EditorDecorationRegistry {
+
+    @Volatile
+    private var providers: List<EditorDecorationProvider> = emptyList()
+
+    /** Whether the editor is currently showing a dark theme; passed to each provider. */
+    @Volatile
+    @JvmField
+    var isDark: Boolean = false
+
+    /** Replace the set of active decoration providers (empty disables decoration entirely). */
+    @JvmStatic
+    fun update(newProviders: List<EditorDecorationProvider>) {
+        providers = newProviders
+    }
+
+    /** The active decoration providers, or an empty list if none. */
+    @JvmStatic
+    fun providers(): List<EditorDecorationProvider> = providers
+}

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
@@ -56,9 +56,14 @@ import io.github.rosemoe.sora.lang.styling.Span
 import io.github.rosemoe.sora.lang.styling.SpanFactory
 import io.github.rosemoe.sora.lang.styling.Spans
 import io.github.rosemoe.sora.lang.styling.TextStyle
+import io.github.rosemoe.sora.lang.styling.span.SpanConstColorResolver
+import io.github.rosemoe.sora.lang.styling.span.SpanExtAttrs
 import io.github.rosemoe.sora.text.CharPosition
 import io.github.rosemoe.sora.text.Content
 import io.github.rosemoe.sora.widget.schemes.EditorColorScheme
+import com.itsaky.androidide.plugins.extensions.DecorationSpan
+import com.itsaky.androidide.syntax.decoration.EditorDecorationRegistry
+import java.util.TreeMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -205,7 +210,88 @@ class LineSpansGenerator(internal var tree: TSTree, internal var lineCount: Int,
     if (list.isEmpty()) {
       list.add(emptySpan(0))
     }
-    return list
+    return applyDecorations(list, startIndex, endIndex)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Plugin editor decorations
+  //
+  // After the base (tree-sitter) spans for a region are built, every registered
+  // EditorDecorationProvider is given the region and returns additive, foreground-only color
+  // spans, which are merged in here. The IDE is feature-agnostic — it knows nothing about what a
+  // provider decorates (brackets, indent guides, markers, ...). Providers run on this analyze
+  // thread and receive the full document content so they can use context outside the region.
+  // ---------------------------------------------------------------------------
+
+  private fun applyDecorations(list: MutableList<Span>, startIndex: Int,
+    endIndex: Int): MutableList<Span> {
+    val providers = EditorDecorationRegistry.providers()
+    if (providers.isEmpty() || endIndex <= startIndex) return list
+
+    val isDark = EditorDecorationRegistry.isDark
+    var decorations: ArrayList<DecorationSpan>? = null
+    for (provider in providers) {
+      val spans = try {
+        provider.decorate(content, startIndex, endIndex, isDark)
+      } catch (t: Throwable) {
+        Log.e(TAG, "Editor decoration provider failed", t)
+        continue
+      }
+      if (spans.isEmpty()) continue
+      (decorations ?: ArrayList<DecorationSpan>().also { decorations = it }).addAll(spans)
+    }
+
+    val decos = decorations ?: return list
+    return mergeDecorations(list, startIndex, endIndex, decos)
+  }
+
+  /**
+   * Merges additive, foreground-only decoration spans into [list]: overrides only the foreground
+   * color of the covered characters while preserving every base style underneath, and keeps the
+   * strictly-ascending, non-overlapping span ordering the renderer requires. Decoration offsets are
+   * absolute; they are clipped to the region and converted to line-relative columns.
+   */
+  private fun mergeDecorations(list: MutableList<Span>, startIndex: Int, endIndex: Int,
+    decorations: List<DecorationSpan>): MutableList<Span> {
+    val lineLen = endIndex - startIndex
+
+    // Snapshot of the base styles, used to restore the original style after each decorated range.
+    val base = TreeMap<Int, Long>()
+    for (s in list) base.putIfAbsent(s.column, s.style)
+    val defaultStyle = TextStyle.makeStyle(EditorColorScheme.TEXT_NORMAL)
+    fun baseStyleAt(col: Int): Long = base.floorEntry(col)?.value ?: defaultStyle
+
+    val result = TreeMap<Int, Span>()
+    for (s in list) result.putIfAbsent(s.column, s)
+
+    for (d in decorations) {
+      val s = (d.start - startIndex).coerceAtLeast(0)
+      val e = (d.end - startIndex).coerceAtMost(lineLen)
+      if (e <= s) continue
+
+      // Override the foreground at the range start and at every span boundary inside it, so the
+      // color survives base-style changes within the range. Base style (bold/etc.) is preserved.
+      var coveredStart = false
+      for (col in result.subMap(s, true, e, false).keys.toList()) {
+        result[col] = coloredSpan(col, result[col]!!.style, d.argb)
+        if (col == s) coveredStart = true
+      }
+      if (!coveredStart) {
+        result[s] = coloredSpan(s, baseStyleAt(s), d.argb)
+      }
+      // Resume the underlying style right after the range, unless a span already begins there.
+      if (e < lineLen && !result.containsKey(e)) {
+        result[e] = SpanFactory.obtain(e, baseStyleAt(e))
+      }
+    }
+
+    return ArrayList(result.values)
+  }
+
+  private fun coloredSpan(column: Int, style: Long, argb: Int): Span {
+    val span = SpanFactory.obtain(column, style)
+    span.setSpanExt(SpanExtAttrs.EXT_COLOR_RESOLVER, SpanConstColorResolver(argb, 0))
+    return span
   }
 
   private fun createSpans(capture: TSQueryCapture, startColumn: Int, endColumn: Int,

--- a/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/extensions/EditorDecorationProvider.kt
+++ b/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/extensions/EditorDecorationProvider.kt
@@ -1,0 +1,42 @@
+
+package com.itsaky.androidide.plugins.extensions
+
+import com.itsaky.androidide.plugins.IPlugin
+
+/**
+ * Additive editor decoration extension: contributes foreground-color spans for regions of editor
+ * text, layered on top of the normal syntax highlighting.
+ *
+ * The provider owns all of its own logic — it decides which characters to color and how. The IDE
+ * is feature-agnostic: it simply calls [decorate] for each analyzed region and merges the returned
+ * spans as foreground overrides. Because the only output is a list of colored ranges, a provider
+ * can never replace or suppress the editor's existing highlighting.
+ *
+ * Typical uses: depth-colored brackets, indent guides, TODO/marker tinting, semantic emphasis.
+ */
+interface EditorDecorationProvider : IPlugin {
+
+    /**
+     * Return additive, foreground-only color spans for the region `[start, end)` of [text].
+     *
+     * Called on a background analysis thread, once per analyzed region (typically a line), and may
+     * be called frequently — keep it fast. [text] is the full, read-only document content so a
+     * provider can use context outside the region (e.g. compute nesting depth by scanning the
+     * prefix); only characters within `[start, end)` may be decorated.
+     *
+     * Returned [DecorationSpan]s use absolute character offsets into [text], must fall within
+     * `[start, end)`, and should not overlap one another. Spans outside the region are ignored.
+     *
+     * @param text full document content (read-only).
+     * @param start absolute character offset of the region start (inclusive).
+     * @param end absolute character offset of the region end (exclusive).
+     * @param isDark whether the editor is currently showing a dark theme.
+     */
+    fun decorate(text: CharSequence, start: Int, end: Int, isDark: Boolean): List<DecorationSpan>
+}
+
+/**
+ * An additive foreground-color span. [start] and [end] are absolute character offsets into the
+ * document ([end] exclusive); [argb] is the foreground color to apply, as a packed ARGB int.
+ */
+data class DecorationSpan(val start: Int, val end: Int, val argb: Int)

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
@@ -17,6 +17,7 @@ import com.itsaky.androidide.plugins.manager.services.CogoProjectProvider
 import com.itsaky.androidide.plugins.manager.services.IdeTooltipServiceImpl
 import com.itsaky.androidide.plugins.manager.services.IdeEditorTabServiceImpl
 import com.itsaky.androidide.plugins.extensions.DocumentationExtension
+import com.itsaky.androidide.plugins.extensions.EditorDecorationProvider
 import com.itsaky.androidide.plugins.extensions.FileOpenExtension
 import com.itsaky.androidide.plugins.extensions.SnippetExtension
 import com.itsaky.androidide.plugins.manager.services.IdeSnippetServiceImpl
@@ -797,11 +798,11 @@ class PluginManager private constructor(
     /**
      * Get all enabled plugins that provide editor decorations (additive coloring of editor text).
      */
-    fun getEnabledEditorDecorationProviders(): List<com.itsaky.androidide.plugins.extensions.EditorDecorationProvider> {
+    fun getEnabledEditorDecorationProviders(): List<EditorDecorationProvider> {
         return loadedPlugins.values
             .filter { it.isEnabled }
             .map { it.plugin }
-            .filterIsInstance<com.itsaky.androidide.plugins.extensions.EditorDecorationProvider>()
+            .filterIsInstance<EditorDecorationProvider>()
     }
 
     fun notifyFileOpened(file: File) {

--- a/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
+++ b/plugin-manager/src/main/kotlin/com/itsaky/androidide/plugins/manager/core/PluginManager.kt
@@ -794,6 +794,16 @@ class PluginManager private constructor(
             .filterIsInstance<FileOpenExtension>()
     }
 
+    /**
+     * Get all enabled plugins that provide editor decorations (additive coloring of editor text).
+     */
+    fun getEnabledEditorDecorationProviders(): List<com.itsaky.androidide.plugins.extensions.EditorDecorationProvider> {
+        return loadedPlugins.values
+            .filter { it.isEnabled }
+            .map { it.plugin }
+            .filterIsInstance<com.itsaky.androidide.plugins.extensions.EditorDecorationProvider>()
+    }
+
     fun notifyFileOpened(file: File) {
         getEnabledFileOpenExtensions().forEach { extension ->
             executeWithErrorHandling("notify file opened") {


### PR DESCRIPTION
## Summary

Adds a generic, **additive** way for plugins to contribute foreground colors to editor text, layered on top of normal syntax highlighting — never replacing it. The IDE is **feature-agnostic**: it knows nothing about what a provider decorates (brackets, indent guides, markers, …); it just merges the spans a provider returns.

Motivation: the only pre-existing editor-coloring hook, `EditorExtension.provideSyntaxHighlighting()`, is dead code (zero call sites) and semantically unsuited — it returns a fixed semantic enum with no RGB/depth and would *replace* all highlighting. It is left untouched here.

## API

```kotlin
interface EditorDecorationProvider : IPlugin {
    fun decorate(text: CharSequence, start: Int, end: Int, isDark: Boolean): List<DecorationSpan>
}
data class DecorationSpan(val start: Int, val end: Int, val argb: Int)
```

The provider receives the full document content and a region, and returns additive, foreground-only color spans. All feature logic lives in the plugin.

## Changes

- **plugin-api** — `EditorDecorationProvider` + `DecorationSpan`.
- **plugin-manager** — `getEnabledEditorDecorationProviders()` collector.
- **common** — `EditorDecorationRegistry` holds the active providers + current theme; read by the editor pipeline, populated by the app. Keeps the editor module free of any plugin-manager dependency (`common` now depends on the leaf `plugin-api` module).
- **editor-treesitter** — after building a region's base spans, `LineSpansGenerator` calls each provider and merges the returned spans as foreground-only overrides, preserving base styles and the strictly-ascending non-overlap invariant. ~30 generic lines; no feature concepts.
- **app** — `EditorDecorationBridge` registers enabled providers + current theme into the registry and posts `ColorSchemeInvalidatedEvent` to repaint; a `ComponentCallbacks` listener flips decorations on day/night changes live.

Dependency direction stays clean: `app → plugin-manager`, `app → common`, `editor → common → plugin-api`; the editor never depends on the plugin manager.

## Verification

Device-verified on an emulator with a companion rainbow-brackets plugin (separate repo) that implements `EditorDecorationProvider`:

- Depth-cycled bracket colors across `()`, `[]`, `{}` in a **Java** file (provider scans text itself, so it's language-agnostic).
- Nesting depth carried across lines.
- Brackets inside strings/comments not colored.
- Day and night palettes; live day/night toggle (no restart).
- Disabling the plugin reverts to normal coloring (additivity).

## Notes

This is the IDE-side generic API + merge. The rainbow plugin (which owns all bracket/depth/palette logic) lives in the plugin-examples repo and compiles against the refreshed `plugin-api.jar`.

_(Reworked from an earlier rainbow-specific `BracketColorExtension` after review feedback that feature logic shouldn't live in the IDE.)_
