### PR TITLE
ADFA-4633: Strip BouncyCastle PQC classes from keystore-generator-plugin APK

### DIFF
--- a/keystore-generator-plugin/build.gradle.kts
+++ b/keystore-generator-plugin/build.gradle.kts
@@ -51,6 +51,21 @@ android {
     }
 }
 
+val bcprovOriginal: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+val stripBcprovPqc by tasks.registering(Jar::class) {
+    archiveFileName.set("bcprov-nopqc.jar")
+    destinationDirectory.set(layout.buildDirectory.dir("libs"))
+    from({ bcprovOriginal.map { zipTree(it) } }) {
+        exclude("org/bouncycastle/pqc/**")
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
+}
+
 dependencies {
     compileOnly(project(":plugin-api"))
 
@@ -60,9 +75,12 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.1.21")
     implementation("androidx.fragment:fragment:1.8.8")
 
-    // BouncyCastle for keystore generation
-    implementation("org.bouncycastle:bcprov-jdk18on:1.78")
-    implementation("org.bouncycastle:bcpkix-jdk18on:1.78")
+    // BouncyCastle for keystore generation (PQC classes stripped via stripBcprovPqc task)
+    bcprovOriginal("org.bouncycastle:bcprov-jdk18on:1.78")
+    implementation(files(stripBcprovPqc.flatMap { it.archiveFile }))
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.78") {
+        exclude(group = "org.bouncycastle", module = "bcprov-jdk18on")
+    }
 }
 
 tasks.wrapper {

--- a/keystore-generator-plugin/settings.gradle.kts
+++ b/keystore-generator-plugin/settings.gradle.kts
@@ -16,6 +16,11 @@ dependencyResolutionManagement {
         google()
         gradlePluginPortal()
     }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }
 
 include(":plugin-api")


### PR DESCRIPTION
## Summary

- Adds a `stripBcprovPqc` Gradle task that repacks `bcprov-jdk18on` excluding `org/bouncycastle/pqc/**`, so PQC classes never land in the APK
- Excludes `bcprov-jdk18on` from `bcpkix-jdk18on`'s transitive deps to prevent the unstripped jar from sneaking back in
- Adds a reference to the root `gradle/libs.versions.toml` in the standalone plugin project's settings so `plugin-api` can resolve its version catalog during standalone builds

## Test plan

- [ ] `keystore-generator-plugin` builds successfully via `./gradlew assembleRelease`
- [ ] Keystore generation works end-to-end in the app
- [ ] Verify `org/bouncycastle/pqc/` is absent from the output APK: `unzip -l build/outputs/apk/release/*.apk | grep pqc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)