### PR TITLE
ADFA-3481 | Fix editor indent OOM on Enter key event

### DIFF
--- a/editor/src/main/java/com/itsaky/androidide/editor/language/treesitter/TreeSitterLanguage.kt
+++ b/editor/src/main/java/com/itsaky/androidide/editor/language/treesitter/TreeSitterLanguage.kt
@@ -25,7 +25,6 @@ import com.itsaky.androidide.editor.schemes.IDEColorScheme
 import com.itsaky.androidide.editor.schemes.LanguageScheme
 import com.itsaky.androidide.editor.schemes.LanguageSpecProvider.getLanguageSpec
 import com.itsaky.androidide.editor.schemes.LocalCaptureSpecProvider.newLocalCaptureSpec
-import com.itsaky.androidide.editor.utils.isNonBlankLine
 import com.itsaky.androidide.treesitter.TSLanguage
 import com.itsaky.androidide.treesitter.TreeSitter
 import com.itsaky.androidide.utils.IntPair
@@ -145,31 +144,23 @@ abstract class TreeSitterLanguage(
 				return DEF_IDENT_ADV
 			}
 
-			var linesToReq = LongArray(1)
-			linesToReq[0] = IntPair.pack(line, column)
-
-			if (content.reference.isNonBlankLine(line + 1)) {
-				// consider the indentation of the next line only if it is non-blank
-				linesToReq += IntPair.pack(line + 1, 0)
-			}
+			// Request both lines so the advance is a relative delta, cancelling any mismatch between the editor's indent size and the file's actual indentation width.
+			val linesToReq = longArrayOf(
+				IntPair.pack(line, column),
+				IntPair.pack(line + 1, 0)
+			)
 
 			val indents = this.indentProvider.getIndentsForLines(
 				content = content.reference,
 				positions = linesToReq,
 			)
 
-			if (indents.size == 1) {
-				val indent = indents[0]
-				if (indent == TreeSitterIndentProvider.INDENTATION_ERR) {
-					return DEF_IDENT_ADV
-				}
-
-				return indent - (spaceCountOnLine + (tabCountOnLine * getTabSize()))
-			}
-
 			val (indentLine, indentNxtLine) = indents
+			// A sentinel indent (e.g. INDENT_AUTO == Int.MAX_VALUE) would overflow the advance into a huge whitespace string (OOM), so fall back to the default advance.
 			if (indentLine == TreeSitterIndentProvider.INDENTATION_ERR
 				|| indentNxtLine == TreeSitterIndentProvider.INDENTATION_ERR
+				|| indentLine == TreeSitterIndentProvider.INDENT_AUTO
+				|| indentNxtLine == TreeSitterIndentProvider.INDENT_AUTO
 			) {
 				log.debug(
 					"expectedIndent[{}]={}, expectedIndentNextLine[{}]={}, returning default indent advance",


### PR DESCRIPTION
## Description

This PR fixes a critical `OutOfMemoryError` that occurs when pressing the Enter key in the code editor, and it corrects the tree-sitter indentation calculation for blank lines. I updated the logic to always request both the current and next lines to calculate a relative indent delta, ensuring accuracy regardless of file indentation width mismatches. Furthermore, I added safeguard checks against sentinel values (like `INDENT_AUTO`) to prevent the application from attempting to allocate extremely large whitespace strings during indent generation.

## Details

```text
OutOfMemoryError: Failed to allocate a 301989904 byte allocation with 50331648 free bytes and 262MB until OOM, target footprint 311780288, growth limit 536870912
    at java.util.Arrays.copyOf(Arrays.java:4276)
    at java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:301)
    at java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:853)
    at java.lang.StringBuilder.append(StringBuilder.java:261)
    at io.github.rosemoe.sora.text.TextUtils.createIndent(SourceFile:32)
    at io.github.rosemoe.sora.widget.CodeEditor.commitText(SourceFile:77)
    at io.github.rosemoe.sora.widget.EditorKeyEventHandler.handleEnterKeyEvent(SourceFile:252)

```

### Before

https://github.com/user-attachments/assets/c3201549-8d9c-4136-acde-30e12f28aac8

### After

https://github.com/user-attachments/assets/884eb50f-156b-4159-a44e-f8fd51328903

## Ticket

[ADFA-3481](https://appdevforall.atlassian.net/browse/ADFA-3481)

Also fixes: [ADFA-2544](https://appdevforall.atlassian.net/browse/ADFA-2544)

## Observation

The crash was caused by sentinel values (e.g., `Int.MAX_VALUE`) being passed unchecked into the `createIndent` utility, causing it to attempt to allocate roughly 300MB of whitespace into memory. The fallback to default advance behavior avoids this overflow.

[ADFA-3481]: https://appdevforall.atlassian.net/browse/ADFA-3481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ