### PR TITLE
ADFA-4816: Prune excluded dirs during Spotless traversal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -297,7 +297,9 @@ spotless {
 
 		target(
 			fileTree(rootDir) {
-				include("**/.gitignore", "**/.gradle")
+				// `.gradle` is only ever a cache directory (pruned via
+				// traversalExcludes), never a formattable file -- so only .gitignore.
+				include("**/.gitignore")
 				exclude(*commonTargetExcludes)
 				exclude(*traversalExcludes)
 				exclude(*buildOutputExcludes)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,6 +140,37 @@ spotless {
 			"termux/**/*",
 		)
 
+	// Directories to PRUNE during the file-tree walk. Spotless auto-prunes
+	// .git/.gradle/build for string-glob targets, but that is bypassed once a
+	// fileTree is passed to target(), so we restore them here. `flox` is the
+	// ADFA-4816 fix: flox/*/.flox/run/* symlinks into /nix/store (millions of
+	// files) made spotlessCheck take 12+ minutes.
+	// Bare directory names are REQUIRED -- Gradle prunes a subtree only when an
+	// exclude matches the directory node itself; a `dir/**` glob matches the
+	// dir's CONTENTS and makes Gradle descend-and-filter (no pruning).
+	val traversalExcludes =
+		arrayOf(
+			"flox",
+			"**/.flox",
+			"**/.git",
+			"**/.gradle",
+		)
+
+	// Real Gradle build-output dirs (root + every subproject), relative to
+	// rootDir -- mirrors Spotless's own auto-exclude. Deliberately NOT
+	// "**/build": source packages named `build` exist (e.g.
+	// app/src/main/java/.../actions/build) and "**/build" would drop them.
+	val buildOutputExcludes =
+		allprojects
+			.map {
+				it.layout.buildDirectory
+					.get()
+					.asFile
+					.relativeTo(rootDir)
+					.invariantSeparatorsPath
+			}.filter { it.isNotEmpty() && !it.startsWith("..") }
+			.toTypedArray()
+
 	// ALWAYS use line feeds (LF -- '\n')
 	lineEndings = LineEnding.UNIX
 
@@ -181,8 +212,14 @@ spotless {
 			},
 		)
 
-		target("**/src/*/java/**/*.java")
-		targetExclude(*commonTargetExcludes)
+		target(
+			fileTree(rootDir) {
+				include("**/src/*/java/**/*.java")
+				exclude(*commonTargetExcludes)
+				exclude(*traversalExcludes)
+				exclude(*buildOutputExcludes)
+			},
+		)
 	}
 
 	kotlin {
@@ -197,10 +234,16 @@ spotless {
 		endWithNewline()
 
 		target(
-			"**/src/*/java/**/*.kt",
-			"**/src/*/kotlin/**/*.kt",
+			fileTree(rootDir) {
+				include(
+					"**/src/*/java/**/*.kt",
+					"**/src/*/kotlin/**/*.kt",
+				)
+				exclude(*commonTargetExcludes)
+				exclude(*traversalExcludes)
+				exclude(*buildOutputExcludes)
+			},
 		)
-		targetExclude(*commonTargetExcludes)
 
 		suppressLintsFor {
 			// suppress the 'file name <some-file> should conform PascalCase' errors
@@ -215,8 +258,14 @@ spotless {
 		trimTrailingWhitespace()
 		endWithNewline()
 
-		target("**/*.gradle.kts")
-		targetExclude(*commonTargetExcludes)
+		target(
+			fileTree(rootDir) {
+				include("**/*.gradle.kts")
+				exclude(*commonTargetExcludes)
+				exclude(*traversalExcludes)
+				exclude(*buildOutputExcludes)
+			},
+		)
 	}
 
 	format("xml") {
@@ -227,13 +276,18 @@ spotless {
 		trimTrailingWhitespace()
 		endWithNewline()
 
-		target("**/src/*/res/**/*.xml")
-		targetExclude(*commonTargetExcludes)
-
-		// Formatting strings.xml with Eclipse WTP causes the strings to be
-		// split into multiple lines, which is not what we want.
-		// Exclude strings.xml from this rule.
-		targetExclude("**/src/*/res/values*/strings.xml")
+		target(
+			fileTree(rootDir) {
+				include("**/src/*/res/**/*.xml")
+				exclude(*commonTargetExcludes)
+				exclude(*traversalExcludes)
+				exclude(*buildOutputExcludes)
+				// Formatting strings.xml with Eclipse WTP causes the strings to be
+				// split into multiple lines, which is not what we want.
+				// Exclude strings.xml from this rule.
+				exclude("**/src/*/res/values*/strings.xml")
+			},
+		)
 	}
 
 	format("misc") {
@@ -241,8 +295,14 @@ spotless {
 		trimTrailingWhitespace()
 		endWithNewline()
 
-		target("**/.gitignore", "**/.gradle")
-		targetExclude(*commonTargetExcludes)
+		target(
+			fileTree(rootDir) {
+				include("**/.gitignore", "**/.gradle")
+				exclude(*commonTargetExcludes)
+				exclude(*traversalExcludes)
+				exclude(*buildOutputExcludes)
+			},
+		)
 	}
 
 	shell {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,14 +140,13 @@ spotless {
 			"termux/**/*",
 		)
 
-	// Directories to PRUNE during the file-tree walk. Spotless auto-prunes
-	// .git/.gradle/build for string-glob targets, but that is bypassed once a
-	// fileTree is passed to target(), so we restore them here. `flox` is the
-	// ADFA-4816 fix: flox/*/.flox/run/* symlinks into /nix/store (millions of
-	// files) made spotlessCheck take 12+ minutes.
-	// Bare directory names are REQUIRED -- Gradle prunes a subtree only when an
-	// exclude matches the directory node itself; a `dir/**` glob matches the
-	// dir's CONTENTS and makes Gradle descend-and-filter (no pruning).
+	// Dirs to PRUNE during the walk. Passing a fileTree to target() bypasses
+	// Spotless's auto-prune of .git/.gradle/build, so restore them. flox is the
+	// ADFA-4816 fix: its /nix/store symlinks (millions of files) made
+	// spotlessCheck take 12+ minutes.
+	// Bare dir names required: Gradle prunes a subtree only when an exclude
+	// matches the dir node itself; `dir/**` matches contents and forces a
+	// descend-and-filter (no pruning).
 	val traversalExcludes =
 		arrayOf(
 			"flox",
@@ -156,10 +155,9 @@ spotless {
 			"**/.gradle",
 		)
 
-	// Real Gradle build-output dirs (root + every subproject), relative to
-	// rootDir -- mirrors Spotless's own auto-exclude. Deliberately NOT
+	// Gradle build-output dirs (root + subprojects), relative to rootDir. Not
 	// "**/build": source packages named `build` exist (e.g.
-	// app/src/main/java/.../actions/build) and "**/build" would drop them.
+	// app/src/main/java/.../actions/build) and would be dropped.
 	val buildOutputExcludes =
 		allprojects
 			.map {
@@ -170,6 +168,19 @@ spotless {
 					.invariantSeparatorsPath
 			}.filter { it.isNotEmpty() && !it.startsWith("..") }
 			.toTypedArray()
+
+	// Target tree with the shared excludes applied; format-specific ones go in
+	// extraExcludes.
+	fun spotlessTarget(
+		vararg includes: String,
+		extraExcludes: Array<String> = emptyArray(),
+	) = fileTree(rootDir) {
+		include(*includes)
+		exclude(*commonTargetExcludes)
+		exclude(*traversalExcludes)
+		exclude(*buildOutputExcludes)
+		exclude(*extraExcludes)
+	}
 
 	// ALWAYS use line feeds (LF -- '\n')
 	lineEndings = LineEnding.UNIX
@@ -212,14 +223,7 @@ spotless {
 			},
 		)
 
-		target(
-			fileTree(rootDir) {
-				include("**/src/*/java/**/*.java")
-				exclude(*commonTargetExcludes)
-				exclude(*traversalExcludes)
-				exclude(*buildOutputExcludes)
-			},
-		)
+		target(spotlessTarget("**/src/*/java/**/*.java"))
 	}
 
 	kotlin {
@@ -234,15 +238,10 @@ spotless {
 		endWithNewline()
 
 		target(
-			fileTree(rootDir) {
-				include(
-					"**/src/*/java/**/*.kt",
-					"**/src/*/kotlin/**/*.kt",
-				)
-				exclude(*commonTargetExcludes)
-				exclude(*traversalExcludes)
-				exclude(*buildOutputExcludes)
-			},
+			spotlessTarget(
+				"**/src/*/java/**/*.kt",
+				"**/src/*/kotlin/**/*.kt",
+			),
 		)
 
 		suppressLintsFor {
@@ -258,14 +257,7 @@ spotless {
 		trimTrailingWhitespace()
 		endWithNewline()
 
-		target(
-			fileTree(rootDir) {
-				include("**/*.gradle.kts")
-				exclude(*commonTargetExcludes)
-				exclude(*traversalExcludes)
-				exclude(*buildOutputExcludes)
-			},
-		)
+		target(spotlessTarget("**/*.gradle.kts"))
 	}
 
 	format("xml") {
@@ -276,17 +268,12 @@ spotless {
 		trimTrailingWhitespace()
 		endWithNewline()
 
+		// Eclipse WTP splits strings.xml entries across lines, so exclude it.
 		target(
-			fileTree(rootDir) {
-				include("**/src/*/res/**/*.xml")
-				exclude(*commonTargetExcludes)
-				exclude(*traversalExcludes)
-				exclude(*buildOutputExcludes)
-				// Formatting strings.xml with Eclipse WTP causes the strings to be
-				// split into multiple lines, which is not what we want.
-				// Exclude strings.xml from this rule.
-				exclude("**/src/*/res/values*/strings.xml")
-			},
+			spotlessTarget(
+				"**/src/*/res/**/*.xml",
+				extraExcludes = arrayOf("**/src/*/res/values*/strings.xml"),
+			),
 		)
 	}
 
@@ -295,16 +282,8 @@ spotless {
 		trimTrailingWhitespace()
 		endWithNewline()
 
-		target(
-			fileTree(rootDir) {
-				// `.gradle` is only ever a cache directory (pruned via
-				// traversalExcludes), never a formattable file -- so only .gitignore.
-				include("**/.gitignore")
-				exclude(*commonTargetExcludes)
-				exclude(*traversalExcludes)
-				exclude(*buildOutputExcludes)
-			},
-		)
+		// Only .gitignore; `.gradle` is a cache dir, pruned via traversalExcludes.
+		target(spotlessTarget("**/.gitignore"))
 	}
 
 	shell {


### PR DESCRIPTION
## Problem

`spotlessCheck` takes 12+ minutes on machines with an *activated* flox environment, and seconds elsewhere. Spotless targets use root-relative `**/` globs with `targetExclude(...)`, which filters matches **after** Gradle has already walked the whole tree — including `flox/*/.flox/run/*` symlinks into `/nix/store` (measured 8.8M files on Linux). The daemon OOMs.

Fixes [ADFA-4816](https://appdevforall.atlassian.net/browse/ADFA-4816).

## Fix

Convert each `**/`-glob block (java, kotlin, kotlinGradle, xml, misc) from `target("**/glob")` + `targetExclude(...)` to `target(fileTree(rootDir) { include(...); exclude(...) })`, so excludes **prune directories during traversal** instead of subtracting after the walk (`FormatExtension` does `target.minus(targetExclude)` post-walk).

## Two things the naive fix gets wrong

Research against Spotless 8.8.0 + Gradle's walker corrected the ticket's proposed exclude list:

1. **`dir/**` does not prune — it descends and filters.** Gradle's `PathVisitor.preVisitDirectory` returns `SKIP_SUBTREE` only when the exclude matches the **directory node itself**. `flox/**` matches flox's *contents*, so Gradle still walks in. Spotless's own auto-excludes use **bare names** for this reason. → excludes here use `flox`, `**/.flox`, `**/.git`, `**/.gradle`.
2. **`**/build` would drop real source.** Source packages named `build` exist (e.g. `app/src/main/java/.../actions/build/DebugAction.kt`); bare `**/build` prunes them. → build outputs are excluded via each project's `buildDirectory` (exactly what Spotless does today), which never collide with `src/.../build` packages.

`commonTargetExcludes` moved onto the include-tree (prunes those large vendored dirs during the walk too). `shell` is unchanged — its targets are literal-prefixed, so Gradle already prunes without a full walk.

## Behavior change

The two tracked `flox/{base,local}/.flox/.gitignore` files leave the `misc` target set. Both already conform (no leading spaces, no trailing whitespace, final newline), so the violation set is unchanged.

## Verification (local, macOS)

- ✅ Config resolves; `spotlessCheck` passes on a clean tree.
- ✅ Still catches violations — flags trailing whitespace added to a tracked `.kt` under `app/src/`.
- ✅ **Source package named `build` is NOT dropped** — `app/src/main/java/.../actions/build/*.kt` is still flagged when dirtied (proves `buildOutputExcludes` targets only real output dirs).
- The Linux/nix-store speedup (acceptance criterion #1, <1 min) is exercised by CI: `.github/workflows/debug.yml` runs `flox activate -d flox/base -- ./gradlew spotlessCheck --no-daemon`.

## Out of scope (follow-ups from the ticket, to be filed separately)

Pre-push hook scoping to changed files; `origin/stage` ratchet-ref freshness; the dead Sentry Gradle plugin.


[ADFA-4816]: https://appdevforall.atlassian.net/browse/ADFA-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ