### PR TITLE
ADFA-4705: Link the created Jira key back into the GitHub issue

### DIFF
--- a/.github/workflows/gh2jira.yml
+++ b/.github/workflows/gh2jira.yml
@@ -9,7 +9,11 @@ jobs:
   create_jira_ticket:
     # Use the latest stable Ubuntu runner environment.
     runs-on: ubuntu-latest
-    
+
+    # Needed so the write-back step can comment on the originating issue.
+    permissions:
+      issues: write
+
     # We use a third-party action, so we must first authenticate to Jira.
     steps:
       - name: Login to Jira
@@ -36,3 +40,11 @@ jobs:
 
       - name: Log created issue
         run: echo "Issue ${{ steps.create.outputs.issue }} was created"
+
+      - name: Comment Jira link on GitHub issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "Tracked in Jira: [${{ steps.create.outputs.issue }}](https://appdevforall.atlassian.net/browse/${{ steps.create.outputs.issue }})"


### PR DESCRIPTION
## What

Make the gh2jira link bidirectional. The `Create Jira Ticket on New Issue` workflow already stamps a GitHub link into the Jira ticket's description, but nothing pointed back the other way — someone reading the GitHub issue had no pointer to the Jira ticket tracking it.

This adds a write-back step that comments the new Jira key on the originating GitHub issue.

## How

- New **Comment Jira link on GitHub issue** step, reusing the existing `steps.create.outputs.issue` output and the runner's built-in `gh` CLI (no new action or auth).
- Grant the job `permissions: issues: write` so `gh issue comment` can post.
- The existing `Log created issue` echo step is kept as-is.

The comment renders as: `Tracked in Jira: [ADFA-####](https://appdevforall.atlassian.net/browse/ADFA-####)`.

## Verification

- YAML parses (`yaml.safe_load`).
- End-to-end is inherently CI-only: open a throwaway issue and confirm (a) the Jira Story is created as today, and (b) a "Tracked in Jira: ADFA-####" comment appears on the issue within a few seconds.

Jira: ADFA-4705
