### PR TITLE
fix: localize plugin manager empty state

### DIFF
--- a/app/src/main/res/layout/activity_plugin_manager.xml
+++ b/app/src/main/res/layout/activity_plugin_manager.xml
@@ -54,7 +54,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="8dp"
-                android:text="No plugins installed"
+                android:text="@string/no_plugins_installed"
                 android:textAppearance="?attr/textAppearanceHeadline6" />
 
             <TextView


### PR DESCRIPTION
## Summary

- replace the plugin manager's hard-coded empty-state label with the existing `no_plugins_installed` string resource
- allow Android to use the Indonesian translation already provided for that resource

## Validation

- parsed the affected layout and verified it references `@string/no_plugins_installed`
- verified the resource exists in both the default and Indonesian resource files
- `git diff --check origin/stage...HEAD`

The full Android build was not run locally because the repository's required `flox` environment is unavailable; it is deferred to CI.

Fixes #1561
