### PR TITLE
ADFA-4222 | Recognize CoGo release signing cert and drop F-Droid signing info

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/utils/BuildInfoUtils.kt
+++ b/app/src/main/java/com/itsaky/androidide/utils/BuildInfoUtils.kt
@@ -76,7 +76,6 @@ object BuildInfoUtils {
 
 		val signer = TermuxUtils.getAPKRelease(sha256DigestForPackage)
 
-		return TermuxConstants.APK_RELEASE_ANDROIDIDE == signer ||
-			TermuxConstants.APK_RELEASE_FDROID == signer
+		return TermuxConstants.APK_RELEASE_COGO == signer
 	}
 }

--- a/termux/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
+++ b/termux/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
@@ -350,17 +350,11 @@ public final class TermuxConstants {
     public static final String TERMUX_GITHUB_ISSUES_REPO_URL = TERMUX_GITHUB_REPO_URL + "/issues"; // Default: "https://github.com/termux/termux-app/issues"
 
 
-    /** AndroidIDE APK release */
-    public static final String APK_RELEASE_ANDROIDIDE = "AndroidIDE"; // Default: "AndroidIDE"
+    /** CoGo APK release */
+    public static final String APK_RELEASE_COGO = "AndroidIDE"; // Default: "AndroidIDE"
 
-    /** AndroidIDE APK release signing certificate SHA-256 digest */
-    public static final String APK_RELEASE_ANDROIDIDE_SIGNING_CERTIFICATE_SHA256_DIGEST = "2DF2CBC1468CCB89DAD1733DC8E027BFF35EEEFA58C9EF35A5518A5D57912007"; // Default: "2DF2CBC1468CCB89DAD1733DC8E027BFF35EEEFA58C9EF35A5518A5D57912007"
-
-    /** F-Droid APK release */
-    public static final String APK_RELEASE_FDROID = "F-Droid"; // Default: "F-Droid"
-
-    /** F-Droid APK release signing certificate SHA-256 digest */
-    public static final String APK_RELEASE_FDROID_SIGNING_CERTIFICATE_SHA256_DIGEST = "0E0E8D2836F926EF04E82D2AAD79589E214DC634ED9BE49EEAF10B89F8958F4C"; // Default: "0E0E8D2836F926EF04E82D2AAD79589E214DC634ED9BE49EEAF10B89F8958F4C"
+    /** CoGo APK release signing certificate SHA-256 digest */
+    public static final String APK_RELEASE_COGO_SIGNING_CERTIFICATE_SHA256_DIGEST = "F23D6104C41D37E85E5690041A0A3F64A6DBB57DF6BBBCE2A2D51870E0D81B6B";
 
 
 

--- a/termux/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
+++ b/termux/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
@@ -351,7 +351,7 @@ public final class TermuxConstants {
 
 
     /** CoGo APK release */
-    public static final String APK_RELEASE_COGO = "AndroidIDE"; // Default: "AndroidIDE"
+    public static final String APK_RELEASE_COGO = "Code On the Go"; // Default: "AndroidIDE"
 
     /** CoGo APK release signing certificate SHA-256 digest */
     public static final String APK_RELEASE_COGO_SIGNING_CERTIFICATE_SHA256_DIGEST = "F23D6104C41D37E85E5690041A0A3F64A6DBB57DF6BBBCE2A2D51870E0D81B6B";

--- a/termux/termux-shared/src/main/java/com/termux/shared/termux/TermuxUtils.java
+++ b/termux/termux-shared/src/main/java/com/termux/shared/termux/TermuxUtils.java
@@ -528,14 +528,9 @@ public class TermuxUtils {
         if (signingCertificateSHA256Digest == null) return "null";
 
         if (signingCertificateSHA256Digest
-            .equalsIgnoreCase(TermuxConstants.APK_RELEASE_ANDROIDIDE_SIGNING_CERTIFICATE_SHA256_DIGEST)
+            .equalsIgnoreCase(TermuxConstants.APK_RELEASE_COGO_SIGNING_CERTIFICATE_SHA256_DIGEST)
         ) {
-            return TermuxConstants.APK_RELEASE_ANDROIDIDE;
-        }
-        if (signingCertificateSHA256Digest
-            .equalsIgnoreCase(TermuxConstants.APK_RELEASE_FDROID_SIGNING_CERTIFICATE_SHA256_DIGEST)
-        ) {
-            return TermuxConstants.APK_RELEASE_FDROID;
+            return TermuxConstants.APK_RELEASE_COGO;
         }
         return "Unknown";
     }


### PR DESCRIPTION
## Summary

Updates the app's self-signature recognition so official builds signed with the App Dev For All release key are correctly detected as **OFFICIAL**, and removes the now-unused F-Droid signing info.

The release APKs (armv8a/armv7a) are signed with:
- **DN**: `CN=Hal Eisen, OU=Engineering, O=App Dev For All, L=San Francisco, ST=CA, C=US`
- **SHA-256**: `f23d6104c41d37e85e5690041a0a3f64a6dbb57df6bbbce2a2d51870e0d81b6b`

## Changes

- **`TermuxConstants.java`**
  - Updated the CoGo APK release signing certificate SHA-256 digest to the ADFA release key (`F23D6104…E0D81B6B`).
  - Removed the F-Droid signing constants (`APK_RELEASE_FDROID`, `APK_RELEASE_FDROID_SIGNING_CERTIFICATE_SHA256_DIGEST`).
  - Renamed `APK_RELEASE_ANDROIDIDE*` → `APK_RELEASE_COGO*`.
- **`TermuxUtils.java`** — dropped the F-Droid branch in `getAPKRelease(...)`.
- **`BuildInfoUtils.kt`** — `isOfficialBuild(...)` now checks only the CoGo signer.

## Notes

- The digest is compared with `equalsIgnoreCase`; `PackageUtils` computes SHA-256 over the DER-encoded cert — exactly what `apksigner`'s "certificate SHA-256 digest" reports — so both ABI variants (same cert) now register as OFFICIAL.