### PR TITLE
ADFA-4471 | Fix SwipeRevealLayout intercepting editor scroll gestures

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/ui/SwipeRevealLayout.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/SwipeRevealLayout.kt
@@ -31,6 +31,7 @@ import com.google.android.material.shape.MaterialShapeDrawable
 import com.itsaky.androidide.R
 import kotlin.math.max
 import kotlin.math.min
+import androidx.core.content.withStyledAttributes
 
 /**
  * A layout which can be dragged vertically to reveal a hidden content.
@@ -67,6 +68,14 @@ open class SwipeRevealLayout @JvmOverloads constructor(
   private var rightDragProgress = 0f
   private var isVerticalDragEnabled = true
 
+  private var isDownInDragHandle = false
+    /**
+     * Whether the most recent touch-down landed within the configured drag handle. The vertical
+     * drag-to-reveal gesture is only captured when this is `true`, so that scroll gestures starting
+     * in the middle of the overlapping content (e.g. the editor) are not stolen.
+     */
+    private val dragHandleLocation = IntArray(2)
+
   init {
     leftDragHelper = ViewDragHelper.create(this, 1f, LeftDragCallback())
     rightDragHelper = ViewDragHelper.create(this, 1f, RightDragCallback())
@@ -74,7 +83,7 @@ open class SwipeRevealLayout @JvmOverloads constructor(
 
   private val dragHelperCallback = object : ViewDragHelper.Callback() {
     override fun tryCaptureView(child: View, pointerId: Int): Boolean {
-      return isVerticalDragEnabled && child === overlappingContent
+      return isVerticalDragEnabled && isDownInDragHandle && child === overlappingContent
     }
 
     override fun onViewPositionChanged(changedView: View, left: Int, top: Int, dx: Int, dy: Int) {
@@ -193,11 +202,15 @@ open class SwipeRevealLayout @JvmOverloads constructor(
 
   init {
     if (attrs != null) {
-      val typedArray = context.obtainStyledAttributes(attrs, R.styleable.SwipeRevealLayout,
-        defStyleAttr, defStyleRes)
-      dragHandleViewId = typedArray.getResourceId(R.styleable.SwipeRevealLayout_dragHandle,
-        dragHandleViewId)
-      typedArray.recycle()
+        context.withStyledAttributes(
+            attrs, R.styleable.SwipeRevealLayout,
+            defStyleAttr, defStyleRes
+        ) {
+            dragHandleViewId = getResourceId(
+                R.styleable.SwipeRevealLayout_dragHandle,
+                dragHandleViewId
+            )
+        }
     }
   }
 
@@ -237,6 +250,9 @@ open class SwipeRevealLayout @JvmOverloads constructor(
       dragHelper.cancel()
       return false
     }
+    if (action == MotionEvent.ACTION_DOWN) {
+      isDownInDragHandle = isTouchInDragHandle(ev)
+    }
     val isLeft = leftDragHelper.shouldInterceptTouchEvent(ev)
     val isRight = rightDragHelper.shouldInterceptTouchEvent(ev)
     val isVertical = dragHelper.shouldInterceptTouchEvent(ev)
@@ -249,6 +265,31 @@ open class SwipeRevealLayout @JvmOverloads constructor(
     rightDragHelper.processTouchEvent(event)
     dragHelper.processTouchEvent(event)
     return true
+  }
+
+  /**
+   * Returns whether the given touch event falls within the bounds of the configured drag handle
+   * (see [dragHandleViewId] / the `app:dragHandle` attribute). When no drag handle is configured,
+   * the whole overlapping content acts as the handle (legacy behavior).
+   */
+  private fun isTouchInDragHandle(ev: MotionEvent): Boolean {
+    if (dragHandleViewId == 0) {
+      return true
+    }
+
+    val handle = findViewById<View>(dragHandleViewId)
+    if (handle == null || handle.visibility != VISIBLE) {
+      return false
+    }
+
+    handle.getLocationOnScreen(dragHandleLocation)
+    val left = dragHandleLocation[0]
+    val top = dragHandleLocation[1]
+    val right = left + handle.width
+    val bottom = top + handle.height
+    val x = ev.rawX
+    val y = ev.rawY
+    return x >= left && x <= right && y >= top && y <= bottom
   }
 
   override fun computeScroll() {

--- a/app/src/main/res/layout/activity_editor.xml
+++ b/app/src/main/res/layout/activity_editor.xml
@@ -26,7 +26,7 @@
                 android:id="@+id/swipe_reveal"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:dragHandle="@id/project_actions_toolbar">
+                app:dragHandle="@id/editor_appBarLayout">
 
                 <include
                     android:id="@+id/mem_usage_view"


### PR DESCRIPTION
## Description

Fixed an issue where `SwipeRevealLayout` would inadvertently steal vertical scroll gestures from the overlapping editor content. The vertical drag-to-reveal gesture is now strictly captured only if the initial touch-down event lands within the bounds of the configured drag handle. Furthermore, the drag handle in the editor layout was updated to map to the `editor_appBarLayout`.

## Details

* Added a touch bounds-check (`isTouchInDragHandle`) on `ACTION_DOWN` to verify the gesture's origin.
* Updated `activity_editor.xml` to point `app:dragHandle` to `@id/editor_appBarLayout` instead of the project actions toolbar.
* Refactored `obtainStyledAttributes` to use the more idiomatic `withStyledAttributes` extension from AndroidX Core.

https://github.com/user-attachments/assets/3305f42c-fabd-49b6-840f-9273d8fda787

## Ticket

[ADFA-4471](https://appdevforall.atlassian.net/browse/ADFA-4471)

## Observation

The logic preserves legacy behavior: if a `SwipeRevealLayout` instance has a `dragHandleViewId` of `0` (no handle configured), the entire overlapping content will continue to act as the handle.

[ADFA-4471]: https://appdevforall.atlassian.net/browse/ADFA-4471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ