### PR TITLE
ADFA-4582 | Restore IdeProjectService.getModuleContext

### DIFF
--- a/plugin-api/api/plugin-api.api
+++ b/plugin-api/api/plugin-api.api
@@ -1196,6 +1196,7 @@ public final class com/itsaky/androidide/plugins/services/IdeArchiveService$Defa
 
 public abstract interface class com/itsaky/androidide/plugins/services/IdeBuildService {
 	public abstract fun addBuildStatusListener (Lcom/itsaky/androidide/plugins/services/BuildStatusListener;)V
+	public abstract fun executeTasks ([Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 	public abstract fun getBuildOutput ()Ljava/lang/String;
 	public abstract fun isBuildInProgress ()Z
 	public abstract fun isToolingServerStarted ()Z
@@ -1205,6 +1206,7 @@ public abstract interface class com/itsaky/androidide/plugins/services/IdeBuildS
 }
 
 public final class com/itsaky/androidide/plugins/services/IdeBuildService$DefaultImpls {
+	public static fun executeTasks (Lcom/itsaky/androidide/plugins/services/IdeBuildService;[Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 	public static fun getBuildOutput (Lcom/itsaky/androidide/plugins/services/IdeBuildService;)Ljava/lang/String;
 	public static fun runApp (Lcom/itsaky/androidide/plugins/services/IdeBuildService;Lcom/itsaky/androidide/plugins/services/BuildAndLaunchCallback;)V
 	public static fun triggerGradleSync (Lcom/itsaky/androidide/plugins/services/IdeBuildService;Lcom/itsaky/androidide/plugins/services/GradleSyncCallback;)V

--- a/plugin-api/api/plugin-api.api
+++ b/plugin-api/api/plugin-api.api
@@ -1303,7 +1303,12 @@ public final class com/itsaky/androidide/plugins/services/IdeProjectManipulation
 public abstract interface class com/itsaky/androidide/plugins/services/IdeProjectService {
 	public abstract fun getAllProjects ()Ljava/util/List;
 	public abstract fun getCurrentProject ()Lcom/itsaky/androidide/plugins/extensions/IProject;
+	public abstract fun getModuleContext (Ljava/lang/String;)Lcom/itsaky/androidide/plugins/services/ModuleContext;
 	public abstract fun getProjectByPath (Ljava/io/File;)Lcom/itsaky/androidide/plugins/extensions/IProject;
+}
+
+public final class com/itsaky/androidide/plugins/services/IdeProjectService$DefaultImpls {
+	public static fun getModuleContext (Lcom/itsaky/androidide/plugins/services/IdeProjectService;Ljava/lang/String;)Lcom/itsaky/androidide/plugins/services/ModuleContext;
 }
 
 public abstract interface class com/itsaky/androidide/plugins/services/IdeSidebarService {

--- a/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/services/IdeServices.kt
+++ b/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/services/IdeServices.kt
@@ -30,6 +30,20 @@ interface IdeProjectService {
      * @return The project at the given path, or null if not found
      */
     fun getProjectByPath(path: File): IProject?
+
+    /**
+     * Resolves the build context (compile/intermediate classpaths, runtime dex files,
+     * selected variant, resource APK, and whether a build is needed) for the module that
+     * owns the given file.
+     *
+     * Defaults to returning null so the method is binary-compatible: hosts that predate it,
+     * and implementors that do not override it, report "unavailable" (mirrors the default on
+     * [IdeUIService.openPluginScreen]).
+     *
+     * @param filePath The absolute path of a source file owned by the module
+     * @return The module context, or null if no module can be resolved
+     */
+    fun getModuleContext(filePath: String): ModuleContext? = null
 }
 
 /**

--- a/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/services/IdeServices.kt
+++ b/plugin-api/src/main/kotlin/com/itsaky/androidide/plugins/services/IdeServices.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import com.itsaky.androidide.plugins.extensions.IProject
 import java.io.File
 import java.io.InputStream
+import java.util.concurrent.CompletableFuture
 
 /**
  * Service interface that provides access to Code On the Go project information.
@@ -214,6 +215,16 @@ interface IdeBuildService {
      * @param callback The callback to unregister
      */
     fun removeBuildStatusListener(callback: BuildStatusListener)
+
+    /**
+     * Executes the given Gradle task paths (e.g. ":app:assembleDebug") and completes with
+     * true on success, false on failure/cancellation.
+     *
+     * Default completes with false so this addition is binary-compatible: hosts that predate
+     * the method, and any implementor that does not override it, report "not executed".
+     */
+    fun executeTasks(vararg tasks: String): CompletableFuture<Boolean> =
+        CompletableFuture.completedFuture(false)
 
     /**
      * Builds and runs the app on the connected device.


### PR DESCRIPTION
## Description

Restores the `getModuleContext` method in `IdeProjectService` and provides a default implementation that returns `null` to ensure binary compatibility with older hosts. The BCV dump (`plugin-api.api`) has been regenerated to accurately reflect these API changes.

## Details

Logic update only; no UI changes.

### ✅ `./gradlew :plugin-api:apiCheck`

<img width="1013" height="595" alt="image" src="https://github.com/user-attachments/assets/c74339ee-f437-4a73-94a8-61b1f70b0b5f" />


## Ticket

[ADFA-4582](https://appdevforall.atlassian.net/browse/ADFA-4582)

## Observation

The default implementation mirrors the default behavior on `IdeUIService.openPluginScreen`, ensuring that hosts predating this method and implementors not overriding it will safely report as "unavailable".

[ADFA-4582]: https://appdevforall.atlassian.net/browse/ADFA-4582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ