### PR TITLE
ADFA-4184: Fix run-shell-injection risk in debug.yml Extract Jira step

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -251,6 +251,11 @@ jobs:
         env:
           COMMIT_MSG: ${{ steps.pr_info.outputs.COMMIT_MSG }}
           BRANCH_TYPE: ${{ needs.validate_branch.outputs.branch_type }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          REF: ${{ github.ref }}
         run: |
           if [[ "$BRANCH_TYPE" == "community" ]]; then
             echo "Community branch, skipping Jira ticket extraction"
@@ -268,9 +273,9 @@ jobs:
             JIRA_URL="https://appdevforall.atlassian.net/browse/${JIRA_TICKET}"
           
             # Fetch Jira ticket title if credentials are available
-            if [ -n "${{ secrets.JIRA_EMAIL }}" ] && [ -n "${{ secrets.JIRA_API_TOKEN }}" ]; then
+            if [ -n "$JIRA_EMAIL" ] && [ -n "$JIRA_API_TOKEN" ]; then
               JIRA_TITLE=$(curl -s \
-                -u "${{ secrets.JIRA_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}" \
+                -u "$JIRA_EMAIL:$JIRA_API_TOKEN" \
                 -H "Accept: application/json" \
                 "https://appdevforall.atlassian.net/rest/api/3/issue/${JIRA_TICKET}?fields=summary" \
                 | jq -r '.fields.summary // ""' 2>/dev/null || echo "")
@@ -285,7 +290,7 @@ jobs:
           else
             JIRA_TICKET="N/A"
             JIRA_TITLE="$COMMIT_MSG"
-            JIRA_URL="https://github.com/${{ github.repository }}/commit/${{ github.sha }} (Ref: ${{ github.ref }})"
+            JIRA_URL="https://github.com/${REPO}/commit/${SHA} (Ref: ${REF})"
           fi
 
           echo "JIRA_TICKET=$JIRA_TICKET" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fixes the Semgrep `run-shell-injection` finding ([ADFA-4184](https://appdevforall.atlassian.net/browse/ADFA-4184)) in `.github/workflows/debug.yml`.

The **Extract Jira Ticket and Fetch Title** step interpolated `github` context (`github.repository`, `github.sha`, `github.ref`) and `secrets.*` directly into its `run:` script. Those values are derived from attacker-controllable branch names / commit messages, so a crafted value could inject shell code on the self-hosted runner and exfiltrate secrets.

## Change

Move every `${{ ... }}` interpolation out of the script into the step's `env:` block, and reference them as double-quoted shell variables (`"$JIRA_EMAIL"`, `${REPO}`, etc.) — the pattern Semgrep and the ticket prescribe. One step touched, +8/-3.

## Verification

- `semgrep --config p/github-actions .github/workflows/debug.yml` → **0** `run-shell-injection` findings (was 1, spanning the step's `run:` block).
- Workflow YAML parses cleanly.

## Scope

Semgrep's rule flags only `github`-context interpolation in `run:`, and this was the sole finding, so this single-step change fully closes the ticket. Other steps interpolate `steps.*.outputs` / `env.*` inline (not flagged by the rule); hardening those for consistency is left as a possible follow-up.


[ADFA-4184]: https://appdevforall.atlassian.net/browse/ADFA-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ