### PR TITLE
ADFA-2468 | Guard block-line drawing against styles.blocks data race

### DIFF
--- a/editor/src/main/java/com/itsaky/androidide/editor/ui/IDEEditor.kt
+++ b/editor/src/main/java/com/itsaky/androidide/editor/ui/IDEEditor.kt
@@ -88,6 +88,7 @@ import io.github.rosemoe.sora.event.SelectionChangeEvent
 import io.github.rosemoe.sora.lang.EmptyLanguage
 import io.github.rosemoe.sora.lang.Language
 import io.github.rosemoe.sora.widget.CodeEditor
+import io.github.rosemoe.sora.widget.EditorRenderer
 import io.github.rosemoe.sora.widget.EditorSearcher
 import io.github.rosemoe.sora.widget.IDEEditorSearcher
 import io.github.rosemoe.sora.widget.component.EditorAutoCompletion
@@ -513,6 +514,12 @@ constructor(
     // not overridable
     final override fun <T : EditorBuiltinComponent?> getComponent(clazz: Class<T>): T & Any =
         super.getComponent(clazz)
+
+    /** Uses [TracingEditorRenderer], which guards block-line drawing against the
+     * styles.blocks data race that otherwise crashes onDraw. */
+    override fun onCreateRenderer(): EditorRenderer {
+        return TracingEditorRenderer(editor = this)
+    }
 
     override fun release() {
         ensureWindowsDismissed()

--- a/editor/src/main/java/com/itsaky/androidide/editor/ui/TracingEditorRenderer.kt
+++ b/editor/src/main/java/com/itsaky/androidide/editor/ui/TracingEditorRenderer.kt
@@ -32,6 +32,7 @@ import io.github.rosemoe.sora.util.LongArrayList
 import io.github.rosemoe.sora.util.MutableInt
 import io.github.rosemoe.sora.widget.CodeEditor
 import io.github.rosemoe.sora.widget.EditorRenderer
+import org.slf4j.LoggerFactory
 
 /**
  * An implementation of [EditorRenderer] which traces the whole drawing process for [IDEEditor].
@@ -42,6 +43,10 @@ class TracingEditorRenderer(
   private val enabled: Boolean = BuildConfig.DEBUG,
   editor: CodeEditor
 ) : EditorRenderer(editor) {
+
+  private companion object {
+    private val log = LoggerFactory.getLogger(TracingEditorRenderer::class.java)
+  }
 
   override fun draw(canvas: Canvas) = trace("draw") {
     super.draw(canvas)
@@ -204,11 +209,21 @@ class TracingEditorRenderer(
   }
 
   override fun drawBlockLines(canvas: Canvas?, offsetX: Float) = trace("drawBlockLines") {
-    super.drawBlockLines(canvas, offsetX)
+    try {
+      super.drawBlockLines(canvas, offsetX)
+    } catch (e: IndexOutOfBoundsException) {
+      // styles.blocks was concurrently cleared by the analyzer worker thread. Skip block
+      // lines this frame; the next invalidate() redraws them.
+      log.warn("Skipped drawing block lines: styles.blocks was modified concurrently", e)
+    }
   }
 
   override fun drawSideBlockLine(canvas: Canvas?) = trace("drawSideBlockLine") {
-    super.drawSideBlockLine(canvas)
+    try {
+      super.drawSideBlockLine(canvas)
+    } catch (e: IndexOutOfBoundsException) {
+      log.warn("Skipped drawing side block line: styles.blocks was modified concurrently", e)
+    }
   }
 
   override fun drawScrollBars(canvas: Canvas?) = trace("drawScrollBars") {


### PR DESCRIPTION
## Description

Fixed an `IndexOutOfBoundsException` that crashes the editor during the `onDraw` rendering phase. The crash occurs due to a data race where `styles.blocks` is concurrently cleared or modified by the analyzer worker thread while the UI thread is trying to draw block lines. Implemented a safeguard in `TracingEditorRenderer` to catch the exception, skip drawing the lines for the current frame, and allow the subsequent `invalidate()` call to redraw them safely.

## Details

Logs addressed:

```
IndexOutOfBoundsException: Index 9 out of bounds for length 0
java.lang.IndexOutOfBoundsException: Index 27 out of bounds for length 0
    at java.util.ArrayList.get(ArrayList.java:435)
    at io.github.rosemoe.sora.widget.EditorRenderer.drawBlockLines(SourceFile:76)

```

* Integrated `TracingEditorRenderer` as the default renderer in `IDEEditor`.
* Added `SLF4J` logging to warn when block lines or side block lines are skipped due to concurrent modification.

https://github.com/user-attachments/assets/a91da765-f77a-48ec-8ab4-31147ea4e1e1

## Ticket

[ADFA-2468](https://appdevforall.atlassian.net/browse/ADFA-2468)

## Observation

It is worth noting that the crash could not be reproduced locally; therefore, this is primarily a defensive fix to prevent unexpected crashes in production.

[ADFA-2468]: https://appdevforall.atlassian.net/browse/ADFA-2468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ