### PR TITLE
ADFA-4841: Fix trivial build warnings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,7 +67,7 @@
         android:theme="@style/Theme.AndroidIDE"
         android:usesCleartextTraffic="true"
         tools:ignore="DiscouragedApi,MediaCapabilities,UnusedAttribute"
-        tools:replace="android:icon,android:name,android:allowBackup, android:supportsRtl, android:theme">
+        tools:replace="android:supportsRtl,android:theme">
         <activity
             android:name=".activities.CrashHandlerActivity"
             android:exported="true"

--- a/resources/src/main/res/values-ar-rSA/strings.xml
+++ b/resources/src/main/res/values-ar-rSA/strings.xml
@@ -242,7 +242,6 @@
   <string name="idepref_buildnrun_summary">تكوين بناء Gradle.</string>
   <string name="configure">تهيئة</string>
   <string name="about">عن التطبيق</string>
-  <string name="idepref_github_summary">Code on the Go مفتوح المصدر!</string>
   <string name="idepref_channel_summary">اشترك للحصول على أحدث تحديثات.</string>
   <string name="idepref_group_summary">مناقشة الميزات، الأخطاء والتحسينات هنا.</string>
   <string name="idepref_changelog_summary">ما الجديد في هذا الإصدار؟ </string>
@@ -340,12 +339,6 @@
   <string name="msg_tasks_to_run">سيتم تشغيل المهام التالية، بالترتيب. انقر فوق الزر \'تشغيل\' مرة أخرى للتأكيد.\n\n%1$s</string>
   <string name="msg_loading_tasks">جارٍ تحميل المهام...</string>
   <!-- GIT -->
-  <string name="git_clone">نسخ</string>
-  <string name="git_clone_repo">نسخ مشروع Git</string>
-  <string name="git_clone_repo_url">رابط المشروع</string>
-  <string name="git_clone_in_progress">نسخ مشروع Git...</string>
-  <string name="git_clone_success">تم نسخ مشروع Git بنجاح</string>
-  <string name="git_clone_failed">فشل في استنساخ مشروع git</string>
   <string name="msg_select_attr">حدد سمة من القائمة أدناه</string>
   <string name="action_show_hierarchy">عرض التسلسل الهرمي للتخطيط</string>
   <string name="idepref_editor_colorScheme">نظام الألوان</string>

--- a/resources/src/main/res/values-bn-rIN/strings.xml
+++ b/resources/src/main/res/values-bn-rIN/strings.xml
@@ -242,7 +242,6 @@
   <string name="idepref_buildnrun_summary">Gradle বিল্ড কনফিগার করুন।</string>
   <string name="configure">কনফিগার করুন</string>
   <string name="about">সম্বন্ধে</string>
-  <string name="idepref_github_summary">Code on the Go হল ওপেন সোর্স!</string>
   <string name="idepref_channel_summary">সাম্প্রতিক আপডেটের জন্য সাবস্ক্রাইব করুন।</string>
   <string name="idepref_group_summary">এখানে বৈশিষ্ট্য, বাগ এবং উন্নতি নিয়ে আলোচনা করুন৷</string>
   <string name="idepref_changelog_summary">এই সংস্করণে নতুন কি আছে?</string>
@@ -340,12 +339,6 @@
   <string name="msg_tasks_to_run">নিম্নলিখিত প্রক্রিয়া গুলি চালানো হবে, ক্রমানুসারে। নিশ্চিত করার জন্য \'Run\' বাটনটিতে আবার ক্লিক করুন.\n\n%1$s</string>
   <string name="msg_loading_tasks">প্রক্রিয়া লোড করা হচ্ছে...</string>
   <!-- GIT -->
-  <string name="git_clone">ক্লোন</string>
-  <string name="git_clone_repo">গিট রেপোসিটরি ক্লোন করুন</string>
-  <string name="git_clone_repo_url">রেপোসিটরি URL</string>
-  <string name="git_clone_in_progress">রেপোসিটরি ক্লোন করা হচ্ছে</string>
-  <string name="git_clone_success">গিট ক্লোন সফল হয়েছে</string>
-  <string name="git_clone_failed">গিট রেপোসিটরি ক্লোন করতে ব্যর্থ</string>
   <string name="msg_select_attr">নীচের লিস্ট থেকে অ্যাট্রিবিউট নির্বাচন করুন</string>
   <string name="action_show_hierarchy">লেআউট-এর শ্রেণিবিন্যাস দেখান</string>
   <string name="idepref_editor_colorScheme">কালার স্কিম</string>

--- a/resources/src/main/res/values-de-rDE/strings.xml
+++ b/resources/src/main/res/values-de-rDE/strings.xml
@@ -241,7 +241,6 @@
   <string name="idepref_buildnrun_summary">Gradle-Build konfigurieren.</string>
   <string name="configure">Konfigurieren</string>
   <string name="about">Über</string>
-  <string name="idepref_github_summary">AndriodIDE ist Open Source!</string>
   <string name="idepref_channel_summary">Abonnieren sie für die neuesten Updates.</string>
   <string name="idepref_group_summary">Diskutieren Sie hier über Features, Bugs und Verbesserungen.</string>
   <string name="idepref_changelog_summary">Was ist neu in der Version?</string>
@@ -339,12 +338,6 @@
   <string name="msg_tasks_to_run">Die folgenden Aufgaben werden in der Reihenfolge ausgeführt. Zum Bestätigen erneut auf \'Ausführen\' klicken.\n\n%1$s</string>
   <string name="msg_loading_tasks">Aufgaben werden geladen...</string>
   <!-- GIT -->
-  <string name="git_clone">Klonen</string>
-  <string name="git_clone_repo">Repository klonen</string>
-  <string name="git_clone_repo_url">Repository URL</string>
-  <string name="git_clone_in_progress">Repository wird geklont</string>
-  <string name="git_clone_success">Git Klon erfolgreich</string>
-  <string name="git_clone_failed">Fehler beim Klonen des Git-Repositorys</string>
   <string name="msg_select_attr">Wählen Sie ein Attribut aus der folgenden Liste</string>
   <string name="action_show_hierarchy">Layout Hierarchie anzeigen</string>
   <string name="idepref_editor_colorScheme">Farbschema</string>

--- a/resources/src/main/res/values-es-rES/strings.xml
+++ b/resources/src/main/res/values-es-rES/strings.xml
@@ -242,7 +242,6 @@
   <string name="idepref_buildnrun_summary">Configurar la compilación de Gradle.</string>
   <string name="configure">Configurar</string>
   <string name="about">Acerca de</string>
-  <string name="idepref_github_summary">¡Code on the Go es de código abierto!</string>
   <string name="idepref_channel_summary">Suscríbete para las últimas actualizaciones.</string>
   <string name="idepref_group_summary">Discuta las funcionalidades, bugs y mejoras aquí.</string>
   <string name="idepref_changelog_summary">¿Qué hay de nuevo?</string>
@@ -340,12 +339,6 @@
   <string name="msg_tasks_to_run">Las siguientes tareas se ejecutarán, en orden. Haga clic en el botón \'Ejecutar\' otra vez para confirmar.\n\n%1$s</string>
   <string name="msg_loading_tasks">Cargando tareas...</string>
   <!-- GIT -->
-  <string name="git_clone">Clonar</string>
-  <string name="git_clone_repo">Clonar repositorio git</string>
-  <string name="git_clone_repo_url">URL del repositorio</string>
-  <string name="git_clone_in_progress">Clonando repositorio</string>
-  <string name="git_clone_success">Clon de Git exitoso</string>
-  <string name="git_clone_failed">Error al clonar el repositorio git</string>
   <string name="msg_select_attr">Seleccione un atributo de la lista de abajo</string>
   <string name="action_show_hierarchy">Mostrar jerarquía de diseño</string>
   <string name="idepref_editor_colorScheme">Paleta de colores</string>

--- a/resources/src/main/res/values-fr-rFR/strings.xml
+++ b/resources/src/main/res/values-fr-rFR/strings.xml
@@ -243,7 +243,6 @@ Dernier projet ouvert : \n%s</string>
   <string name="idepref_buildnrun_summary">Configure the Gradle build.</string>
   <string name="configure">Configure</string>
   <string name="about">À propos</string>
-  <string name="idepref_github_summary">Code on the Go est open source !</string>
   <string name="idepref_channel_summary">Subscribe for latest updates.</string>
   <string name="idepref_group_summary">Discuss featues, bugs and improvements here.</string>
   <string name="idepref_changelog_summary">What\'s new in this version?</string>
@@ -341,12 +340,6 @@ Dernier projet ouvert : \n%s</string>
   <string name="msg_tasks_to_run">The following tasks will be run, in order. Click the \'Run\' button again to confirm.\n\n%1$s</string>
   <string name="msg_loading_tasks">Loading tasks...</string>
   <!-- GIT -->
-  <string name="git_clone">Clone</string>
-  <string name="git_clone_repo">Clone git repository</string>
-  <string name="git_clone_repo_url">Repository URL</string>
-  <string name="git_clone_in_progress">Cloning repository</string>
-  <string name="git_clone_success">Git clone successful</string>
-  <string name="git_clone_failed">Failed to clone git repository</string>
   <string name="msg_select_attr">Select an attribute from the below list</string>
   <string name="action_show_hierarchy">Show layout hierarchy</string>
   <string name="idepref_editor_colorScheme">Color Scheme</string>

--- a/resources/src/main/res/values-hi-rIN/strings.xml
+++ b/resources/src/main/res/values-hi-rIN/strings.xml
@@ -241,7 +241,6 @@
   <string name="idepref_buildnrun_summary">ग्रेडल बिल्ड को कॉन्फ़िगर करें।</string>
   <string name="configure">कॉन्फ़िगर</string>
   <string name="about">विवरण</string>
-  <string name="idepref_github_summary">Code on the Go ओपन सोर्स है!</string>
   <string name="idepref_channel_summary">नवीनतम अपडेट के लिए सदस्यता लें |</string>
   <string name="idepref_group_summary">सुविधाओं, बगों और सुधारों पर यहां चर्चा करें।</string>
   <string name="idepref_changelog_summary">इस वर्शन में क्या नया है?</string>
@@ -339,12 +338,6 @@
   <string name="msg_tasks_to_run">क्रमानुसार निम्न कार्य चलाये जायेंगे। पुष्टि करने के लिए \'चलाएं\' बटन पर फिर से क्लिक करें.\n\n%1$s</string>
   <string name="msg_loading_tasks">टास्क लोड हो रहे हैं...</string>
   <!-- GIT -->
-  <string name="git_clone">क्लोन</string>
-  <string name="git_clone_repo">Git रिपॉजिटरी क्लोन करें</string>
-  <string name="git_clone_repo_url">रिपॉजिटरी URL</string>
-  <string name="git_clone_in_progress">रिपॉजिटरी क्लोन हो रही है</string>
-  <string name="git_clone_success">Git क्लोन सफल हुआ</string>
-  <string name="git_clone_failed">Git रिपॉजिटरी क्लोन करने में विफल</string>
   <string name="msg_select_attr">नीचे दी गई सूची से एक एट्रिब्यूट का चयन करें</string>
   <string name="action_show_hierarchy">लेआउट हायरार्की दिखाएं</string>
   <string name="idepref_editor_colorScheme">कलर स्कीम</string>

--- a/resources/src/main/res/values-pt-rBR/strings.xml
+++ b/resources/src/main/res/values-pt-rBR/strings.xml
@@ -242,7 +242,6 @@
   <string name="idepref_buildnrun_summary">Configurar a compilação do Gradle.</string>
   <string name="configure">Configurações</string>
   <string name="about">Sobre</string>
-  <string name="idepref_github_summary">Code on the Go é de código aberto!</string>
   <string name="idepref_channel_summary">Inscreva-se para receber as últimas atualizações.</string>
   <string name="idepref_group_summary">Discuta aqui recursos, bugs e melhorias.</string>
   <string name="idepref_changelog_summary">O que há de novo nesta versão?</string>
@@ -340,12 +339,6 @@
   <string name="msg_tasks_to_run">As seguintes tarefas serão executadas, em ordem. Clique no botão \'Executar\' novamente para confirmar.\n\n%1$s</string>
   <string name="msg_loading_tasks">Carregando tarefas...</string>
   <!-- GIT -->
-  <string name="git_clone">Clonar</string>
-  <string name="git_clone_repo">Clonar repositório git</string>
-  <string name="git_clone_repo_url">URL do repositório</string>
-  <string name="git_clone_in_progress">Clonando repositório</string>
-  <string name="git_clone_success">Git clonado com sucesso</string>
-  <string name="git_clone_failed">Falha ao clonar repositório git</string>
   <string name="msg_select_attr">Selecione um atributo da lista abaixo</string>
   <string name="action_show_hierarchy">Mostrar hierarquia do layout</string>
   <string name="idepref_editor_colorScheme">Esquema de cores</string>

--- a/resources/src/main/res/values-ro-rRO/strings.xml
+++ b/resources/src/main/res/values-ro-rRO/strings.xml
@@ -242,7 +242,6 @@
   <string name="idepref_buildnrun_summary">Configure the Gradle build.</string>
   <string name="configure">Configure</string>
   <string name="about">About</string>
-  <string name="idepref_github_summary">Code on the Go is open source!</string>
   <string name="idepref_channel_summary">Subscribe for latest updates.</string>
   <string name="idepref_group_summary">Discuss featues, bugs and improvements here.</string>
   <string name="idepref_changelog_summary">What\'s new in this version?</string>
@@ -340,12 +339,6 @@
   <string name="msg_tasks_to_run">Următoarele activități vor fi rulate, în ordine. Faceți clic pe butonul \'Rulare\' pentru confirmare.\n\n%1$s</string>
   <string name="msg_loading_tasks">Încarc sarcinile…</string>
   <!-- GIT -->
-  <string name="git_clone">Clonare</string>
-  <string name="git_clone_repo">CClonează repozitoriu Git</string>
-  <string name="git_clone_repo_url">URL repozitoriu</string>
-  <string name="git_clone_in_progress">Clonează repozitoriu</string>
-  <string name="git_clone_success">Clona Git cu succes</string>
-  <string name="git_clone_failed">Nu a reușit să cloneze depozitul git</string>
   <string name="msg_select_attr">Selectați un atribut din lista de mai jos</string>
   <string name="action_show_hierarchy">Arată ierarhia layout-ului</string>
   <string name="idepref_editor_colorScheme">Schema de culori</string>

--- a/resources/src/main/res/values-ru-rRU/strings.xml
+++ b/resources/src/main/res/values-ru-rRU/strings.xml
@@ -241,7 +241,6 @@
   <string name="idepref_buildnrun_summary">Настройте сборку Gradle.</string>
   <string name="configure">Настройки</string>
   <string name="about">О приложении</string>
-  <string name="idepref_github_summary">Code on the Go - проект с открытым исходным кодом!</string>
   <string name="idepref_channel_summary">Узнавайте о новых обновлениях!</string>
   <string name="idepref_group_summary">Сообщайте об ошибках, предлагайте новые функции и обсуждайте нововведения здесь.</string>
   <string name="idepref_changelog_summary">Что нового в этой версии?</string>
@@ -342,12 +341,6 @@
   <string name="close_without_saving">Закрыть без сохранения файлов</string>
   <string name="save_and_close">Сохранить файлы и закрыть проект</string>
   <!-- GIT -->
-  <string name="git_clone">Клонировать</string>
-  <string name="git_clone_repo">Клонировать репозиторий Git</string>
-  <string name="git_clone_repo_url">URL репозитория</string>
-  <string name="git_clone_in_progress">Клонирования репозитория</string>
-  <string name="git_clone_success">Клонирование Git успешно завершено</string>
-  <string name="git_clone_failed">Ошибка клонирования репозитория Git</string>
   <string name="msg_select_attr">Выберите атрибут из списка ниже</string>
   <string name="action_show_hierarchy">Показать иерархию разметки</string>
   <string name="idepref_editor_colorScheme">Цветовая схема</string>

--- a/resources/src/main/res/values-tr-rTR/strings.xml
+++ b/resources/src/main/res/values-tr-rTR/strings.xml
@@ -242,7 +242,6 @@
   <string name="idepref_buildnrun_summary">Gradle inşasını yapılandırın.</string>
   <string name="configure">Yapılandır</string>
   <string name="about">Hakkında</string>
-  <string name="idepref_github_summary">Code on the Go açık kaynaktır!</string>
   <string name="idepref_channel_summary">Son güncellemeler için abone olun.</string>
   <string name="idepref_group_summary">Özellikleri, sorunları ve iyileştirmeleri burada tartışın.</string>
   <string name="idepref_changelog_summary">Bu sürümde yeni ne var?</string>
@@ -340,12 +339,6 @@
   <string name="msg_tasks_to_run">Takip eden görevler sırayla çalıştırılacak. Tekrar \'Çalıştır\' tuşuna basarak doğrulayın.\n\n%1$s</string>
   <string name="msg_loading_tasks">Görevler yükleniyor...</string>
   <!-- GIT -->
-  <string name="git_clone">Kopya oluştur</string>
-  <string name="git_clone_repo">Git deposu klonla</string>
-  <string name="git_clone_repo_url">Depo Linki</string>
-  <string name="git_clone_in_progress">Depo klonlanıyor</string>
-  <string name="git_clone_success">Depo başarıyla klonlandı</string>
-  <string name="git_clone_failed">Depo klonlama başarısız</string>
   <string name="msg_select_attr">Aşağıdaki listeden bir öznitelik seç</string>
   <string name="action_show_hierarchy">Düzen aşamalarını göster</string>
   <string name="idepref_editor_colorScheme">Renk Şeması</string>

--- a/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/resources/src/main/res/values-zh-rCN/strings.xml
@@ -241,7 +241,6 @@
   <string name="idepref_buildnrun_summary">Gradle 构建配置。</string>
   <string name="configure">配置</string>
   <string name="about">关于</string>
-  <string name="idepref_github_summary">Code on the Go 是开源的！</string>
   <string name="idepref_channel_summary">订阅以获取最新更新</string>
   <string name="idepref_group_summary">在这里讨论功能、错误和改进。</string>
   <string name="idepref_changelog_summary">此版本有什么新内容?</string>
@@ -339,12 +338,6 @@
   <string name="msg_tasks_to_run">将按顺序运行以下任务，再次单击“运行”按钮进行确认。\n\n%1$s</string>
   <string name="msg_loading_tasks">正在加载任务…</string>
   <!-- GIT -->
-  <string name="git_clone">克隆</string>
-  <string name="git_clone_repo">克隆 git 仓库</string>
-  <string name="git_clone_repo_url">存储库 URL</string>
-  <string name="git_clone_in_progress">克隆存储库</string>
-  <string name="git_clone_success">git 克隆成功</string>
-  <string name="git_clone_failed">无法克隆 git 存储库</string>
   <string name="msg_select_attr">从下面的列表中选择一个属性</string>
   <string name="action_show_hierarchy">显示布局层次</string>
   <string name="idepref_editor_colorScheme">配色方案</string>

--- a/subprojects/shizuku-manager/src/main/jni/adb_pairing.cpp
+++ b/subprojects/shizuku-manager/src/main/jni/adb_pairing.cpp
@@ -215,12 +215,12 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         return -1;
 
     JNINativeMethod methods_PairingContext[] = {
-            {"nativeConstructor", "(Z[B)J",  (void *) PairingContext_Constructor},
-            {"nativeMsg",         "(J)[B",   (void *) PairingContext_Msg},
-            {"nativeInitCipher",  "(J[B)Z",  (void *) PairingContext_InitCipher},
-            {"nativeEncrypt",     "(J[B)[B", (void *) PairingContext_Encrypt},
-            {"nativeDecrypt",     "(J[B)[B", (void *) PairingContext_Decrypt},
-            {"nativeDestroy",     "(J)V",    (void *) PairingContext_Destroy},
+            {(char *) "nativeConstructor", (char *) "(Z[B)J",  (void *) PairingContext_Constructor},
+            {(char *) "nativeMsg",         (char *) "(J)[B",   (void *) PairingContext_Msg},
+            {(char *) "nativeInitCipher",  (char *) "(J[B)Z",  (void *) PairingContext_InitCipher},
+            {(char *) "nativeEncrypt",     (char *) "(J[B)[B", (void *) PairingContext_Encrypt},
+            {(char *) "nativeDecrypt",     (char *) "(J[B)[B", (void *) PairingContext_Decrypt},
+            {(char *) "nativeDestroy",     (char *) "(J)V",    (void *) PairingContext_Destroy},
     };
 
     env->RegisterNatives(env->FindClass("moe/shizuku/manager/adb/PairingContext"), methods_PairingContext,


### PR DESCRIPTION
## Summary
Based on the build log for [run 30053583432 / job 89360621449](https://github.com/appdevforall/CodeOnTheGo/actions/runs/30053583432/job/89360621449?pr=1570), which had 4,409 warning lines. Three genuinely trivial fixes:

- Trim `tools:replace` in `AndroidManifest.xml` to only `supportsRtl,theme` - `icon`/`name`/`allowBackup` had nothing to replace (no other manifest declares them), producing 3 manifest-merger warnings with zero effect on the merged output.
- Remove 7 orphaned translation-only strings (`git_clone*`, `idepref_github_summary`) across 11 locale files - no default value, zero code references anywhere, dead weight from a removed/never-shipped feature. AAPT2 already silently drops them for lacking a default; this removes the dead source and 14 "removing resource ... without required default value" warnings.
- Fix 12 `-Wwritable-strings` warnings in `adb_pairing.cpp` - `JNINativeMethod`'s legacy NDK struct fields are typed `char*`, so literal string init needs an explicit cast.

**Not attempted here** (flagged as bigger, separate work):
- ~4,346 of the 4,409 warning lines (98.6%!) are a single repeated D8 warning: R8 (bundled with our AGP 8.8.2) can't fully parse Kotlin 2.3.0's metadata format. Same root cause as two smaller warnings ("Unsupported Kotlin plugin version" from kotlin-dsl's embedded Kotlin, and "recommend a newer AGP for compileSdk=36"). All three stem from the AGP/Gradle/Kotlin toolchain being out of sync - a real fix means bumping AGP, which is a much bigger, riskier change than "trivial."
- GitHub Actions Node.js 20 deprecation warnings - the flagged actions need major version bumps (checkout v4->v7, google-github-actions/auth v2->v3, setup-uv v6->v9, cancel-workflow-action 0.12.1->0.13.1) across 9 workflow files. Verifiable only via live CI runs, not something to do blindly under "trivial."

## Test plan
- [x] `:app:assembleV8Debug` builds successfully
- [x] Confirmed via fresh (non-cached) task execution that all three warning categories are gone: 0 manifest-merger warnings, 0 orphaned-resource warnings, 0 `-Wwritable-strings` warnings
