### PR TITLE
ADFA-4643: Remove com.sun.jna from the APK

### DIFF
--- a/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/conf/AndroidModuleConf.kt
+++ b/composite-builds/build-logic/plugins/src/main/java/com/itsaky/androidide/plugins/conf/AndroidModuleConf.kt
@@ -97,7 +97,6 @@ fun Project.configureAndroidModule(coreLibDesugDep: Provider<MinimalExternalModu
 						"META-INF/CHANGES",
 						"META-INF/README.md",
 						"META-INF/LICENSE-notice.md",
-						"com/sun/jna/**",
 					),
 				)
 				pickFirsts.addAll(

--- a/subprojects/aaptcompiler/build.gradle.kts
+++ b/subprojects/aaptcompiler/build.gradle.kts
@@ -40,7 +40,9 @@ dependencies {
 	implementation(projects.logger)
 
 	api(libs.aapt2.annotations)
-	api(libs.aapt2.common)
+	api(libs.aapt2.common) {
+		exclude(group = "net.java.dev.jna")
+	}
 	api(libs.composite.layoutlibApi)
 
 	api(projects.subprojects.aapt2Proto)

--- a/templates-api/build.gradle.kts
+++ b/templates-api/build.gradle.kts
@@ -35,7 +35,9 @@ dependencies {
 	api(projects.subprojects.xmlDom)
 	api(projects.subprojects.xmlUtils)
 
-	api(libs.aapt2.common)
+	api(libs.aapt2.common) {
+		exclude(group = "net.java.dev.jna")
+	}
 	api(libs.androidx.annotation)
 	api(libs.androidx.appcompat)
 	api(libs.google.material)

--- a/templates-api/build.gradle.kts
+++ b/templates-api/build.gradle.kts
@@ -42,5 +42,5 @@ dependencies {
 	api(libs.androidx.appcompat)
 	api(libs.google.material)
 
-    implementation(libs.google.gson)
+	implementation(libs.google.gson)
 }


### PR DESCRIPTION
## Summary
- `com.sun.jna` isn't a direct dependency — it's pulled in transitively via `com.android.tools:common:31.2.2` (depended on as `api(libs.aapt2.common)` in `templates-api` and `subprojects/aaptcompiler`), through `jna-platform`.
- The only JNA usage inside `common` is `ComputerArchUtilsKt.computeIsRosetta()`, a macOS-only Rosetta/x86-emulation detector gated behind an `os.name` check that's unreachable on Android (`os.name` is always `"Linux"` there) — confirmed by decompiling the class.
- Excludes `net.java.dev.jna` on the `aapt2-common` dependency in both consuming modules, and removes the now-redundant `com/sun/jna/**` packaging exclude.
- Saves ~221 kB from the APK per the ticket.

## Test plan
- [x] `dependencyInsight` confirms `net.java.dev.jna` is fully gone from `:app`'s runtime classpath
- [x] `compileV8DebugKotlin` succeeds for `aaptcompiler`, `templates-api`, `templates-impl`, `app`
- [x] Unit tests pass for `aaptcompiler` and `templates-api`
- [x] Full `:app:assembleV8Debug` succeeds
- [x] Verified the built APK contains no `com/sun/jna` classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
