### PR TITLE
ADFA-4634: Remove Jackson and kotlinx.serialization, consolidate on Gson

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,6 @@ plugins {
 	id("com.itsaky.androidide.desugaring")
 	alias(libs.plugins.sentry)
 	alias(libs.plugins.google.services)
-	kotlin("plugin.serialization")
 }
 
 fun propOrEnv(name: String): String =
@@ -318,7 +317,6 @@ dependencies {
 	implementation(libs.common.markwon.linkify)
 	implementation(libs.commons.text.v1140)
 
-	implementation(libs.kotlinx.serialization.json)
 	// Koin for Dependency Injection
 	implementation(libs.koin.android)
 	implementation(libs.androidx.security.crypto)
@@ -340,9 +338,6 @@ dependencies {
 
     // Pebble template engine
     implementation("io.pebbletemplates:pebble:4.1.1")
-
-    // Jackson JSON parsing dependency
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
 }
 
 tasks.register("downloadDocDb") {

--- a/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
+++ b/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
@@ -27,7 +27,13 @@ import java.util.concurrent.ConcurrentHashMap
 import io.pebbletemplates.pebble.template.PebbleTemplate
 import android.os.Environment.getExternalStorageDirectory
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.TypeAdapter
+import com.google.gson.TypeAdapterFactory
 import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken
+import com.google.gson.stream.JsonWriter
 import okio.ByteString.Companion.toByteString
 
 
@@ -70,7 +76,23 @@ class WebServer(private val config: ServerConfig) {
     private          val brotliCompression  : String  = "br"
     private          val pebbleEngine = PebbleEngine.Builder().loader(StringLoader()).build()
     private          val templateCache = ConcurrentHashMap<Int, PebbleTemplate>()
-    private          val gson = Gson()
+    private          val gson: Gson = GsonBuilder()
+        .registerTypeAdapterFactory(object : TypeAdapterFactory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T>? {
+                if (type.rawType != Any::class.java) return null
+                val delegate = gson.getDelegateAdapter(this, type)
+                return object : TypeAdapter<T>() {
+                    override fun write(out: JsonWriter, value: T?) = delegate.write(out, value)
+                    override fun read(inp: JsonReader): T? {
+                        if (inp.peek() != JsonToken.NUMBER) return delegate.read(inp)
+                        val s = inp.nextString()
+                        return (if ('.' in s) s.toDouble() else s.toLong()) as T
+                    }
+                }
+            }
+        })
+        .create()
     private          val dbContextType = object : TypeToken<Map<String, Any>>() {}.type
     private          var bookshelfTemplateId : Int = -1;
     private          val HTTP_INTERNAL_SERVER_ERROR = 500
@@ -453,7 +475,10 @@ class WebServer(private val config: ServerConfig) {
         }
 
         // Load JSON data into a template context Map<> for instantiation
-        val context: Map<String, Any> = gson.fromJson(dbContent.toString(Charsets.UTF_8), dbContextType)
+        val dbContentStr = dbContent.toString(Charsets.UTF_8)
+        if (dbContentStr.isBlank() || dbContentStr.trim() == "null")
+            throw Exception("Template ID $templateId has empty or null JSON context")
+        val context: Map<String, Any> = gson.fromJson(dbContentStr, dbContextType)
 
         // Evaluate template with loaded data and return the output
         val sw = StringWriter()

--- a/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
+++ b/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
@@ -28,12 +28,8 @@ import io.pebbletemplates.pebble.template.PebbleTemplate
 import android.os.Environment.getExternalStorageDirectory
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import com.google.gson.TypeAdapter
-import com.google.gson.TypeAdapterFactory
+import com.google.gson.ToNumberPolicy
 import com.google.gson.reflect.TypeToken
-import com.google.gson.stream.JsonReader
-import com.google.gson.stream.JsonToken
-import com.google.gson.stream.JsonWriter
 import okio.ByteString.Companion.toByteString
 
 
@@ -76,22 +72,8 @@ class WebServer(private val config: ServerConfig) {
     private          val brotliCompression  : String  = "br"
     private          val pebbleEngine = PebbleEngine.Builder().loader(StringLoader()).build()
     private          val templateCache = ConcurrentHashMap<Int, PebbleTemplate>()
-    private          val gson: Gson = GsonBuilder()
-        .registerTypeAdapterFactory(object : TypeAdapterFactory {
-            @Suppress("UNCHECKED_CAST")
-            override fun <T> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T>? {
-                if (type.rawType != Any::class.java) return null
-                val delegate = gson.getDelegateAdapter(this, type)
-                return object : TypeAdapter<T>() {
-                    override fun write(out: JsonWriter, value: T?) = delegate.write(out, value)
-                    override fun read(inp: JsonReader): T? {
-                        if (inp.peek() != JsonToken.NUMBER) return delegate.read(inp)
-                        val s = inp.nextString()
-                        return (if ('.' in s) s.toDouble() else s.toLong()) as T
-                    }
-                }
-            }
-        })
+    private val gson: Gson = GsonBuilder()
+        .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
         .create()
     private          val dbContextType = object : TypeToken<Map<String, Any>>() {}.type
     private          var bookshelfTemplateId : Int = -1;

--- a/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
+++ b/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
@@ -25,10 +25,9 @@ import io.pebbletemplates.pebble.PebbleEngine
 import io.pebbletemplates.pebble.loader.StringLoader
 import java.util.concurrent.ConcurrentHashMap
 import io.pebbletemplates.pebble.template.PebbleTemplate
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import android.os.Environment.getExternalStorageDirectory
-import kotlinx.serialization.builtins.UByteArraySerializer
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import okio.ByteString.Companion.toByteString
 
 
@@ -452,8 +451,7 @@ class WebServer(private val config: ServerConfig) {
         }
 
         // Load JSON data into a template context Map<> for instantiation
-        val mapper = ObjectMapper()
-        val context: Map<String, Any> = mapper.readValue(dbContent.toString(Charsets.UTF_8), object : TypeReference<Map<String, Any>>() {})
+        val context: Map<String, Any> = Gson().fromJson(dbContent.toString(Charsets.UTF_8), object : TypeToken<Map<String, Any>>() {}.type)
 
         // Evaluate template with loaded data and return the output
         val sw = StringWriter()

--- a/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
+++ b/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt
@@ -70,6 +70,8 @@ class WebServer(private val config: ServerConfig) {
     private          val brotliCompression  : String  = "br"
     private          val pebbleEngine = PebbleEngine.Builder().loader(StringLoader()).build()
     private          val templateCache = ConcurrentHashMap<Int, PebbleTemplate>()
+    private          val gson = Gson()
+    private          val dbContextType = object : TypeToken<Map<String, Any>>() {}.type
     private          var bookshelfTemplateId : Int = -1;
     private          val HTTP_INTERNAL_SERVER_ERROR = 500
     private          val HTTP_NOT_FOUND = 404
@@ -451,7 +453,7 @@ class WebServer(private val config: ServerConfig) {
         }
 
         // Load JSON data into a template context Map<> for instantiation
-        val context: Map<String, Any> = Gson().fromJson(dbContent.toString(Charsets.UTF_8), object : TypeToken<Map<String, Any>>() {}.type)
+        val context: Map<String, Any> = gson.fromJson(dbContent.toString(Charsets.UTF_8), dbContextType)
 
         // Evaluate template with loaded data and return the output
         val sw = StringWriter()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,6 @@ buildscript {
 	dependencies {
 		classpath(libs.kotlin.gradle.plugin)
 		classpath(libs.nav.safe.args.gradle.plugin)
-		classpath(libs.kotlin.serialization.plugin)
 	}
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,6 @@ koinAndroid = "4.1.1"
 kotlin = "2.3.0"
 kotlin-coroutines = "1.9.0"
 kotlinxCoroutinesCore = "1.10.2"
-kotlinxSerializationJson = "1.9.0"
 lifecycleViewmodelKtx = "2.7.0"
 paletteKtx = "1.0.0"
 playServicesOssLicenses = "17.1.0"
@@ -128,7 +127,6 @@ google-genai = { module = "com.google.genai:google-genai", version.ref = "google
 gson-v2101 = { module = "com.google.code.gson:gson", version.ref = "gson" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koinAndroid" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 
@@ -307,7 +305,6 @@ tooling-slf4j = { module = "org.slf4j:slf4j-api", version = "2.0.12" }
 # Classpaths
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin-serialization-plugin = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 nav-safe-args-gradle-plugin = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "androidx-navigation" }
 maven-publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish-plugin" }
 androidx-monitor = { group = "androidx.test", name = "monitor", version.ref = "monitor" }


### PR DESCRIPTION
## Summary

- Gson was already the project-wide JSON library (24 source files across 11 modules); Jackson and kotlinx.serialization were redundant
- Replaced the single Jackson `ObjectMapper.readValue()` call in `WebServer.kt` with the Gson equivalent (`Gson().fromJson()`)
- Removed the `kotlinx.serialization` compiler plugin and runtime dependency — it was declared but had zero actual usages (one dead import)
- Cleaned up all three orphaned kotlinx.serialization entries from `libs.versions.toml`

## Test plan

- [x] Project builds without errors
- [x] Web server JSON parsing works (DB dump → Pebble template context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)