### PR TITLE
Update strings.xml for Chinese language

### DIFF
--- a/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/resources/src/main/res/values-zh-rCN/strings.xml
@@ -1,468 +1,1432 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-  <!-- Code on the Go -->
-  <string name="copy" tools:override="true">复制</string>
-  <string name="terminal_more">更多…</string>
-  <string name="text_to_search">要搜索的文本</string>
-  <string name="about_option_email">发电子邮件</string>
-  <string name="about_option_website">网站</string>
-  <string name="about_footer">Code on the Go %1$s (%2$s)</string>
-  <string name="about_subtitle">简而言之，一个适用于 Android 的 IDE</string>
-  <string name="msg_get_package_failed">获取软件包名称失败！</string>
-  <string name="msg_need_help">如果您在使用 Code on the Go 或构建 Android 应用时遇到问题，您可以加入 Telegram 群组寻求帮助。\n\n您也可以发送建议到我们的电子邮件地址。</string>
-  <string name="need_help">需要帮助？</string>
-  <string name="ide_preferences">IDE 首选项</string>
-  <string name="discussions_on_telegram">在 Telegram 上讨论</string>
-  <string name="official_tg_channel">官方 Telegram 频道</string>
-  <string name="msg_empty_view">没有数据</string>
-  <string name="title_terminal">终端</string>
-  <string name="reset">重置</string>
-  <string name="app_logs">应用日志</string>
-  <string name="ide_logs">IDE 日志</string>
-  <string name="cancel_project_text">取消</string>
-  <string name="close_without_saving">关闭且不保存文件</string>
-  <string name="save_and_close">保存文件并关闭项目</string>
-  <!-- LSP, Diagnostics & Completions -->
-  <string name="get_started">开始使用</string>
-  <string name="msg_cannot_perform_fix">无法执行快速修复</string>
-  <string name="msg_performing_actions">正在执行快速修复…</string>
-  <string name="msg_api_info_since">添加于 API %d</string>
-  <string name="msg_api_info_removed">已在 API %d 中移除</string>
-  <string name="msg_api_info_deprecated">已在 API %d 中弃用</string>
-  <string name="msg_finding_references">查找引用&#8230;</string>
-  <string name="msg_finding_definition">查找定义…</string>
-  <string name="msg_no_definition">没有找到定义</string>
-  <!-- Build Tools Installation -->
-  <string name="msg_no_references">没有找到引用</string>
-  <string name="view_diags">诊断信息</string>
-  <string name="title_installation_failed">安装失败</string>
-  <string name="msg_picked_isnt_dir">所选文件不是目录！</string>
-  <string name="please_wait">请稍等片刻…</string>
-  <!-- Project Builder -->
-  <string name="title_unsupported_device">不兼容的设备</string>
-  <string name="msg_unsupported_device">您正在仅 %2$s 的设备上使用 Code on the Go 的 %1$s 变体。此配置不兼容，请安装 Code on the Go 的 %2$s 变体。</string>
-  <string name="title_clear_output">清空输出</string>
-  <string name="build_output">构建输出</string>
-  <string name="quick_run_debug">快速运行</string>
-  <string name="msg_sync_needed">Gradle 文件已更改，请重构您的项目以同步依赖项和配置。</string>
-  <string name="preparing">准备中</string>
-  <string name="preparing_first">准备中，首次构建可能需要 10-15 分钟！</string>
-  <string name="msg_installing_gradlew">Gradle Wrapper 不可用！\n正在安装默认的包装器。如有需要，将下载 Gradle v7.4。</string>
-  <string name="run">运行</string>
-  <!-- Project -->
-  <string name="title_first_build">正在设置您的新项目</string>
-  <string name="msg_first_build">Code on the Go 正在设置您新项目的文件和目录。请耐心等待！\n\n设置完成后，屏幕底部将显示\"项目已初始化\"。</string>
-  <string name="create_project">创建项目</string>
-  <string name="minimum_sdk">最低 SDK 版本</string>
-  <string name="new_project">新项目</string>
-  <string name="package_name">软件包名称</string>
-  <string name="project_app_name">应用名称</string>
-  <string name="msg_create_new_project_greeting">开始创建你的惊人项目！</string>
-  <string name="title_confirm_open_project">打开上一次的项目？</string>
-  <string name="msg_confirm_open_project">您要打开上次打开的项目吗？打开的项目是：\n%s</string>
-  <string name="title_close_project">关闭当前项目</string>
-  <string name="msg_opened_project_does_not_exist">上次打开的项目不存在！</string>
-  <string name="msg_create_new_project">创建新项目</string>
-  <string name="msg_open_existing_project">打开现有项目</string>
-  <string name="title_confirm_project_close">关闭项目</string>
-  <!-- Templates -->
-  <string name="msg_confirm_project_close">当您关闭项目时，所有构建任务将停止，项目文件中未保存的更改可能会丢失。您是否希望在关闭项目之前保存文件？</string>  <string name="template_basic">基本项目</string>
-  <string name="template_empty">空项目</string>
-  <string name="template_navigation_drawer">抽屉式导航栏项目</string>
-  <string name="template_navigation_tabs">底部导航栏 Activity</string>
-  <string name="template_tabs">选项卡 Activity</string>
-  <string name="template_no_activity">无 Activity</string>
-  <string name="template_no_AndroidX">无 AndroidX</string>
-  <!-- Files -->
-  <string name="save">保存</string>
-  <string name="menu_find">查找</string>
-  <string name="menu_find_file">在文件中查找</string>
-  <string name="menu_find_project">在项目中查找</string>
-  <string name="msg_search_modules">在模块中搜索</string>
-  <string name="msg_no_modules">未在项目中找到模块</string>
-  <string name="hint_find_project_filter">过滤文件扩展名（可选）</string>
-  <string name="msg_find_project_filter">用‘|’分隔</string>
-  <string name="msg_empty_search_query">请输入文本</string>
-  <string name="msg_select_search_modules">选择要搜索的模块</string>
-  <string name="msg_searching_project">正在项目中查找，请稍候…</string>
-  <string name="view_search_results">搜索结果</string>
-  <string name="project_created_successfully">项目创建成功！</string>
-  <string name="project_creation_failed">项目创建失败</string>
-  <string name="msg_folder_creation_failed">创建文件夹失败！</string>
-  <string name="msg_file_creation_failed">文件创建失败！</string>
-  <string name="msg_layout_file_creation_failed">布局文件创建失败！</string>
-  <string name="msg_folder_created">文件夹创建成功！</string>
-  <string name="msg_file_created">文件创建成功！</string>
-  <string name="msg_folder_exists">文件夹已存在！</string>
-  <string name="msg_file_exists">文件已存在！</string>
-  <string name="msg_layout_file_exists">布局文件已存在！</string>
-  <string name="msg_invalid_name">名称无效！</string>
-  <string name="text_create">创建</string>
-  <string name="msg_can_contain_slashes">如果路径包含文件分隔符（“/”），则将创建所需的（父）目录（如果它们不存在）。</string>
-  <string name="folder_name">文件夹名称</string>
-  <string name="file_name">文件名称</string>
-  <string name="new_name">新名称</string>
-  <string name="new_file">新文件</string>
-  <string name="create_auto_layout">创建布局文件</string>
-  <string name="new_java_class">新 Java 类</string>
-  <string name="new_xml_resource">新 XML 资源</string>
-  <string name="new_folder">新文件夹</string>
-  <string name="title_confirm_delete">确认删除</string>
-  <string name="msg_confirm_delete">您确定要删除：\n%s 吗？</string>
-  <string name="copied">复制成功！</string>
-  <string name="msg_rename_file">输入文件（夹）的新名称。</string>
-  <string name="renamed">重命名成功！</string>
-  <string name="rename_failed">无法重命名文件！</string>
-  <string name="deleted">删除成功！</string>
-  <string name="delete_failed">无法删除文件！</string>
-  <string name="copy_path">复制路径</string>
-  <string name="rename_file">重命名</string>
-  <string name="delete_file">删除</string>
-  <string name="action_closeAll">关闭全部</string>
-  <string name="action_closeOthers">关闭其他</string>
-  <string name="action_closeThis">关闭当前</string>
-  <string name="all_saved">所有文件已保存！</string>
-  <string name="save_failed">文件保存失败</string>
-  <string name="msg_newfile_dest">位于：%s/</string>
-  <string name="restype_drawable">可绘制资源</string>
-  <string name="restype_layout">布局</string>
-  <string name="restype_menu">菜单</string>
-  <string name="restype_other">其他</string>
-  <string name="classtype_class">类</string>
-  <string name="classtype_activity">活动</string>
-  <string name="title_interface">界面</string>
-  <string name="classtype_enum">枚举</string>
-  <string name="msg_failed_list_files">无法列出项目文件！</string>
-  <!-- Code Editor -->
-  <string name="open_with">打开为…</string>
-  <string name="undo">撤销</string>
-  <string name="redo">重做</string>
-  <!-- Preferences -->
-  <string name="title_change_text_size">编辑器字体大小</string>
-  <string name="idepref_about_title">关于 Code on the Go</string>
-  <string name="idepref_build_clearCache_title">清除 Gradle 缓存</string>
-  <string name="idepref_build_clearCache_summary">清除 Gradle 缓存目录。这将删除 Gradle 下载的所有依赖项，所需的文件将在下一次构建中重新下载。</string>
-  <string name="idepref_build_customgradlecommands_title">Gradle 附加标志</string>
-  <string name="idepref_build_customgradlecommands_summary">选择在执行每个任务时使用的额外 Gradle 标志。</string>
-  <string name="idepref_editor_fontsize_title">字体大小</string>
-  <string name="idepref_editor_fontsize_summary">编辑器的字体大小</string>
-  <string name="idepref_editor_paintingflags_title">绘制不可打印字符标志</string>
-  <string name="idepref_editor_paintingflags_summary">选择编辑器应绘制哪些不可打印字符</string>
-  <string name="idepref_editor_word_wrap_title">自动换行</string>
-  <string name="idepref_editor_word_wrap_summary">在编辑器中使用自动换行</string>
-  <string name="idepref_editor_use_magnifier_title">启用放大镜</string>
-  <string name="idepref_editor_use_magnifier_summary">在编辑器中选择文本时放大光标处的文本</string>
-  <string name="idepref_editor_title">编辑器</string>
-  <string name="idepref_build_title">构建 &amp; 运行</string>
-  <string name="title_open_projects">打开上一次的项目</string>
-  <string name="msg_open_projects">如果选中，IDE 将记住上次打开的项目，并在下次启动时重新打开。</string>
-  <string name="title_confirm_project_open">打开项目前确认</string>
-  <string name="msg_confirm_project_open">打开上次打开的项目前确认。</string>
-  <string name="title_default_shell">在终端中使用系统 Shell</string>
-  <string name="msg_default_shell">如果选中，将在终端中使用“/system/bin/sh”。</string>
-  <string name="title_general">常规</string>
-  <string name="title_tab_size">Tab 宽度</string>
-  <string name="msg_tab_size">指定制表符代表的空格数</string>
-  <string name="msg_preferences">首选项</string>
-  <string name="pref_changelog">变更日志</string>
-  <string name="msg_editor_font_size">请选择编辑器的默认字体大小：</string>
-  <string name="msg_clear_cache">这将删除 Gradle 创建的缓存目录。如果删除，下一次的构建可能需要更长的时间，因为 Gradle 将再次下载所需的文件。\n\n您确定要删除缓存吗？</string>
-  <!-- Error Messages used while Logging -->
-  <!-- Layout preview and designer -->
-  <string name="title_preview_layout">预览布局</string>
-  <string name="title_viewaction_delete">删除</string>
-  <string name="msg_yesno_def_title">请确认</string>
-  <string name="msg_yesno_def_message">您确定吗？</string>
-  <string name="msg_empty_ui_layout">尚未添加任何视图，单击以添加。</string>
-  <string name="msg_generate_xml_failed">XML 代码生成失败</string>
-  <string name="title_generating_xml">生成 XML 代码</string>
-  <string name="msg_swipe_up">上滑可查看构建输出、日志等。</string>
-  <string name="msg_ide_crashed">Code on the Go 崩溃了</string>
-  <string name="msg_crash_info">请使用以下堆栈跟踪在 Github 上打开一个 issue：</string>
-  <string name="msg_close_crash_page">单击下面的按钮以复制日志和打开 issues 页面。</string>
-  <string name="title_translations">翻译</string>
-  <string name="action_expand_selection">扩选</string>
-  <string name="idepref_java_matchLower_title">代码补全匹配小写字母</string>
-  <string name="title_common">常规</string>
-  <string name="title_files_unsaved">未保存文件</string>
-  <string name="msg_files_unsaved">部分文件并未保存，是否在关闭项目之前保存？未保存的文件：\n%s</string>
-  <string name="idepref_java_matchLower_summary">若启用，输入大小写字母都将提示类名及其作用域成员</string>
-  <string name="idepref_editor_ligatures_title">连体字</string>
-  <string name="idepref_editor_ligatures_summary">启用或禁用连体字</string>
-  <string name="yes">是</string>
-  <string name="no">否</string>
-  <string name="msg_viewaction_add_attr">添加属性</string>
-  <string name="msg_file_tree">文件树</string>
-  <string name="hint_attr_value">属性值</string>
-  <string name="title_format_code">格式化代码</string>
-  <string name="title_show_tooltip">帮助</string>
-  <string name="idepref_java_useGoogleStyle_title">使用 Google Java 样式代码格式化</string>
-  <string name="idepref_java_useGoogleStyle_summary">使用 Google Java 样式代码格式化配置格式化 Java 源代码</string>
-  <string name="idepref_visiblePassword_title">明文密码标记</string>
-  <string name="idepref_visiblePassword_summary">编辑器中使用明文密码输入类型标记。这确保软键盘不会有字词建议。</string>
-  <string name="previous">上一个</string>
-  <string name="title_gradle_service_notification_ticker">Gradle 构建服务已启动</string>
-  <string name="title_gradle_service_notification">Gradle 构建服务</string>
-  <string name="title_cancel_build">取消构建</string>
-  <string name="msg_initializing_project">初始化项目</string>
-  <string name="msg_project_initialized">项目已初始化</string>
-  <string name="msg_project_initialization_failed">项目初始化失败</string>
-  <string name="msg_project_not_initialized">项目未初始化</string>
-  <string name="msg_replacement">替换</string>
-  <string name="title_sync_project">同步项目</string>
-  <string name="wizard_save_location">保存位置</string>
-  <string name="wizard_language">项目语言</string>
-  <string name="next">下一个</string>
-  <string name="exit">退出</string>
-  <string name="idepref_title_customGradleInstallation">自定义 Gradle 安装</string>
-  <string name="idepref_msg_customGradleInstallation">指定用于构建的自定义 Gradle 路径，这将会覆盖 gradle-wrapper.properties 中指定的版本</string>
-  <string name="msg_gradle_installation_path">Gradle 安装路径</string>
-  <string name="msg_gradle_installation_input_help">留空将使用 Gradle 包装器</string>
-  <string name="build_status_idle">没有正在进行的构建</string>
-  <string name="build_status_in_progress">构建正在进行中……</string>
-  <string name="build_status_failed">构建失败，请参阅构建输出以获取详情</string>
-  <string name="build_status_sucess">构建成功</string>
-  <string name="msg_output_text_extraction_failed">无法从编辑器获取文本</string>
-  <string name="err_invalid_data_by_intent">Intent 返回了无效数据</string>
-  <string name="msg_select_from_primary_storage">从内部存储中选择目录</string>
-  <string name="err_authority_not_allowed">权限“%s”不被允许</string>
-  <string name="idepref_useIcu_title">使用 ICU 库</string>
-  <string name="idepref_useIcu_summary">使用 ICU 库以检索字词边缘进行双击和长按字词的选择</string>
-  <!--The text sorrounded with '@@' is spanned as clickable.-->
-  <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_output">上滑查看 @@构建输出@@</string>
-  <string name="idepref_editor_useSoftTabs_title">使用空格代替制表符</string>
-  <string name="idepref_editor_useSoftTabs_summary">设置是否使用多个空格代替制表符 (\\t)</string>
-  <string name="btn_donate">捐助</string>
-  <string name="btn_docs">文档</string>
-  <string name="btn_close">关闭</string>
-  <string name="msg_ignore_case">忽略大小写</string>
-  <string name="msg_use_regex">使用正则表达式</string>
-  <string name="idepref_buildnrun_summary">Gradle 构建配置。</string>
-  <string name="configure">配置</string>
-  <string name="about">关于</string>
-  <string name="idepref_channel_summary">订阅以获取最新更新</string>
-  <string name="idepref_group_summary">在这里讨论功能、错误和改进。</string>
-  <string name="idepref_changelog_summary">此版本有什么新内容?</string>
-  <string name="idepref_about_summary">有关 Code on the Go 的更多信息。</string>
-  <string name="idepref_general_summary">常规 IDE 配置。</string>
-  <string name="idepref_editor_summary">配置编辑器。</string>
-  <string name="idepref_xml_trimFinalNewLine_title">删除末尾新行</string>
-  <string name="idepref_xml_insertFinalNewLine_title">插入末尾新行</string>
-  <string name="idepref_xml_trimFinalNewLine_summary">删除文件末尾多余的空行</string>
-  <string name="idepref_xml_insertFinalNewLine_summary">在文件末尾插入空行。</string>
-  <string name="idepref_xml_splitAttributes_title">拆分属性</string>
-  <string name="idepref_xml_splitAttributes_summary">安排属性到新行</string>
-  <string name="idepref_xml_joinCDataLines_title">加入 CDATA 行</string>
-  <string name="idepref_xml_joinCDataLines_summary">规范 CDATA 内容。</string>
-  <string name="idepref_xml_joinComment_title">加入注释行</string>
-  <string name="idepref_xml_joinComment_summary">规范注释内容。</string>
-  <string name="idepref_xml_joinContent_title">加入内容行</string>
-  <string name="idepref_xml_joinContent_summary">规范元素内容</string>
-  <string name="idepref_xml_spaceBeforeEmptyClose_title">闭合标签前空格</string>
-  <string name="idepref_xml_spaceBeforeEmptyClose_summary">在自闭合标签结束括号前插入空格。</string>
-  <string name="idepref_xml_preserveEmptyContent_title">保留空内容</string>
-  <string name="idepref_xml_preserveEmptyContent_summary">保留元素内的空内容（空格、换行符、制表符等）。</string>
-  <string name="idepref_xml_preserveAttrLineBreaks_title">保留属性换行符</string>
-  <string name="idepref_xml_preserveAttrLineBreaks_summary">保留属性之间的换行符。</string>
-  <string name="idepref_xml_closingBrackNewLine_title">新行右括号</string>
-  <string name="idepref_xml_closingBrackNewLine_summary">将右括号放在新的一行上。</string>
-  <string name="idepref_xml_trimTrailingWs_title">删除行末空格</string>
-  <string name="idepref_xml_trimTrailingWs_summary">删除每行末尾多余的空格</string>
-  <string name="idepref_maxLineWidth_title">最大行宽</string>
-  <string name="idepref_maxLineWidth_summary">每行字符数最高上限</string>
-  <string name="idepref_splitAttrIndentSize_title">拆分属性缩进大小</string>
-  <string name="idepref_splitAttrIndentSize_summary">分割属性缩进的空格数。</string>
-  <string name="idepref_preservedNewLines_title">保留新行</string>
-  <string name="idepref_preservedNewLines_summary">应保留的最大连续换行数。</string>
-  <string name="idepref_emptyElements_title">空元素行为</string>
-  <string name="idepref_emptyElements_summary">选择空元素的格式化行为</string>
-  <string name="xml_formatting_options">XML 格式化选项</string>
-  <string name="xml_formatting_options_summary">配置 XML 格式化程序</string>
-  <string name="idepref_customFont_title">使用自定义字体</string>
-  <string name="idepref_customFont_summary">如果启用，文件“/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf”将用作编辑器字体。</string>
-  <string name="msg_installing_apk">正在安装 APK …</string>
-  <string name="msg_action_open_application">您想打开该应用吗？</string>
-  <string name="title_gradle_service_notification_channel">Code on the Go Gradle 构建服务</string>
-  <string name="msg_hex_color_code">十六进制颜色代码</string>
-  <string name="msg_color_picker_pick">选择</string>
-  <string name="msg_chmod_exec">正在设置可执行权限…</string>
-  <string name="msg_linking">正在将 %1$s 链接到 %2$s</string>
-  <string name="msg_extracting_hooks">正在提取钩子库…</string>
-  <string name="msg_empty_package">软件包名称为空</string>
-  <string name="msg_package_is_not_valid">软件包名称无效</string>
-  <string name="msg_package_is_to_long">软件包名称过长</string>
-  <string name="msg_package_not_valid_char_1">符号“_”不能是软件包名称中的首字符</string>
-  <string name="msg_package_not_use_digit_first">数字不能是软件包名称中的首字符</string>
-  <string name="msg_package_not_valid_char_2">Android 应用的软件包名称中不允许使用字符“%1$s”</string>
-  <string name="msg_package_mus_have_dot">软件包名称中必须至少有一个“.”分隔</string>
-  <string name="action_import_classes">导入类</string>
-  <string name="action_generate_setters_getters">生成 setter/getter</string>
-  <string name="action_add_throws">添加“throws”</string>
-  <string name="action_comment_line">注释此行</string>
-  <string name="action_create_missing_method">创建缺失方法</string>
-  <string name="action_convert_to_block">转为块</string>
-  <string name="action_generate_constructor">生成构造函数</string>
-  <string name="action_implement_abstract_methods">实现抽象方法</string>
-  <string name="action_remove_class">删除类</string>
-  <string name="action_remove_method">删除方法</string>
-  <string name="action_remove_unused_throws">删除未使用的 throws</string>
-  <string name="action_suppress_unchecked_warning">抑制“unchecked​​”警告</string>
-  <string name="action_uncomment_line">取消注释</string>
-  <string name="action_convert_to_statement">转为声明</string>
-  <string name="msg_select_fields">选择字段</string>
-  <string name="msg_no_fields_selected">未选择字段</string>
-  <string name="msg_no_fields_found">未找到字段</string>
-  <string name="action_override_superclass_methods">重写父类方法</string>
-  <string name="msg_no_methods_selected">未选择方法</string>
-  <string name="msg_cannot_override_methods">无法重写方法</string>
-  <string name="msg_cannot_generate_setters_getters">无法生成 setter 和 getter</string>
-  <string name="msg_select_methods">选择要重写的方法</string>
-  <string name="msg_no_overridable_methods">找不到任何可重写的方法</string>
-  <string name="action_goto_definition">转到定义</string>
-  <string name="action_find_references">查找引用</string>
-  <string name="action_generate_toString">生成 toString()</string>
-  <string name="action_remove_unused_imports">删除未使用的导入</string>
-  <string name="action_organize_imports">整理导入</string>
-  <string name="msg_cannot_generate_toString">无法生成 toString()</string>
-  <string name="msg_toString_overridden">toString() 已被重写</string>
-  <string name="action_generate_missing_constructor">生成缺失的构造函数</string>
-  <string name="msg_cannot_generate_constructor">无法生成构造函数</string>
-  <string name="msg_constructor_available">已存在相同参数类型的构造函数</string>
-  <string name="replace">替换</string>
-  <string name="replaceAll">全部替换</string>
-  <string name="title_run_tasks">运行任务</string>
-  <string name="hint_search_tasks">搜索任务…</string>
-  <string name="msg_err_select_tasks">请选择要运行的任务</string>
-  <string name="title_confirmation">确认</string>
-  <string name="msg_tasks_to_run">将按顺序运行以下任务，再次单击“运行”按钮进行确认。\n\n%1$s</string>
-  <string name="msg_loading_tasks">正在加载任务…</string>
-  <!-- GIT -->
-  <string name="msg_select_attr">从下面的列表中选择一个属性</string>
-  <string name="action_show_hierarchy">显示布局层次</string>
-  <string name="idepref_editor_colorScheme">配色方案</string>
-  <string name="idepref_editor_colorScheme_summary">选择要在编辑器中使用的配色方案</string>
-  <string name="idepref_general_uiMode">界面模式</string>
-  <string name="idepref_general_uiMode_summary">选择 IDE 的主题背景</string>
-  <string name="uiMode_light">浅色</string>
-  <string name="uiMode_dark">深色</string>
-  <string name="uiMode_system">跟随系统</string>
-  <string name="idepref_general_themeSelector_title">主题</string>
-  <string name="idepref_general_themeSelector_summary">选择 Code on the Go 主题（需要重启）。</string>
-  <string name="idepref_general_projectConfig">项目配置</string>
-  <string name="msg_app_launch_failed">在启动应用之前，必须先构建并安装该应用。</string>
-  <string name="idepref_java_diagnosticEnabled_title">启用诊断</string>
-  <string name="idepref_java_diagnosticsEnabled_summary">（实验性）是否应该分析 Java 源文件的错误。</string>
-  <string name="title_reload_color_schemes">重载配色方案</string>
-  <string name="msg_dir_picker_failed">无法启动目录选取器：%1$s</string>
-  <string name="msg_tooling_server_unavailable">Tooling API 服务器不可用。检查构建输出和 IDE 日志是否有错误。</string>
-  <string name="idepref_deleteEmptyLines_title">退格键删除空行</string>
-  <string name="idepref_deleteEmptyLines_summary">编辑器是否应在单个退格键事件中删除空行。</string>
-  <string name="idepref_deleteTabs_title">退格键删除制表符</string>
-  <string name="idepref_deleteTabs_summary">启用后，编辑器将在按下退格键时删除等于制表符宽度的空格。</string>
-  <string name="btn_sync">同步</string>
-  <string name="btn_ignore_changes">忽略修改</string>
-  <string name="title_fix_imports">修复导入</string>
-  <string name="msg_no_unresolved_classes">找不到未解析的类名</string>
-  <string name="title_class_chooser">哪个 %1$s？</string>
-  <string name="permlab_bind_logger_service">绑定日志服务</string>
-  <string name="permdesc_bind_logger_service">允许该应用绑定到 Code on the Go 的日志记录服务。 Code on the Go 需要此权限才能读取该应用的日志。</string>
-  <string name="wizard_module_name">模块名称</string>
-  <string name="wizard_module_type">模块类型</string>
-  <string name="msg_invalid_module_name">无效的 Gradle 模块名称</string>
-  <string name="msg_value_empty">值为空</string>
-  <string name="msg_file_not_exist">文件不存在</string>
-  <string name="msg_path_must_be_file">必须是文件路径</string>
-  <string name="msg_classname_with_keywords">类名包含关键字</string>
-  <string name="msg_path_must_be_dir">必须是目录路径</string>
-  <string name="msg_invalid_layout_name">布局文件名无效</string>
-  <string name="msg_invalid_project_details">项目信息无效</string>
-  <string name="msg_use_kts">将 Kotlin 脚本 (.kts) 用于 Gradle build 文件</string>
-  <string name="title_privacy">隐私</string>
-  <string name="title_unique_id">唯一身份</string>
-  <string name="title_device">设备</string>
-  <string name="title_app_version">应用版本</string>
-  <string name="title_country">国家</string>
-  <string name="title_cpu_arch">CPU 架构</string>
-  <string name="title_preview_data">预览数据</string>
-  <string name="title_android_version">Android 版本</string>
-  <string name="btn_opt_in">选择加入</string>
-  <string name="title_developer_options">开发者选项</string>
-  <string name="idepref_devOptions_summary">Code on the Go 的实验和调试选项</string>
-  <string name="idepref_group_debugging">调试</string>
-  <string name="idepref_devOptions_dumpLogs_title">转储日志</string>
-  <string name="idepref_devOptions_dumpLogs_summary">将 Code on the Go 日志转储到 $HOME/.cg/logs</string>
-  <string name="msg_emptyview_applogs">运行应用的 debug 变体以在此处查看其日志。</string>
-  <string name="msg_logsender_disabled">LogSender 已禁用。您可以在首选项中启用它。</string>
-  <string name="msg_emptyview_idelogs">IDE 中的日志显示在这里。</string>
-  <string name="msg_emptyview_diagnostics">打开文件以显示其诊断结果</string>
-  <string name="msg_emptyview_buildoutput">"构建应用或运行任务以在此处查看其构建输出。"</string>
-  <string name="msg_codeaction_failed">无法执行代码操作</string>
-  <string name="idepref_devOptions_enableLogsender_title">启用 LogSender</string>
-  <string name="idepref_devOptions_enableLogsender_summary">禁用后，应用的日志将不会显示在 Code on the Go 中</string>
-  <string name="title_build_variants">构建变体</string>
-  <string name="build_variants_apply">应用</string>
-  <string name="build_variants_cancel">放弃</string>
-  <string name="msg_build_variants_fetch_failed">无法获取构建变体</string>
-  <string name="title_choose_application">选择应用项</string>
-  <string name="err_selected_variant_not_found">找不到选定的构建变体</string>
-  <string name="title_disconnect_log_senders">断开日志发送器</string>
-  <string name="title_begin_long_select">开始长选</string>
-  <string name="idepref_editor_stickScroll_title">粘滞滚动</string>
-  <string name="idepref_editor_stickyScroll_summary">滚动编辑器时在顶部显示当前范围。</string>
-  <string name="idepref_launchAppAfterInstall_title">安装后启动应用</string>
-  <string name="idepref_launchAppAfterInstall_summary">如果启用，IDE 安装应用程序后，将（不经确认）立即启动该应用程序。</string>
-  <string name="title_run_options">运行选项</string>
-  <string name="err_cannot_determine_package">无法确定软件包名称，不能运行应用。</string>
-  <string name="msg_launch_failure_no_app_module">项目中未找到应用模块，无法运行应用。</string>
-  <string name="title_launch_app">启动应用</string>
-  <string name="title_experiment_flavor">实验性功能</string>
-  <string name="msg_experimental_flavor">您正在 %2$s 的设备上使用 Code on the Go 的 %1$s 变体。此配置可能有效，但会使性能降低并可能导致安全漏洞。请尽可能避免使用此配置。</string>
-  <string name="idepref_editor_pinLineNumbers_title">固定行号</string>
-  <string name="idepref_editor_pinLineNumbers_summary">编辑器是否应在水平滚动时固定行号栏。</string>
-  <string name="theme_blue_wave">蓝色波浪</string>
-  <string name="theme_sunny_glow">阳光熠熠</string>
-  <string name="theme_material_you">Material You</string>
-  <string name="idepref_general_localeSelector_title">语言</string>
-  <string name="idepref_general_localeSelector_summary">选择 Code on the Go 的语言。</string>
-  <string name="locale_system_default">系统默认</string>
-  <string name="msg_project_dir_inaccessible">无法访问项目目录</string>
-  <string name="msg_file_is_not_dir">所选文件不是目录</string>
-  <string name="msg_project_dir_doesnt_exist">项目目录不存在</string>
-  <string name="msg_files_being_saved">文件保存操作已在进行中！</string>
-  <string name="title_install_tools">SDK 安装</string>
-  <string name="subtitle_install_tools">安装开发工具</string>
-  <string name="msg_install_tools">必须安装开发工具才能使 IDE 工作，单击完成按钮将打开终端来安装工具。若要安装，请按照<![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">此处</a>的说明进行操作。<br/><br/>或者阅读<a href="https://docs.androidide.com/">文档</a>]]>。</string>
-  <string name="greeting_title">欢迎</string>
-  <string name="greeting_subtitle">学习、构建、启动，一切尽在您的 Android 设备上。</string>
-  <string name="title_grant">授权</string>
-  <string name="permission_title_storage">存储</string>
-  <string name="permission_desc_storage">需要访问项目文件。</string>
-  <string name="permission_desc_install_packages">允许 Code on the Go 安装其构建的应用程序。</string>
-  <string name="permission_title_install_packages">安装软件包</string>
-  <string name="onboarding_title_permissions">权限</string>
-  <string name="onboarding_subtitle_permissions">Code on the Go 需要以下权限</string>
-  <string name="msg_grant_permissions">请授予权限以继续。</string>
-  <string name="msg_no_internet">您似乎已离线，检查您的互联网连接。</string>
-  <string name="msg_connected_to_cellular">注意！您正在使用蜂窝移动数据。</string>
-  <string name="msg_connected_to_metered_connection">注意！您使用的是按流量计费的网络。</string>
-  <string name="msg_disable_background_data_restriction">禁用后台数据限制，以避免安装失败。</string>
-  <string name="msg_cannot_create_terminal_session">无法创建终端会话</string>
-  <string name="action_auto_install">自动安装</string>
-  <string name="action_manual_install">手动安装</string>
-  <string name="hint_android_sdk_version">Android SDK 版本</string>
-  <string name="hin_jdk_version">JDK 版本</string>
-  <string name="action_install_git">安装 Git</string>
-  <string name="action_install_openssh">安装 OpenSSH</string>
-  <string name="msg_terminal_new_sessions_disabled">无法创建会话，新会话被禁用！</string>
-  <string name="title_install_location_error">安装位置错误</string>
-  <string name="title_unsupported_user">不支持的用户</string>
-  <string name="title_socials">社交</string>
-  <string name="title_contribute">贡献</string>
-  <string name="summary_contribute">它不仅仅是一个 IDE，更是一个社区。为 Code on the Go 贡献代码、想法和热情。</string>
-  <string name="msg_app_unavailable_for_intent">没有可用于处理意图的应用。</string>
-  <string name="title_open_source_licenses">开源许可</string>
-  <string name="summary_open_source_licenses">查看开放源代码许可。</string>
-  <string name="idepref_jdkVersion_title">JDK 版本</string>
-  <string name="idepref_jdkVersion_summary">当前选择：%1$s（更改需重启）</string>
+
+	<!-- Code on the Go -->
+	<string name="copy" tools:override="true">复制</string>
+	<string name="terminal_more">更多</string>
+	<string name="text_to_search">要查找的文本</string>
+	<string name="app_name" translatable="false">Code on the Go</string>
+	<string name="about_option_email">邮箱</string>
+	<string name="about_option_website">网站</string>
+	<string name="about_footer_alternate" translatable="false">Code on the Go v\u2022 %s</string>
+	<string name="about_footer">Code on the Go %1$s，适用于 %2$s</string>
+	<string name="about_subtitle">没有电脑？没有网络？没问题！随时随地编写应用</string>
+	<string name="msg_get_package_failed">提取包名失败</string>
+	<string name="msg_need_help">如果你在使用 Code on the Go 或构建 Android 应用时遇到问题，可以加入我们的讨论论坛寻求帮助\n\n你也可以通过邮箱发送建议</string>
+	<string name="download_codeonthego_message">从官方网站下载 Code on the Go，获取最新功能和更新</string>
+	<string name="download_codeonthego_url">https://appdevforall.org/codeonthego</string>
+	<string name="msg_invalid_url">提供的 URL 无效</string>
+	<string name="msg_no_browser_found">未找到可处理该请求的浏览器</string>
+	<string name="need_help">需要帮助？</string>
+	<string name="ide_preferences">IDE 偏好设置</string>
+	<string name="discussions_on_telegram">支持和讨论论坛</string>
+	<string name="official_tg_channel">官方 Telegram 频道</string>
+	<string name="msg_empty_view">无数据</string>
+	<string name="title_terminal">终端</string>
+	<string name="reset">重置</string>
+	<string name="app_logs">应用日志</string>
+	<string name="ide_logs">IDE 日志</string>
+	<string name="default_tooltip">关于此功能的通用信息</string>
+	<string name="err_insufficient_storage_title">存储空间不足！</string>
+    <string name="err_insufficient_storage_msg">%1$s 需要至少 %2$dGB 的可用空间才能运行并解压必要的工具\n\n请释放设备存储空间后重试</string>
+    <string name="action_close_app">关闭 %1$s</string>
+    <string name="action_free_up_space">释放空间</string>
+
+	<!-- Agent -->
+	<string name="agent_backend_selected">🤖 系统：已选择 %1$s 后端</string>
+	<string name="agent_current_model">当前模型：%1$s</string>
+	<string name="agent_no_model_selected_warning">⚠️ 警告：未选择模型文件</string>
+	<string name="agent_local_model_not_loaded">本地模型未加载，请打开 AI 设置，选择一个模型，然后重试</string>
+	<string name="agent_backend_not_ready">AI 后端尚未就绪，请检查你的 AI 设置</string>
+	<string name="agent_local_model_loaded_success">本地模型加载成功！</string>
+	<string name="agent_local_model_loaded_failure">错误：加载本地模型失败</string>
+	<string name="agent_operation_cancelled_by_user">操作已被用户取消</string>
+	<string name="agent_planner_tool_fallback">规划器在多次尝试后未能生成有效的工具调用，请直接提供文本回答，无需调用任何工具</string>
+	<string name="agent_planner_reject_unexpected_tool">之前的规划被拒绝，因为模型试图调用工具，但当时不允许进行任何工具调用</string>
+	<string name="agent_planner_reject_malformed_tool">之前的规划失败，因为工具调用格式错误</string>
+	<string name="agent_planner_reject_invalid_tool">之前的规划因无效的工具调用被拒绝</string>
+	<string name="agent_planner_tool_blocked_note">工具 `%1$s` 已被屏蔽，直到你能解释如何安全调用它为止</string>
+	<string name="agent_planner_retry_instruction">%1$s%2$s 在尝试再次调用工具之前，请仔细检查所需参数并确认调用工具的必要性，如果可以用概念性方式回答请求，请用文本回复，而不是强行调用工具</string>
+	<string name="agent_planner_invalid_output_notice">规划器输出无效 正在请求修正规划...</string>
+	<string name="agent_tool_call_missing_name">发出了一个没有名称的函数调用，请提供有效的工具名称</string>
+	<string name="agent_tool_call_unknown_tool">请求了未知工具 `%1$s` 请仅使用支持的工具</string>
+	<string name="agent_tool_call_blocked">工具 `%1$s` 因格式错误的调用被临时屏蔽 请选择其他工具或以文本方式回复 </string>
+	<string name="agent_tool_call_missing_args">工具 `%1$s` 缺少必需的参数：%2$s </string>
+	<string name="agent_planner_invalid_tool_usage_header">之前的规划违反了工具要求：\n</string>
+	<string name="agent_planner_invalid_tool_usage_footer">请使用有效的工具参数重新规划，或者在不必要使用工具时提供文本回复 </string>
+	<string name="agent_planner_invalid_tool_usage_notice">规划器提出了无效的工具用法 正在请求修正规划...</string>
+	<string name="agent_approval_deny">拒绝</string>
+	<string name="agent_approval_once">允许一次</string>
+	<string name="agent_approval_session">本次会话允许</string>
+	<string name="agent_approval_title">是否允许 \'%1$s\'？</string>
+	<string name="agent_dialog_cancel">取消</string>
+	<string name="agent_dialog_run">运行</string>
+	<string name="agent_hint_boolean">true 或 false</string>
+	<string name="agent_hint_file_content">文件内容</string>
+	<string name="agent_hint_limit">1000</string>
+	<string name="agent_hint_number">输入一个数字</string>
+	<string name="agent_hint_offset">0</string>
+	<string name="agent_hint_param">输入 %1$s</string>
+	<string name="agent_hint_path_example">例如：app/src/main/AndroidManifest.xml</string>
+	<string name="agent_hint_search_pattern">搜索模式...</string>
+	<string name="agent_images_selected">已选择 %1$d 张图片</string>
+	<string name="agent_required_fields_missing">请填写所有必填字段(标有*)</string>
+	<string name="agent_select_tool_to_test">选择一个要测试的工具</string>
+	<string name="agent_test_tool_title">测试工具：%1$s</string>
+	<string name="agent_title_ellipsis_suffix">...</string>
+	<string name="agent_tokens_na">令牌数：N/A</string>
+	<string name="agent_tokens_percentage">令牌数：%1$d%%</string>
+	<string name="agent_tool_description_missing">无描述</string>
+	<string name="agent_tool_no_params">描述：%1$s\n\n此工具没有参数</string>
+	<string name="agent_tool_not_found">未找到工具：%1$s</string>
+	<string name="agent_run_tool_title">运行 %1$s</string>
+
+	<!-- LSP, Diagnostics & Completions -->
+	<string name="get_started">开始使用</string>
+	<string name="msg_cannot_perform_fix">无法执行快速修复</string>
+	<string name="msg_performing_actions">正在执行代码操作…</string>
+	<string name="msg_api_info_since">自 API %d 起</string>
+	<string name="msg_api_info_removed">在 API %d 中移除</string>
+	<string name="msg_api_info_deprecated">在 API %d 中弃用</string>
+	<string name="msg_finding_references">正在查找引用…</string>
+	<string name="msg_finding_definition">正在查找定义…</string>
+	<string name="msg_no_definition">未找到定义</string>
+
+	<!-- Build Tools Installation -->
+	<string name="msg_no_references">未找到引用</string>
+	<string name="msg_no_imports_found">未找到导入</string>
+	<string name="view_diags">诊断信息</string>
+	<string name="title_installation_failed">安装失败</string>
+	<string name="error_installation_failed">安装资源失败</string>
+	<string name="err_asset_entry_not_found">在资源 zip 文件中未找到条目 \'%1$s\'</string>
+	<string name="err_missing_or_corrupt_assets">缺少安装文件 %1$s 安装可能已损坏或不完整</string>
+	<string name="msg_picked_isnt_dir">所选文件不是目录 </string>
+	<string name="please_wait">请稍候 </string>
+	<string name="not_enough_storage">可用存储空间不足，无法完成安装  内部存储分区需要额外 %1$.1fGB 的空间  你当前有 %2$.1fGB 可用空间</string>
+	<string name="storage_not_accessible">存储不可访问 请确保设备已解锁，然后重试 </string>
+	<string name="terminal_installation_failed_low_storage">终端设置失败！存储空间不足，或安装过程中文件被移除，请清理一些空间后重试</string>
+	<string name="terminal_installation_failed_secondary_user">终端安装仅支持主要用户 </string>
+
+	<!-- Project Builder -->
+	<string name="title_unsupported_device">此设备不受支持</string>
+	<string name="msg_unsupported_device">你在仅支持 %2$s 的设备上使用了 Code On The Go 的 %1$s 变体  此配置不受支持，请安装 %2$s 变体的 Code On The Go</string>
+	<string name="title_clear_output">清除输出</string>
+	<string name="build_output">构建输出</string>
+	<string name="quick_run_debug">快速运行</string>
+	<string name="msg_sync_needed">Gradle 文件已更改，请同步项目以更新依赖项和设置</string>
+	<string name="preparing">正在准备</string>
+	<string name="preparing_first">初始化项目可能需要一些时间</string>
+	<string name="msg_installing_gradlew">Gradle Wrapper 不可用\n正在安装默认 Wrapper，必要时将下载 Gradle v7.4</string>
+	<string name="run">运行</string>
+	<string name="gradle" translatable="false">Gradle</string>
+	<string name="action_start_debugger">调试</string>
+
+
+	<!-- Project -->
+	<string name="title_first_build">正在设置你的项目</string>
+	<string name="msg_first_build">Code on the Go 正在初始化你的项目，请耐心等待！\n\n设置完成后，屏幕底部将显示"项目已初始化"</string>
+	<string name="create_project">创建新项目</string>
+	<string name="minimum_sdk">最低 SDK</string>
+	<string name="new_project">新建项目</string>
+	<string name="package_name">包名</string>
+	<string name="project_app_name">应用名称</string>
+	<string name="msg_create_new_project_greeting">阅读快速入门指南</string>
+	<string name="title_confirm_open_project">打开上次的项目？</string>
+	<string name="msg_confirm_open_project">是否要打开上次打开的项目？项目为：\n%s</string>
+	<string name="title_close_project">关闭此项目</string>
+	<string name="msg_opened_project_does_not_exist">上次打开的项目不存在！</string>
+	<string name="msg_create_new_project">创建新项目</string>
+	<string name="msg_open_existing_project">打开已保存的项目</string>
+	<string name="msg_delete_existing_project">删除已保存的项目</string>
+	<string name="clone_git_project">克隆 Git 项目</string>
+	<string name="msg_delete_existing_project_failed">删除已有项目失败</string>
+	<string name="title_confirm_project_close">关闭项目</string>
+	<string name="cancel_project_text">取消</string>
+	<string name="close_without_saving">关闭但不保存文件</string>
+	<string name="save_and_close">保存文件并关闭项目</string>
+	<string name="search_projects_hint">按名称搜索项目…</string>
+    <string name="sort_projects_label">排序项目</string>
+    <string name="toggle_sorting">切换排序</string>
+    <string name="reset_sorting">重置</string>
+    <string name="apply_sorting">排序</string>
+    <string name="sort_by_hint">排序依据</string>
+    <string name="sort_by_name">名称</string>
+    <string name="sort_by_created">创建时间</string>
+    <string name="sort_by_modified">修改时间</string>
+    <string name="filters_active">筛选器已启用</string>
+    <string name="filter_chip_remove_sort">移除排序</string>
+    <string name="filter_chip_remove_search">移除搜索筛选</string>
+    <string-array name="sort_options">
+        <item>@string/sort_by_name</item>
+        <item>@string/sort_by_created</item>
+        <item>@string/sort_by_modified</item>
+    </string-array>
+	<string name="project_info">信息</string>
+	<string name="project_info_title">基本信息</string>
+	<string name="project_info_general_title">常规</string>
+	<string name="project_info_structure_title">结构</string>
+	<string name="project_info_build_title">构建</string>
+	<string name="project_info_name">项目名称</string>
+	<string name="project_info_path">项目路径</string>
+	<string name="project_info_template">基础模板</string>
+	<string name="project_info_size">项目大小</string>
+	<string name="project_info_files_count">文件数量</string>
+	<string name="project_info_gradle_v">Gradle 版本</string>
+	<string name="project_info_kotlin_v">Kotlin 版本</string>
+	<string name="project_info_java_v">Java 版本</string>
+	<string name="msg_file_tree_drag_failed">开始拖拽文件失败</string>
+    <string name="msg_file_tree_drag_error">准备拖拽文件时出错</string>
+    <string name="msg_file_tree_drag_file_not_found">找不到文件</string>
+    <string name="msg_file_tree_drag_not_a_file">只能拖拽文件</string>
+
+	<!-- Templates -->
+	<string name="msg_confirm_project_close">关闭项目后，所有构建任务将停止，项目中未保存的更改可能会丢失，是否要在关闭项目前保存文件？</string>
+	<string name="template_basic">基础 Activity</string>
+	<string name="template_empty">空白 Activity</string>
+	<string name="template_navigation_drawer">导航抽屉 Activity</string>
+	<string name="template_compose" translatable="false">Compose Activity</string>
+	<string name="template_navigation_tabs">底部导航 Activity</string>
+	<string name="template_tabs">标签页 Activity</string>
+	<string name="template_no_activity">无 Activity</string>
+	<string name="template_no_AndroidX">旧版项目（无 AndroidX）</string>
+	<string name="template_plugin">插件</string>
+	<string name="template_ndk">NDK Activity</string>
+
+	<!-- Plugin Template Wizard -->
+	<string name="wizard_plugin_name">插件名称</string>
+	<string name="wizard_plugin_id">插件 ID（包名）</string>
+	<string name="wizard_plugin_description">插件描述</string>
+	<string name="wizard_plugin_author">作者名称</string>
+	<string name="wizard_include_sample_code">包含示例代码</string>
+	<string name="wizard_plugin_permissions">权限</string>
+	<string name="wizard_plugin_extensions">扩展</string>
+	<string name="wizard_plugin_options">选项</string>
+
+	<!-- Plugin Permissions -->
+	<string name="perm_filesystem_read">文件系统读取</string>
+	<string name="perm_filesystem_write">文件系统写入</string>
+	<string name="perm_network_access">网络访问</string>
+	<string name="perm_system_commands">系统命令</string>
+	<string name="perm_ide_settings">IDE 设置</string>
+	<string name="perm_project_structure">项目结构</string>
+
+	<!-- Plugin Extensions -->
+	<string name="ext_ui">UI 扩展</string>
+	<string name="ext_editor_tab">编辑器标签扩展</string>
+	<string name="ext_documentation">文档扩展</string>
+	<string name="ext_editor">编辑器扩展</string>
+	<string name="ext_project">项目扩展</string>
+	<string name="unknown">未知</string>
+
+	<!-- Files -->
+	<string name="save">保存</string>
+	<string name="menu_find">查找</string>
+	<string name="menu_find_file">在文件中查找</string>
+	<string name="menu_find_project">在项目中查找</string>
+	<string name="msg_search_modules">在模块中搜索</string>
+	<string name="msg_no_modules">在项目中未找到模块</string>
+	<string name="hint_find_project_filter">筛选文件扩展名（可选）</string>
+	<string name="msg_find_project_filter">用 \'|\' 分隔</string>
+	<string name="msg_empty_search_query">请输入文本</string>
+	<string name="msg_select_search_modules">选择要搜索的模块</string>
+	<string name="msg_searching_project">正在搜索项目…</string>
+	<string name="view_search_results">搜索结果</string>
+	<string name="project_created_successfully">项目创建成功！</string>
+	<string name="project_creation_failed">创建项目失败</string>
+	<string name="msg_scroll_to_create_project">滚动到底部以创建项目</string>
+	<string name="msg_folder_creation_failed">创建文件夹失败</string>
+	<string name="msg_file_creation_failed">创建文件失败</string>
+	<string name="msg_layout_file_creation_failed">创建布局文件失败</string>
+	<string name="msg_folder_created">文件夹创建成功</string>
+	<string name="msg_file_created">文件创建成功</string>
+	<string name="msg_folder_exists">文件夹已存在</string>
+	<string name="msg_file_exists">文件已存在</string>
+	<string name="msg_layout_file_exists">布局文件已存在</string>
+	<string name="msg_invalid_name">名称无效</string>
+	<string name="text_create">创建</string>
+	<string name="msg_can_contain_slashes">如果文件路径包含文件夹分隔符（\'/\'），任何缺失的父文件夹将自动创建</string>
+	<string name="folder_name">文件夹名称</string>
+	<string name="file_name">文件名</string>
+	<string name="new_name">新名称</string>
+	<string name="new_file">新建文件</string>
+	<string name="create_auto_layout">创建布局文件</string>
+	<string name="new_java_class">新建 Java 类</string>
+	<string name="new_xml_resource">新建 XML 资源</string>
+	<string name="new_folder">新建文件夹</string>
+	<string name="title_confirm_delete">确认删除</string>
+	<string name="msg_confirm_delete">确定要删除：\n%s？</string>
+	<string name="copied">复制成功</string>
+	<string name="msg_rename_file">为文件/文件夹输入一个新名称</string>
+	<string name="renamed">重命名成功</string>
+	<string name="rename_failed">无法重命名文件</string>
+    <string name="file_name_too_long">文件名不能超过 40 个字符</string>
+	<string name="deleted">删除成功</string>
+	<string name="delete_failed">无法删除文件</string>
+	<string name="copy_path">复制路径</string>
+	<string name="rename_file">重命名</string>
+	<string name="delete_file">删除</string>
+	<string name="action_closeAll">全部关闭</string>
+	<string name="action_install">安装</string>
+	<string name="action_closeOthers">关闭其他</string>
+	<string name="action_closeThis">关闭此页</string>
+	<string name="all_saved">所有文件已保存</string>
+	<string name="save_failed">保存文件失败</string>
+	<string name="msg_newfile_dest">目标位置：%s/</string>
+	<string name="restype_drawable">Drawable</string>
+	<string name="restype_layout">布局</string>
+	<string name="restype_menu">菜单</string>
+	<string name="restype_other">其他</string>
+	<string name="classtype_class">类</string>
+	<string name="classtype_activity">Activity</string>
+	<string name="title_interface">接口</string>
+	<string name="classtype_enum">枚举</string>
+	<string name="lang_java">Java</string>
+	<string name="lang_kotlin">Kotlin</string>
+	<string name="new_kotlin_class">新建 Kotlin 类</string>
+	<string name="msg_failed_list_files">列出项目文件失败</string>
+	<string name="msg_file_tree_drop_import_failed">导入拖放的文件失败</string>
+	<string name="msg_file_tree_drop_no_files">未拖放任何外部文件</string>
+	<string name="msg_file_tree_drop_destination_missing">目标文件夹不存在</string>
+	<string name="msg_file_tree_drop_destination_unresolved">无法解析目标文件夹</string>
+	<string name="msg_file_tree_drop_default_name">拖放的文件</string>
+	<string name="msg_file_tree_drop_read_failed">无法读取拖放的文件：%1$s</string>
+	<string name="msg_file_tree_drop_imported_single">已导入 1 个文件</string>
+	<string name="msg_file_tree_drop_imported_multiple">已导入 %1$d 个文件</string>
+
+	<!-- Shortcuts -->
+	<string name="shortcut_close_current_file">关闭当前文件</string>
+	<string name="shortcut_create_project">创建项目</string>
+    <string name="shortcut_open_project">打开项目</string>
+    <string name="shortcut_clone_repository">克隆仓库</string>
+    <string name="shortcut_close_file">关闭文件</string>
+    <string name="shortcut_open_preferences">打开偏好设置</string>
+    <string name="shortcut_find_in_project">在项目中查找</string>
+    <string name="shortcut_open_terminal">打开终端</string>
+
+	<!-- Code Editor -->
+	<string name="open_with">用…打开</string>
+
+	<string name="undo">撤销</string>
+	<string name="redo">重做</string>
+
+	<!-- Preferences -->
+	<string name="title_change_text_size">编辑器字体大小</string>
+	<string name="idepref_about_title">关于 Code on the Go</string>
+	<string name="idepref_build_clearCache_title">清除 Gradle 缓存</string>
+	<string name="idepref_build_clearCache_summary">清除 Gradle 缓存目录 这将删除 Gradle 下载的所有依赖项，所需文件将在下次构建时重新下载</string>
+	<string name="idepref_build_customgradlecommands_title">附加 Gradle 标志</string>
+	<string name="idepref_build_customgradlecommands_summary">选择要随每个任务执行的附加 Gradle 标志 </string>
+	<string name="idepref_editor_fontsize_title">字体大小</string>
+	<string name="idepref_editor_fontsize_summary">设置默认字体大小(以sp为单位)</string>
+	<string name="idepref_editor_paintingflags_title">显示非打印字符</string>
+	<string name="idepref_editor_paintingflags_summary">选择显示哪些非打印字符（如制表符、空格和换行符）</string>
+	<string name="idepref_editor_word_wrap_title">自动换行</string>
+	<string name="idepref_editor_word_wrap_summary">将长文本或代码行拆分为多行，使其适应可见窗口</string>
+	<string name="idepref_editor_use_magnifier_title">启用放大镜</string>
+	<string name="idepref_editor_use_magnifier_summary">长按并保持以放大光标周围的区域</string>
+	<string name="idepref_editor_title">编辑器</string>
+	<string name="idepref_build_title">构建和运行</string>
+	<string name="title_open_projects">打开上次的项目</string>
+	<string name="msg_open_projects">启用后，重启 Code on the Go 时将自动打开上次打开的项目</string>
+	<string name="title_confirm_project_open">确认打开项目</string>
+	<string name="msg_confirm_project_open">启用后，Code on the Go 在打开上次的项目前会要求确认</string>
+	<string name="msg_error_opening_project">打开项目时出错</string>
+	<string name="title_default_shell">在终端中使用系统 Shell</string>
+	<string name="msg_default_shell">如果选中，终端将使用 \'/system/bin/sh\'</string>
+	<string name="title_general">通用</string>
+	<string name="title_tab_size">制表符大小</string>
+	<string name="msg_tab_size">设置 Tab 键缩进的空格数</string>
+	<string name="msg_preferences">偏好设置</string>
+	<string name="pref_changelog">更新日志</string>
+	<string name="msg_editor_font_size">请选择编辑器的默认字体大小：</string>
+	<string name="msg_clear_cache">这将删除 Gradle 创建的缓存目录，如果删除，下次构建可能会比平时稍慢，因为 Gradle 将重新下载所需文件\n\n确定要删除缓存吗？</string>
+
+	<!-- Error Messages used while Logging -->
+
+	<!-- Layout preview and designer -->
+	<string name="title_preview_layout">预览布局</string>
+	<string name="title_preview_compose">预览 Compose</string>
+	<string name="title_viewaction_delete">删除</string>
+	<string name="msg_yesno_def_title">请确认</string>
+	<string name="msg_yesno_def_message">确定吗？</string>
+	<string name="msg_empty_ui_layout">尚未添加任何视图 点击添加视图</string>
+	<string name="msg_generate_xml_failed">生成 XML 代码失败</string>
+    <string name="xml_validation_error_title">布局 XML 错误</string>
+    <string name="xml_validation_error_invalid_file">所选文件不是有效的 Android XML 布局</string>
+    <string name="xml_error_parse">无法读取此布局 XML %1$s</string>
+    <string name="xml_error_io">无法打开此布局 XML %1$s</string>
+    <string name="xml_error_generic">无法打开此布局 %1$s</string>
+    <string name="xml_error_single_child_container">%1$s 只能有一个直接子视图  请将视图包裹在 LinearLayout 或 ConstraintLayout 等容器中</string>
+    <string name="xml_error_add_child_failed">无法将 %1$s 放入 %2$s 中  该容器可能不接受子视图，或已有最大数量的子视图</string>
+    <string name="xml_validation_error_generic">无法打开此布局  请修复 XML 后重试</string>
+	<string name="title_generating_xml">正在生成 XML 代码</string>
+	<string name="msg_swipe_up">上滑以显示日志、诊断、调试信息等</string>
+	<string name="preview_render_error_title">预览不可用</string>
+	<string name="preview_render_error_message">无法创建根视图  XML 为空或缺少有效的顶级元素</string>
+
+	<!-- Crash Screen -->
+	<string name="msg_ide_crashed">Code on the Go 崩溃了</string>
+	<string name="msg_crash_info">发生内部错误\n\n有助于我们修复问题的详细信息已保存，并将在你的设备下次联网时安全发送\n\n按"确定"后应用将关闭，任何未保存的更改可能会丢失 请重新启动应用以继续 \n\n如果错误再次发生，请尝试重启设备 如果问题仍然存在，请%1$s</string>
+	<string name="contact_support_team">联系我们的支持团队 </string>
+	<string name="crash_email_subject">应用崩溃报告</string>
+	<string name="crash_email_body">构建编号 - %1$s\n\n请描述应用崩溃时你在做什么：\n\n</string>
+	<string name="msg_close_crash_page">点击下方按钮关闭此页面</string>
+	<string name="msg_ok">确定</string>
+
+	<string name="title_translations">翻译</string>
+	<string name="action_expand_selection">展开选择</string>
+	<string name="action_explain_selection">解释所选内容</string>
+	<string name="msg_ai_gemini_api_key_missing">缺少 Gemini API 密钥 请在 AI 设置中添加 </string>
+	<string name="msg_ai_local_model_not_loaded">本地模型未加载 请在 AI 设置中加载模型 </string>
+	<string name="idepref_java_matchLower_title">小写匹配补全</string>
+	<string name="title_common">通用</string>
+	<string name="idepref_editor_category_common" translatable="false">@string/title_common</string>
+	<string name="idepref_editor_category_java" translatable="false">Java</string>
+	<string name="title_files_unsaved">未保存的文件</string>
+	<string name="msg_files_unsaved">部分文件尚未保存 是否要在关闭前保存？未保存的文件：\n%s</string>
+	<string name="idepref_java_matchLower_summary">启用后，即使以小写输入，代码补全也能匹配类名和成员（不区分大小写匹配） </string>
+	<string name="idepref_editor_ligatures_title">字体连字</string>
+	<string name="idepref_editor_ligatures_summary">启用/禁用字体连字</string>
+	<string name="yes">是</string>
+	<string name="no">否</string>
+	<string name="msg_viewaction_add_attr">添加属性</string>
+	<string name="msg_file_tree">文件树</string>
+	<string name="hint_attr_value">属性值</string>
+	<string name="title_format_code">格式化代码</string>
+	<string name="title_show_tooltip">帮助</string>
+	<string name="show_tooltip_show_more">显示更多</string>
+	<string name="faq_activity_title">更多信息</string>
+	<string name="idepref_java_useGoogleStyle_title">使用 Google Java 样式格式化代码</string>
+	<string name="idepref_java_useGoogleStyle_summary">使用 Google 约定格式化 Java 代码 </string>
+	<string name="idepref_visiblePassword_title">隐藏键盘建议</string>
+	<string name="idepref_visiblePassword_summary">禁用屏幕键盘的文本预测和自动更正 </string>
+	<string name="previous">上一个</string>
+	<string name="title_gradle_service_notification_ticker">Gradle 构建服务已启动</string>
+	<string name="title_gradle_service_notification">Gradle 构建服务</string>
+	<string name="title_cancel_build">取消构建</string>
+	<string name="msg_initializing_project">正在初始化项目</string>
+	<string name="msg_project_initialized">项目已初始化</string>
+	<string name="msg_project_initialization_failed_with_name">%1$s 的项目初始化失败</string>
+	<string name="msg_project_initialization_failed">项目初始化失败</string>
+	<string name="msg_project_not_initialized">项目尚未初始化</string>
+	<string name="msg_replacement">替换为</string>
+	<string name="title_sync_project">同步项目</string>
+	<string name="wizard_save_location">保存位置</string>
+	<string name="wizard_language">项目语言</string>
+	<string name="next">下一步</string>
+	<string name="exit">退出</string>
+	<string name="idepref_title_customGradleInstallation">自定义 Gradle 安装</string>
+	<string name="idepref_msg_customGradleInstallation">指定用于构建的自定义 Gradle 安装 这将覆盖 gradle-wrapper.properties 中指定的版本 </string>
+	<string name="msg_gradle_installation_path">Gradle 安装路径</string>
+	<string name="msg_gradle_installation_input_help">留空则使用 Gradle Wrapper </string>
+
+	<string name="build_status_idle">没有进行中的构建</string>
+	<string name="build_status_in_progress">正在构建…</string>
+	<string name="build_status_failed">构建失败 请查看构建输出面板了解详情 </string>
+	<string name="build_status_sucess">构建成功</string>
+	<string name="msg_output_text_extraction_failed">从编辑器获取文本失败</string>
+	<string name="err_invalid_data_by_intent">Intent 返回了无效数据</string>
+	<string name="msg_select_from_primary_storage">从主存储中选择目录</string>
+	<string name="err_authority_not_allowed">Authority \'%s\' 不允许</string>
+	<string name="idepref_useIcu_title">将空格作为单词边界</string>
+	<string name="idepref_useIcu_summary">启用后，编辑器将空格视为单词之间的分隔符 </string>
+	<string name="msg_drawer_for_files">要查看文件树和项目选项，请从左向右滑动或点击左上角的菜单图标 </string>
+	<string name="msg_swipe_for_output">要查看日志、诊断信息等，请上滑或点击页面底部 </string>
+	<string name="msg_help_hint">要查看 Code on the Go 应用的帮助，长按任意元素可查看提示 在编辑器中，选中文本并长按可显示编辑工具栏和帮助按钮 </string>
+	<string name="msg_long_press_help">要查看 Code on the Go 的帮助，长按任意元素可查看提示 在编辑器中，选中文本并长按可显示编辑工具栏和帮助按钮 </string>
+	<string name="idepref_editor_useSoftTabs_title">使用软制表符</string>
+	<string name="idepref_editor_useSoftTabs_summary">选择 Tab 键是插入空格还是制表符 </string>
+	<string name="btn_donate">捐赠</string>
+	<string name="btn_docs">帮助</string>
+	<string name="btn_close">关闭</string>
+	<string name="msg_ignore_case">忽略大小写</string>
+	<string name="msg_use_regex">使用正则表达式</string>
+	<string name="idepref_buildnrun_summary">配置 Gradle 构建</string>
+	<string name="configure">配置</string>
+	<string name="about">关于</string>
+	<string name="idepref_channel_summary">订阅获取最新更新 </string>
+	<string name="idepref_group_summary">在此讨论功能、错误和改进 </string>
+	<string name="idepref_changelog_summary">此版本有什么新内容？</string>
+	<string name="idepref_about_summary">关于 Code on the Go 的更多信息</string>
+	<string name="idepref_general_summary">通用 IDE 配置</string>
+	<string name="idepref_editor_summary">配置编辑器</string>
+	<string name="xml" translatable="false">XML</string>
+	<string name="idepref_xml_trimFinalNewLine_title">修剪末尾换行符</string>
+	<string name="idepref_xml_insertFinalNewLine_title">插入末尾换行符</string>
+	<string name="idepref_xml_trimFinalNewLine_summary">删除文件末尾的空换行符 </string>
+	<string name="idepref_xml_insertFinalNewLine_summary">在文件末尾插入一个换行符 </string>
+	<string name="idepref_xml_splitAttributes_title">拆分属性</string>
+	<string name="idepref_xml_splitAttributes_summary">将每个属性放在单独的一行 </string>
+	<string name="idepref_xml_joinCDataLines_title">合并 CDATA 行</string>
+	<string name="idepref_xml_joinCDataLines_summary">将多个 CDATA 块合并为一个块 </string>
+	<string name="idepref_xml_joinComment_title">合并注释行</string>
+	<string name="idepref_xml_joinComment_summary">将多个单行 XML 注释合并为一行 </string>
+	<string name="idepref_xml_joinContent_title">合并内容行</string>
+	<string name="idepref_xml_joinContent_summary">将单个 XML 元素中的多行文本合并为一行 </string>
+	<string name="idepref_xml_spaceBeforeEmptyClose_title">空关闭标签前加空格</string>
+	<string name="idepref_xml_spaceBeforeEmptyClose_summary">在每个结束标签前添加一个空格 </string>
+	<string name="idepref_xml_preserveEmptyContent_title">保留空内容</string>
+	<string name="idepref_xml_preserveEmptyContent_summary">保留原本空行上的标签，而不是折叠它们 </string>
+	<string name="idepref_xml_preserveAttrLineBreaks_title">保留属性换行</string>
+	<string name="idepref_xml_preserveAttrLineBreaks_summary">保持属性在单独的行上，而不是折叠它们 </string>
+	<string name="idepref_xml_closingBrackNewLine_title">关闭括号换行</string>
+	<string name="idepref_xml_closingBrackNewLine_summary">将关闭括号和自闭合标签放在最后一个属性之后的新行上 </string>
+	<string name="idepref_xml_trimTrailingWs_title">修剪尾部空格</string>
+	<string name="idepref_xml_trimTrailingWs_summary">删除行尾的多余空格 </string>
+	<string name="idepref_maxLineWidth_title">最大行宽</string>
+	<string name="idepref_maxLineWidth_summary">设置单行最大字符数，超过后编辑器会自动换行或折行 </string>
+	<string name="idepref_splitAttrIndentSize_title">拆分属性缩进大小</string>
+	<string name="idepref_splitAttrIndentSize_summary">设置拆分到单独行上的属性自动缩进空格数 </string>
+	<string name="idepref_preservedNewLines_title">保留换行</string>
+	<string name="idepref_preservedNewLines_summary">设置文件重新格式化或保存时保留的最大空白行数 </string>
+	<string name="idepref_emptyElements_title">空元素行为</string>
+	<string name="idepref_emptyElements_summary">选择空 XML 元素的格式化方式 </string>
+	<string name="xml_formatting_options">XML 格式化选项</string>
+	<string name="xml_formatting_options_summary">设置 XML 文件的格式化偏好 </string>
+	<string name="idepref_customFont_title">使用自定义字体</string>
+	<string name="idepref_customFont_summary">启用后，将使用 "/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf" 作为编辑器字体 </string>
+	<string name="msg_installing_apk">正在安装 APK…</string>
+	<string name="msg_action_open_application">你的应用已安装 是否要启动该应用？</string>
+	<string name="msg_action_open_title_application">应用已安装</string>
+
+	<string name="title_gradle_service_notification_channel">Code on the Go Gradle 构建服务</string>
+	<string name="msg_hex_color_code">十六进制颜色代码</string>
+	<string name="msg_unsupported_color_format">不支持的色彩格式：%s</string>
+	<string name="msg_color_picker_pick">选取</string>
+	<string name="msg_chmod_exec">正在设置可执行权限…</string>
+	<string name="msg_linking">正在链接 %1$s 到 %2$s</string>
+	<string name="msg_extracting_hooks">正在提取钩子库…</string>
+	<string name="msg_empty_package">包名为空</string>
+	<string name="msg_package_is_not_valid">包名无效</string>
+	<string name="msg_package_is_to_long">包名过长</string>
+	<string name="msg_package_not_valid_char_1">字符 \'_\' 不能作为包名段的首字符</string>
+	<string name="msg_package_not_use_digit_first">数字不能作为包名段的首字符</string>
+	<string name="msg_package_not_valid_char_2">字符 "%1$s" 在 Android 应用包名中不允许使用 </string>
+	<string name="msg_package_mus_have_dot">包名必须至少包含一个 \'.\' 分隔符 </string>
+
+	<string name="action_import_classes">导入类</string>
+	<string name="action_generate_setters_getters">生成 setter/getter</string>
+	<string name="action_add_throws">添加 \'throws\'</string>
+	<string name="action_comment_line">注释行</string>
+	<string name="action_create_missing_method">创建缺失的方法</string>
+	<string name="action_convert_to_block">转换为块</string>
+	<string name="action_generate_constructor">生成构造方法</string>
+	<string name="action_implement_abstract_methods">实现抽象方法</string>
+	<string name="action_remove_class">移除类</string>
+	<string name="action_remove_method">移除方法</string>
+	<string name="action_remove_unused_throws">移除未使用的 throws</string>
+	<string name="action_suppress_unchecked_warning">抑制 \'unchecked\' 警告</string>
+	<string name="action_uncomment_line">取消注释行</string>
+	<string name="action_convert_to_statement">转换为语句</string>
+	<string name="msg_select_fields">选择字段</string>
+	<string name="msg_no_fields_selected">未选择字段</string>
+	<string name="msg_no_fields_found">未找到字段</string>
+	<string name="action_override_superclass_methods">重写超类方法</string>
+	<string name="msg_no_methods_selected">未选择方法</string>
+	<string name="msg_cannot_override_methods">无法重写方法</string>
+	<string name="msg_cannot_generate_setters_getters">无法生成 setter 和 getter</string>
+	<string name="msg_select_methods">选择要重写的方法</string>
+	<string name="msg_no_overridable_methods">找不到任何可重写的方法</string>
+	<string name="action_goto_definition">转到定义</string>
+	<string name="action_find_references">查找引用</string>
+	<string name="action_generate_toString">生成 toString()</string>
+	<string name="action_remove_unused_imports">移除未使用的导入</string>
+	<string name="action_organize_imports">整理导入</string>
+	<string name="action_null_safety_fixes">空安全修复</string>
+	<string name="action_null_safety_assert">添加非空断言 (!!)</string>
+	<string name="action_null_safety_safe_call">更改为安全调用 (?.)</string>
+	<string name="action_null_safety_elvis">添加 Elvis 运算符 (?:)</string>
+	<string name="action_implement_members">实现成员</string>
+	<string name="msg_cannot_generate_toString">无法生成 toString() 实现</string>
+	<string name="msg_toString_overridden">toString() 已被重写</string>
+	<string name="action_generate_missing_constructor">生成缺失的构造方法</string>
+	<string name="msg_cannot_generate_constructor">无法生成构造方法</string>
+	<string name="msg_constructor_available">已存在具有相同参数类型的构造方法</string>
+
+	<string name="replace">替换</string>
+	<string name="replaceAll">全部替换</string>
+	<string name="title_run_tasks">运行任务</string>
+	<string name="hint_search_tasks">搜索任务…</string>
+	<string name="msg_err_select_tasks">请选择要运行的任务</string>
+	<string name="title_confirmation">确认</string>
+	<string name="msg_tasks_to_run">以下任务将按顺序运行 请再次点击"运行"按钮确认 \n\n%1$s</string>
+	<string name="msg_loading_tasks">正在加载任务…</string>
+
+	<string name="ui_category_widgets" translatable="false">Widgets</string>
+	<string name="ui_category_layouts" translatable="false">Layouts</string>
+
+	<string name="widget_view" translatable="false">View</string>
+	<string name="widget_textview" translatable="false">TextView</string>
+	<string name="widget_button" translatable="false">Button</string>
+	<string name="widget_checkbox" translatable="false">CheckBox</string>
+	<string name="widget_checked_textview" translatable="false">CheckedTextView</string>
+	<string name="widget_edittext" translatable="false">EditText</string>
+	<string name="widget_image_button" translatable="false">ImageButton</string>
+	<string name="widget_image_view" translatable="false">ImageView</string>
+	<string name="widget_progressbar" translatable="false">ProgressBar</string>
+	<string name="widget_radio_button" translatable="false">RadioButton</string>
+	<string name="widget_radio_group" translatable="false">RadioGroup</string>
+	<string name="widget_seekbar" translatable="false">SeekBar</string>
+	<string name="widget_spinner" translatable="false">Spinner</string>
+	<string name="widget_auto_complete_textview" translatable="false">AutoCompleteTextView</string>
+	<string name="widget_multi_auto_complete_textview" translatable="false">MultiAutoCompleteTextView</string>
+	<string name="widget_listview" translatable="false">ListView</string>
+	<string name="widget_surfaceview" translatable="false">SurfaceView</string>
+	<string name="widget_switch" translatable="false">Switch</string>
+	<string name="widget_textureview" translatable="false">TextureView</string>
+	<string name="widget_togglebutton" translatable="false">ToggleButton</string>
+	<string name="widget_webview" translatable="false">WebView</string>
+	<string name="widget_frame_layout" translatable="false">FrameLayout</string>
+	<string name="widget_grid_layout" translatable="false">GridLayout</string>
+	<string name="widget_linear_layout_horz" translatable="false">LinearLayout (H)</string>
+	<string name="widget_linear_layout_vert" translatable="false">LinearLayout (V)</string>
+	<string name="widget_relative_layout" translatable="false">RelativeLayout</string>
+	<string name="widget_scrollview" translatable="false">ScrollView</string>
+	<string name="widget_horizontal_scrollview" translatable="false">HorizontalScrollView</string>
+	<string name="widget_text_clock" translatable="false">TextClock</string>
+	<string name="widget_digital_clock" translatable="false">DigitalClock</string>
+	<string name="widget_calendar_view" translatable="false">CalendarView</string>
+	<string name="widget_space" translatable="false">Space</string>
+	<string name="widget_number_picker" translatable="false">NumberPicker</string>
+	<string name="widget_chronometer" translatable="false">Chronometer</string>
+	<string name="widget_rating_bar" translatable="false">RatingBar</string>
+	<string name="widget_quick_contact_badge" translatable="false">QuickContactBadge</string>
+	<string name="widget_videoview" translatable="false">VideoView</string>
+	<string name="widget_analog_clock" translatable="false">AnalogClock</string>
+	<string name="widget_grid_view" translatable="false">GridView</string>
+	<string name="widget_viewanimator" translatable="false">ViewAnimator</string>
+	<string name="widget_viewswitcher" translatable="false">ViewSwitcher</string>
+	<string name="widget_textswitcher" translatable="false">TextSwitcher</string>
+	<string name="widget_imageswitcher" translatable="false">ImageSwitcher</string>
+	<string name="widget_viewflipper" translatable="false">ViewFlipper</string>
+
+	<string name="msg_select_attr">从以下列表中选择一个属性</string>
+	<string name="action_show_hierarchy">显示布局层次</string>
+	<string name="idepref_editor_colorScheme">色彩方案</string>
+	<string name="idepref_editor_colorScheme_summary">选择编辑器中使用的色彩方案</string>
+	<string name="idepref_general_uiMode">界面模式</string>
+	<string name="idepref_general_uiMode_summary">选择使用浅色模式、深色模式或跟随当前系统设置 </string>
+	<string name="uiMode_light">浅色</string>
+	<string name="uiMode_dark">深色</string>
+	<string name="uiMode_system">跟随系统</string>
+	<string name="idepref_general_themeSelector_title">主题</string>
+	<string name="idepref_general_themeSelector_summary">为 Code on the Go 选择主题（需要重启） </string>
+	<string name="idepref_general_projectConfig">项目配置</string>
+	<string name="msg_app_launch_failed">必须先构建并安装应用才能启动 </string>
+	<string name="idepref_java_diagnosticEnabled_title">启用诊断</string>
+	<string name="idepref_java_diagnosticsEnabled_summary">（实验性）是否分析 Java 源文件中的错误 </string>
+	<string name="title_reload_color_schemes">重新加载色彩方案</string>
+	<string name="msg_dir_picker_failed">启动目录选择器失败：%1$s</string>
+	<string name="msg_tooling_server_unavailable">Tooling API 服务器不可用 请检查构建输出和 IDE 日志中的错误信息 </string>
+	<!-- Shown when one or more dependency JARs were corrupt/unreadable during classpath indexing. %1$s is a comma-separated list of dependency names (may end with an overflow clause). -->
+	<string name="msg_unreadable_classpath_jars">部分依赖项无法读取，已跳过，因此代码补全可能不完整：%1$s 请同步项目以重新下载依赖项 </string>
+	<!-- Appended to the dependency list when more than three dependencies were skipped. %1$s is the first listed dependency names; %2$d is the count of additional ones. -->
+	<string name="msg_unreadable_classpath_jars_overflow">%1$s 及其他 %2$d 个</string>
+	<string name="idepref_deleteEmptyLines_title">按退格键时删除空行</string>
+	<string name="idepref_deleteEmptyLines_summary">如果某行不包含可见文本字符，按退格键将删除整行 </string>
+	<string name="idepref_deleteTabs_title">智能退格缩进</string>
+	<string name="idepref_deleteTabs_summary">按退格键时删除整个缩进级别，而不仅仅是一个字符 </string>
+
+	<!-- GitHub -->
+	<string name="title_warning">警告</string>
+	<string name="title_github" translatable="false">GitHub</string>
+	<string name="checkout_conflict_message">检出冲突：请在拉取之前提交或暂存本地更改 冲突文件：\n%1$s</string>
+	<string name="choose_different_location">选择其他位置</string>
+	<string name="new_directory_name">新目录名称</string>
+	<string name="error">错误</string>
+	<string name="error_deleting_directory">删除目录时出错：%s</string>
+	<string name="deleting_directory">正在删除目录</string>
+
+	<string name="btn_sync">同步</string>
+	<string name="btn_ignore_changes">忽略这些更改</string>
+	<string name="title_fix_imports">修复导入</string>
+	<string name="msg_no_unresolved_classes">未发现未解析的类名</string>
+	<string name="title_class_chooser">哪个 %1$s？</string>
+
+	<string name="permlab_bind_logger_service">绑定到日志服务</string>
+	<string name="permdesc_bind_logger_service">允许此应用绑定到 Code on the Go 的日志服务 此权限是 Code on the Go 读取此应用日志所必需的 </string>
+	<string name="wizard_module_name">模块名称</string>
+	<string name="wizard_module_type">模块类型</string>
+	<string name="msg_invalid_module_name">无效的 Gradle 模块名称</string>
+	<string name="msg_value_empty">值为空</string>
+	<string name="msg_file_not_exist">文件不存在</string>
+	<string name="msg_path_must_be_file">必须是文件路径</string>
+	<string name="msg_classname_with_keywords">类名包含关键字</string>
+	<string name="msg_path_must_be_dir">必须是目录路径</string>
+	<string name="msg_invalid_layout_name">无效的布局文件名</string>
+	<string name="msg_invalid_project_details">无效的项目详细信息</string>
+	<string name="msg_use_kts">对 Gradle 构建文件使用 Kotlin 脚本 (.kts)</string>
+	<string name="title_privacy">隐私</string>
+
+	<string name="privacy_disclosure_title">隐私和分析</string>
+	<string name="privacy_disclosure_message">Code on the Go 使用 Firebase Analytics 和 GlitchTip 来帮助我们改进应用 \n\nFirebase Analytics 收集匿名使用数据，帮助我们了解应用的使用情况 \n\nGlitchTip 帮助我们跟踪和修复错误 \n\n不会收集或分享任何个人信息 所有数据均按照我们的隐私政策进行处理 </string>
+	<string name="privacy_disclosure_accept">我了解</string>
+	<string name="privacy_disclosure_learn_more">了解更多</string>
+
+	<string name="title_unique_id">唯一 ID</string>
+	<string name="title_device">设备</string>
+	<string name="title_app_version">应用版本</string>
+	<string name="title_country">国家/地区</string>
+	<string name="title_cpu_arch">CPU 架构</string>
+	<string name="title_preview_data">预览数据</string>
+	<string name="title_android_version">Android 版本</string>
+	<string name="btn_opt_in">同意</string>
+	<string name="title_developer_options">开发者选项</string>
+	<string name="idepref_devOptions_summary">Code on the Go 的实验/调试选项</string>
+	<string name="idepref_group_debugging">调试</string>
+	<string name="idepref_devOptions_dumpLogs_title">转储日志</string>
+	<string name="idepref_devOptions_dumpLogs_summary">将 Code on the Go 日志转储到 $HOME/.cg/logs</string>
+	<string name="msg_emptyview_applogs">运行应用的调试版本以在此查看其日志 </string>
+	<string name="msg_logsender_disabled">LogSender 已禁用 你可以在偏好设置中启用它 </string>
+	<string name="msg_emptyview_idelogs">IDE 的日志在此显示 </string>
+	<string name="msg_emptyview_diagnostics">打开文件以显示其诊断结果</string>
+	<string name="log_filter_hint">筛选行</string>
+	<string name="log_action_filter">筛选</string>
+	<string name="log_action_search">搜索</string>
+	<string name="log_action_share">分享</string>
+	<string name="log_action_clear">清除</string>
+	<string name="log_filter_hide">隐藏筛选栏</string>
+	<string name="log_filter_level_verbose">详细</string>
+	<string name="log_filter_level_debug">调试</string>
+	<string name="log_filter_level_info">信息</string>
+	<string name="log_filter_level_warning">警告</string>
+	<string name="log_filter_level_error">错误</string>
+	<string name="tooltip_search_output">在输出中搜索</string>
+	<string name="tooltip_filter_output">筛选输出</string>
+	<string name="msg_emptyview_buildoutput">构建应用或运行任务以在此查看构建输出 </string>
+	<string name="msg_codeaction_failed">执行代码操作失败</string>
+	<string name="idepref_devOptions_enableLogsender_title">启用 LogSender</string>
+	<string name="idepref_devOptions_enableLogsender_summary">禁用后，来自应用的日志将不会在 Code on the Go 中显示</string>
+	<string name="title_build_variants">构建变体</string>
+	<string name="title_agent">Agent</string>
+	<string name="build_variants_apply">应用</string>
+	<string name="build_variants_cancel">取消</string>
+	<string name="msg_build_variants_fetch_failed">获取构建变体失败</string>
+	<string name="title_choose_application">选择应用</string>
+	<string name="err_selected_variant_not_found">未找到所选的构建变体</string>
+	<string name="err_no_release_variant">未找到模块 \'%1$s\' 的 release 构建变体 分析功能需要 release 变体</string>
+	<string name="title_disconnect_log_senders">断开日志发送器</string>
+	<string name="title_begin_long_select">开始长按选择</string>
+	<string name="idepref_editor_stickScroll_title">粘性滚动</string>
+	<string name="idepref_editor_stickyScroll_summary">滚动时将当前作用域标头固定在编辑器顶部 </string>
+	<string name="idepref_launchAppAfterInstall_title">安装后启动应用</string>
+	<string name="idepref_launchAppAfterInstall_summary">启用后，IDE 将在应用安装后立即启动它（无需确认） </string>
+	<string name="title_run_options">运行选项</string>
+	<string name="err_cannot_determine_package">无法运行应用 无法确定包名 </string>
+	<string name="msg_launch_failure_no_app_module">无法运行应用 项目中未找到应用模块 </string>
+	<string name="title_launch_app">启动应用</string>
+	<string name="title_experiment_flavor">实验性</string>
+	<string name="msg_experimental_flavor">你在 %2$s 设备上使用了 Code On The Go 的 %1$s 变体 此配置可能有效，但会导致性能下降并可能存在安全漏洞 请尽可能避免使用此配置 </string>
+	<string name="idepref_editor_pinLineNumbers_title">固定行号</string>
+	<string name="idepref_editor_pinLineNumbers_summary">锁定行号在视图中，水平滚动时保持可见 </string>
+	<string name="theme_blue_wave">蓝色波浪</string>
+	<string name="theme_sunny_glow">阳光辉光</string>
+	<string name="theme_material_you">Material You</string>
+	<string name="idepref_general_localeSelector_title">语言</string>
+	<string name="idepref_general_localeSelector_summary">选择 Code on the Go 的语言 </string>
+	<string name="locale_system_default">系统默认</string>
+	<string name="msg_project_dir_inaccessible">项目目录不可访问</string>
+	<string name="msg_file_is_not_dir">所选文件不是目录</string>
+	<string name="msg_project_dir_doesnt_exist">项目目录不存在</string>
+	<string name="msg_project_cache_read_failure">读取项目缓存失败</string>
+	<string name="msg_font_copy_failed">无法保存字体文件 请重试 </string>
+	<string name="msg_files_being_saved">文件保存操作正在进行中！</string>
+	<string name="msg_undock_save_failed">无法保存"%1$s" 取消停靠 </string>
+	<string name="title_install_tools">安装开发工具</string>
+	<string name="subtitle_install_tools">\n要安装构建 Android 项目所需的工具，请点击屏幕右下角的按钮\n</string>
+	<string name="msg_install_tools"> </string>
+	<string name="greeting_title">欢迎</string>
+	<string name="greeting_subtitle">没有电脑？没有网络？没问题 </string>
+	<string name="title_grant">允许</string>
+	<string name="permission_title_storage">存储</string>
+	<string name="permission_desc_storage">允许 Code on the Go 在此设备上打开和保存文件 </string>
+	<string name="permission_title_install_packages">安装包</string>
+	<string name="permission_desc_install_packages">允许 Code on the Go 安装你在此设备上构建的应用 </string>
+	<string name="permission_title_overlay_window">浮动调试器</string>
+	<string name="permission_desc_overlay_window">允许 Code on the Go 在应用运行时显示浮动调试控件以检查代码 </string>
+	<string name="permission_overlay_unsupported_hint">此设备不支持浮动调试器 </string>
+	<string name="permission_overlay_restricted_settings_hint">如果无法启用此权限，请显示 Code on the Go 的应用信息，点击三点菜单，然后启用受限设置 </string>
+	<string name="permission_overlay_restricted_dialog_title">启用受限设置</string>
+	<string name="permission_overlay_restricted_dialog_message">Android 已关闭"在其他应用上层显示"开关，因为 Code on the Go 是从应用商店外部安装的 要开启它：</string>
+	<string name="permission_overlay_open_app_info">打开应用信息</string>
+	<string name="permission_title_notifications">通知</string>
+	<string name="permission_desc_notifications">允许 Code on the Go 显示通知 </string>
+	<string name="permission_title_accessibility">无障碍</string>
+	<string name="permission_desc_accessibility">允许 Code on the Go 访问无障碍服务以进行调试 </string>
+	<string name="finish_installation">完成安装</string>
+	<string name="onboarding_title_permissions">权限</string>
+	<string name="onboarding_subtitle_permissions">Code on the Go 需要以下权限：</string>
+	<string name="msg_grant_permissions">请授予权限以继续 </string>
+	<string name="msg_no_internet">你似乎处于离线状态 请检查网络连接 </string>
+	<string name="msg_connected_to_cellular">请注意！你正在使用蜂窝数据 </string>
+	<string name="msg_connected_to_metered_connection">请注意！你正在使用按流量计费的网络 </string>
+	<string name="msg_disable_background_data_restriction">请禁用后台数据限制以避免安装失败 </string>
+	<string name="msg_cannot_create_terminal_session">无法创建终端会话</string>
+	<string name="action_auto_install">自动安装</string>
+	<string name="action_manual_install">手动安装</string>
+	<string name="hint_android_sdk_version">Android SDK 版本</string>
+	<string name="hin_jdk_version">JDK 版本</string>
+	<string name="action_install_git">安装 Git</string>
+	<string name="action_install_openssh">安装 OpenSSH</string>
+	<string name="msg_terminal_new_sessions_disabled">无法创建会话 新会话已被禁用 </string>
+	<string name="title_install_location_error">安装位置错误</string>
+	<string name="title_unsupported_user">不支持的用户</string>
+	<string name="title_socials">社交</string>
+	<string name="title_contribute">贡献</string>
+	<string name="summary_contribute">这不仅仅是一个 IDE，更是一个社区 为 Code On The Go 贡献代码、创意和热情 </string>
+	<string name="msg_app_unavailable_for_intent">没有可用的应用来处理此 Intent </string>
+	<string name="title_open_source_licenses">开源许可证</string>
+	<string name="summary_open_source_licenses">查看开源许可证 </string>
+	<string name="idepref_jdkVersion_title">JDK 版本</string>
+	<string name="idepref_jdkVersion_summary">当前选择：%1$s（更改后需重启）</string>
+	<string name="ide_setup_in_progress">设置正在进行中</string>
+	<string name="ide_setup_complete">Code on the Go 设置完成 </string>
+	<string name="msg_complete_ide_setup">请完成 IDE 设置以继续 </string>
+	<string name="debugger_title">调试器</string>
+	<string name="debugger_starting">正在启动调试器…</string>
+	<string name="debugger_starting_failed">启动调试器失败 请查看 IDE 日志了解详情 </string>
+	<string name="debugger_started">调试器已启动</string>
+	<string name="debugger_variables">变量</string>
+	<string name="debugger_call_stack">调用栈</string>
+	<string name="debugger_thread">线程</string>
+	<string name="debugger_step_into">步入</string>
+	<string name="debugger_step_out">步出</string>
+	<string name="debugger_step_over">步过</string>
+	<string name="debugger_kill">终止</string>
+	<string name="debugger_suspend">挂起</string>
+	<string name="debugger_resume">恢复</string>
+	<string name="debugger_restart">重启</string>
+	<string name="debugger_status_resolving">正在解析…</string>
+	<string name="debugger_thread_resolution_failure"><![CDATA[<resolution-failure>]]></string>
+	<string name="debugger_loading_variable_value">正在加载变量值</string>
+	<string name="debugger_variable_truncated">因大小被截断</string>
+
+	<!-- Connected to <VM-name> (<VM-version>) -->
+	<string name="debugger_state_connected">已连接到 %1$s（%2$s）</string>
+	<string name="debugger_state_not_paired">应用未配对 点击调试器按钮开始无线 ADB 配对 </string>
+	<string name="debugger_state_not_connected">应用已成功配对 点击调试器按钮构建并安装可调试版本 </string>
+
+	<string name="debugger_value_unavailable">&lt;不可用&gt;</string>
+	<string name="debugger_value_error">&lt;错误&gt;</string>
+	<string name="debugger_variable_value_hint">变量值</string>
+	<string name="debugger_variable_dialog_title">%1$s：%2$s</string>
+	<string name="debugger_value_null">null</string>
+	<string name="debugger_dialog_hint_enter_value">输入值</string>
+	<string name="debugger_dialog_button_set">设置</string>
+	<string name="debugger_variable_value_invalid">此变量的值无效</string>
+	<string name="debugger_error_immutable_variable">变量 \'%1$s\' 的值无法更新 </string>
+	<string name="debugger_error_network_access_error">网络访问错误</string>
+	<string name="debugger_error_errno">无法监听 JDWP 连接 操作失败，错误代码 %1$d </string>
+	<string name="debugger_error_errno_eperm">Code On the Go 不允许在本地网络上打开或绑定网络套接字 </string>
+	<string name="debugger_error_errno_econnrefused">Code On the Go 的网络访问被系统屏蔽 该应用不允许使用网络，或服务不可用 </string>
+	<string name="debugger_error_debugger_startup_failure">无法启动 Code On the Go 调试器 </string>
+	<string name="debugger_not_ready">调试器尚未准备好进行调试会话 </string>
+	<string name="debugger_error_suggestion_network_restriction">请确保 Code On the Go 有权限访问本地网络 可以在设备的设置中进入 Code On the Go 的"应用信息"界面，检查"数据使用"下是否允许网络访问（具体名称可能因设备而异） \n\n如果允许网络访问但问题仍然存在，请附上日志提交错误报告 </string>
+
+	<string name="err_no_activity_to_handle_action">没有 Activity 可以处理操作 %1$s</string>
+
+	<string name="file">文件</string>
+	<string name="actions">操作</string>
+	<string name="help">帮助</string>
+	<string name="email_feedback_warning_prompt">要发送私密消息到 feedback@appdevforall.org，请点击<b>确定</b> 如果你未连接到互联网，消息将不会立即发送 是否要继续？</string>
+	<string name="feedback_subject">对 %1$s 屏幕的反馈</string>
+	<string name="feedback_message">\n\n请在下方的空白处输入你的反馈 如果你在报告问题，请尽可能详细地描述该问题 \n\n谢谢！\n\n-------------堆栈追踪----------\n%1$s</string>
+	<string name="feedback_device_info">应用版本：%1$s\n\nAndroid 版本：%2$s\n\n设备：%3$s</string>
+	<string name="feedback_stack_trace_unavailable">堆栈追踪不可用 请描述你遇到的问题 </string>
+	<string name="send_feedback">发送反馈</string>
+	<string name="alert_message">发送反馈</string>
+	<string name="fab_more">更多</string>
+	<string name="msg_recent_projects">最近的项目</string>
+	<string name="msg_create_new_from_recent">点击<b>新建项目</b>按钮创建新项目，或从文件夹打开已有项目 </string>
+	<string name="msg_no_recent_projects">你没有任何最近的项目</string>
+	<string name="msg_no_projects_to_delete">没有可用于删除的项目 </string>
+	<string name="msg_no_valid_projects">在 %1$s 中未找到有效的 Android 项目</string>
+	<string name="msg_skipped_invalid_projects">部分文件夹已被跳过，因为它们不是有效的 Android 项目文件夹 </string>
+	<string name="msg_cannot_access_folder">无法访问文件夹 %1$s 请检查存储权限 </string>
+	<string name="msg_no_subfolders">文件夹 %1$s 不包含任何子文件夹 </string>
+	<string name="msg_create_new_project_instruction">点击"新建项目"按钮创建一个新项目 </string>
+	<string name="date">%1$s：%2$s</string>
+	<string name="date_created_label">创建时间</string>
+	<string name="date_modified_label">修改时间</string>
+	<string name="loading_project">正在加载项目…</string>
+	<string name="project_directory_invalid">%s 不是有效的 Android 项目文件夹 请打开其他文件夹 </string>
+	<string name="open_from_folder">从文件夹打开</string>
+	<string name="msg_delete_selected_project">确定要删除所选项目吗？此操作无法撤消 </string>
+	<string name="feedback_email">feedback@appdevforall.org</string>
+	<string name="no_email_apps">未找到邮件应用</string>
+	<string name="msg_internet_access_required">需要互联网访问 </string>
+	<string name="msg_contact_app_dev_title">联系 App Dev for All</string>
+	<string name="msg_contact_app_dev_description">要报告问题、提出建议或提问，请发送邮件至 feedback@appdevforall.org \n需要互联网访问 </string>
+	<string name="code_on_the_go">Code on the Go</string>
+	<string name="feedback_email_subject">Code on the Go 反馈</string>
+	<string name="msg_feedback_log_too_long">日志太大，无法直接发送 </string>
+	<string name="msg_no_internet_no_problem">没有电脑？没有网络？\n没问题 </string>
+	<string name="offline_message">离线</string>
+	<string name="more_label">更多</string>
+	<string name="send_email">发送邮件</string>
+	<string name="close">关闭</string>
+	<string name="tooltip_see_more_text">+ 查看更多</string>
+	<string name="more_information_about">关于 %1$s 的更多信息</string>
+	<string name="learn_more">了解更多</string>
+	<string name="alert">注意！</string>
+	<string name="commit_canceled_files_to_commit">有文件需要提交，提交已取消</string>
+	<string name="commit_canceled_no_files_to_commit">没有要提交的文件，提交已取消</string>
+	<string name="committed_all_changes_to_repository_in">已将所有更改提交到 %1$s 中的仓库</string>
+	<string name="halt">暂停</string>
+	<string name="breakpoint">断点</string>
+	<string name="project_name">项目名称</string>
+	<string name="project_options">项目选项</string>
+	<string name="desc_enter_fullscreen">进入全屏</string>
+    <string name="desc_exit_fullscreen">退出全屏</string>
+
+	<!-- Plugin System -->
+	<string name="plugin_manager">插件管理器</string>
+	<string name="plugin_manager_title">插件管理器</string>
+	<string name="plugin_manager_summary">管理 IDE 插件和扩展</string>
+	<string name="plugins">插件</string>
+	<string name="no_plugins_installed">未安装插件</string>
+	<string name="no_plugins_installed_hint">点击 + 按钮安装你的第一个插件</string>
+	<string name="install_plugin">安装插件</string>
+	<string name="plugin_installed">插件安装成功</string>
+	<string name="plugin_install_failed">安装插件失败</string>
+	<string name="plugin_enabled">插件已启用</string>
+	<string name="plugin_disabled">插件已禁用</string>
+	<string name="plugin_uninstalled">插件已卸载</string>
+	<string name="enable_plugin">启用</string>
+	<string name="disable_plugin">禁用</string>
+	<string name="uninstall_plugin">卸载</string>
+	<string name="plugin_details">插件详情</string>
+	<string name="plugin_permissions">权限</string>
+	<string name="plugin_dependencies">依赖项</string>
+
+	<!-- Plugin crash dialog -->
+	<string name="title_plugin_crashed">插件崩溃</string>
+	<string name="msg_plugin_crash">"%1$s"已崩溃（第 %2$d/3 次） </string>
+	<string name="msg_plugin_crash_disabled">"%1$s"因反复崩溃已被禁用 </string>
+	<string name="msg_plugin_crash_dev_hint">如果你是插件开发者，请点击信息图标查看崩溃日志 </string>
+	<string name="cd_plugin_crash_view_logs">查看崩溃日志</string>
+	<string name="title_plugin_crash_log">崩溃日志：%1$s</string>
+	<string name="msg_crash_log_copied">崩溃日志已复制到剪贴板</string>
+
+	<!-- Message shown when the bootstrap installer is extract a file from the zip -->
+	<!-- The first parameter is the name of the zip entry -->
+	<string name="bootstrap_installer_unzipping">正在解压 %1$s</string>
+
+	<!-- Message shown when the bootstrap installer is in the linking phase -->
+	<string name="bootstrap_installer_linking">正在解析符号链接…</string>
+
+	<!-- Tooltip HTML Template -->
+	<string name="tooltip_html_template"><![CDATA[
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <style>
+                     body {
+                        margin: 0;
+                        padding: 10px;
+                        word-wrap: break-word;
+                        color: %1$s;
+                     }
+                     a{
+                        color: %3$s;
+                        text-decoration: underline;
+                       }
+                </style>
+            </head>
+            <body>
+                %2$s
+            </body>
+
+		</html>
+		]]></string>
+
+	<!-- Tooltip HTML Components -->
+	<string name="tooltip_buttons_separator"><![CDATA[<br>]]></string>
+	<string name="tooltip_detail_links_template"><![CDATA[%1$s<br><br>%2$s]]></string>
+	<string name="plugin_documentation_third_party_disclaimer">&lt;br&gt;&lt;br&gt;&lt;em style=&quot;color: #888; font-size: 0.9em;&quot;&gt;此文档由第三方插件提供 &lt;/em&gt;</string>
+
+	<!-- Tooltip Debug Dialog -->
+	<string name="tooltip_debug_dialog_title">提示调试信息</string>
+	<string name="tooltip_debug_metadata_html"><![CDATA[<b>版本</b> <small>%1$s</small><br/>
+<b>行：</b> %2$d<br/>
+<b>ID：</b> %3$d<br/>
+<b>类别：</b> %4$s<br/>
+<b>标签：</b> %5$s<br/>
+<b>原始摘要：</b> %6$s<br/>
+<b>原始详情：</b> %7$s<br/>
+<b>按钮：</b> %8$s<br/>]]></string>
+	<string name="tooltip_debug_plugin_html"><![CDATA[<h3>插件提示调试信息</h3>
+<b>版本：</b> <small>%1$s</small><br/>
+<b>行：</b> %2$d<br/>
+<b>ID：</b> %3$d<br/>
+<b>类别：</b> %4$s<br/>
+<b>标签：</b> %5$s<br/>
+<br/>
+<b>原始摘要：</b><br/>
+<small>%6$s</small><br/>
+<br/>
+<b>原始详情：</b><br/>
+<small>%7$s</small><br/>
+<br/>
+<b>按钮：</b> %8$s]]></string>
+
+	<!-- Tooltip Debug Button Formatting -->
+	<string name="tooltip_debug_button_separator"><![CDATA[<br/>]]></string>
+	<string name="tooltip_debug_button_item_template_simple">• %1$s</string>
+	<string name="tooltip_debug_button_item_template">\'%1$s \u2192 %2$s\'</string>
+
+	<string name="info_icon_content_description">信息图标</string>
+	<string name="feedback_button_description">发送关于此提示的反馈</string>
+	<string name="sponsor_button_description">在 GitHub Sponsors 上支持我们</string>
+	<string name="cd_more_options">更多选项</string>
+	<string name="cd_expand_collapse">展开或折叠</string>
+	<string name="cd_file_icon">文件图标</string>
+	<string name="cd_folder_icon">文件夹图标</string>
+	<string name="cd_close">关闭</string>
+	<string name="cd_save">保存</string>
+	<string name="cd_undo">撤销</string>
+	<string name="cd_redo">重做</string>
+	<string name="cd_delete">删除</string>
+	<string name="cd_add">添加</string>
+	<string name="cd_search">搜索</string>
+	<string name="cd_diagnostic_error">错误</string>
+	<string name="cd_diagnostic_warning">警告</string>
+	<string name="cd_diagnostic_info">信息</string>
+
+	<!-- Toolbar content descriptions for TalkBack (match actual function) -->
+	<string name="cd_toolbar_quick_run">快速运行</string>
+	<string name="cd_toolbar_cancel_build">取消构建</string>
+	<string name="cd_toolbar_sync_project">同步项目</string>
+	<string name="cd_toolbar_start_debugger">启动调试器</string>
+	<string name="cd_toolbar_run_gradle_tasks">运行 Gradle 任务</string>
+	<string name="cd_toolbar_undo">撤销</string>
+	<string name="cd_toolbar_redo">重做</string>
+	<string name="cd_toolbar_save">保存</string>
+	<string name="cd_toolbar_preview_layout">预览布局</string>
+	<string name="cd_toolbar_find">查找</string>
+	<string name="cd_toolbar_find_in_file">在文件中查找</string>
+	<string name="cd_toolbar_find_in_project">在项目中查找</string>
+	<string name="cd_toolbar_launch_app">启动应用</string>
+	<string name="cd_toolbar_disconnect_log_senders">断开日志发送器</string>
+	<string name="cd_toolbar_image_to_layout">图片转布局</string>
+
+	<!-- Drawer toggle content descriptions -->
+	<string name="cd_drawer_open">打开项目菜单</string>
+	<string name="cd_drawer_close">关闭项目菜单</string>
+
+	<string name="unknown_error">发生未知错误 </string>
+	<string name="build_in_progress_warning">构建已在进行中 忽略新请求 </string>
+	<string name="error_build_service_not_found">未找到构建服务 </string>
+	<string name="error_task_execution_failed">任务执行失败 </string>
+	<string name="error_no_output_listing_file">项目模型中未找到输出列表文件 </string>
+	<string name="error_no_apk_in_output_listing">输出列表文件中未找到 APK </string>
+	<string name="error_apk_not_exist">指定的 APK 文件不存在：%1$s</string>
+	<string name="info_build_cancelled">构建已被用户取消 </string>
+	<string name="error_quick_run_failed">快速运行失败 </string>
+	<string name="status_building">正在构建…</string>
+	<string name="status_installing_plugin">正在安装插件…</string>
+	<string name="title_install_plugin">安装插件</string>
+	<string name="title_plugin_already_installed">插件已安装</string>
+	<string name="msg_plugin_overwrite_confirm">\'%1$s\' v%2$s 已安装 是否将其替换为 v%3$s？</string>
+	<string name="msg_install_plugin_prompt">插件 \'%1$s\' 构建成功 是否立即安装？</string>
+	<string name="btn_install">安装</string>
+	<string name="btn_later">稍后</string>
+	<string name="msg_plugin_installed_restart">插件已安装 请重启应用以激活它 </string>
+	<string name="title_restart_required">需要重启</string>
+	<string name="msg_restart_for_plugin_changes">插件更改将在重启应用后生效 是否立即重启？</string>
+	<string name="btn_restart_now">立即重启</string>
+	<string name="msg_plugin_install_failed">安装插件失败：%1$s</string>
+	<string name="msg_plugin_signature_mismatch">\'%1$s\' 是从不同的构建变体安装的 请先卸载它，再安装此版本 </string>
+	<string name="msg_plugin_error_clip_label">插件错误</string>
+	<string name="msg_plugin_file_not_found">未找到插件文件</string>
+	<string name="msg_plugin_invalid_file">无效或损坏的插件文件 无法读取插件元数据 </string>
+	<string name="msg_plugin_installed">插件安装成功</string>
+	<string name="msg_plugin_load_failed">加载插件失败：%1$s</string>
+	<string name="msg_plugin_enabled">插件已启用</string>
+	<string name="msg_plugin_enable_failed">启用插件失败</string>
+	<string name="msg_plugin_enable_error">启用插件时出错：%1$s</string>
+	<string name="msg_plugin_disabled">插件已禁用</string>
+	<string name="msg_plugin_disable_failed">禁用插件失败</string>
+	<string name="msg_plugin_disable_error">禁用插件时出错：%1$s</string>
+	<string name="msg_plugin_uninstalled">插件已成功卸载</string>
+	<string name="msg_plugin_uninstall_failed">卸载插件失败</string>
+	<string name="msg_plugin_uninstall_error">卸载插件时出错：%1$s</string>
+	<string name="msg_source_delete_failed">无法删除安装文件</string>
+	<string name="msg_unsupported_plugin_file">不支持的文件类型 请选择 .cgp 文件</string>
+	<string name="msg_no_file_manager">未找到文件管理器</string>
+	<string name="msg_plugin_manager_init_failed">初始化插件管理器失败：%1$s</string>
+	<string name="checkbox_delete_source_after_install">安装后删除安装文件</string>
+	<string name="action_discover_plugins">发现插件</string>
+	<string name="url_discover_plugins" translatable="false">https://www.appdevforall.org/contribute/</string>
+	<string name="init_failed_with_reason">%1$s：%2$s</string>
+
+	<string name="msg_template_warnings">\n\n项目创建已完成，但有警告/错误 请打开 IDE 日志查看详情 </string>
+
+	<!-- Name of the notification channel which is used to show notifications for wireless debugging -->
+	<string name="notification_channel_adb_pairing">无线调试配对</string>
+
+	<!-- Hint for the notification text field which asks the user to enter the wireless debugging pairing code -->
+	<string name="notification_adb_pairing_input_paring_code">输入配对码</string>
+
+	<!-- Title for the notification when the wireless debugging pairing service is being searched. -->
+	<string name="notification_adb_pairing_searching_for_service_title">正在搜索配对服务</string>
+
+	<!-- Title for the notification when the wireless debugging pairing service is found. -->
+	<string name="notification_adb_pairing_service_found_title">已找到配对服务</string>
+
+	<!-- Text for the button in the notification to stop searching for the wireless debugging pairing service. -->
+	<string name="notification_adb_pairing_stop_searching">停止搜索</string>
+
+	<!-- Title for the notification when wireless debugging pairing is in progress. -->
+	<string name="notification_adb_pairing_working_title">正在配对</string>
+
+	<!-- Title for the notification when wireless debugging pairing has succeeded. -->
+	<string name="notification_adb_pairing_succeed_title">配对成功</string>
+
+	<!-- Text for the notification when wireless debugging pairing has succeeded, instructing the user on the next step. -->
+	<string name="notification_adb_pairing_succeed_text">按返回按钮返回 Code on the Go </string>
+
+	<!-- Title for the notification when wireless debugging pairing has failed. -->
+	<string name="notification_adb_pairing_failed_title">配对失败</string>
+
+	<!-- Text for the button in the notification to retry wireless debugging pairing after it has failed. -->
+	<string name="notification_adb_pairing_retry">重试</string>
+
+	<!-- Error message displayed when the entered wireless debugging pairing code is incorrect. -->
+	<string name="paring_code_is_wrong">配对码错误 </string>
+
+	<!-- Error message displayed when the application cannot connect to the wireless debugging service port. -->
+	<string name="cannot_connect_port">无法连接到无线调试服务 </string>
+
+	<!-- Error message displayed when the Keystore mechanism on the device is broken, preventing key generation for wireless
+		debugging. -->
+	<string name="adb_error_key_store">无法生成无线调试密钥 \n设备上的密钥库机制可能已损坏 </string>
+
+	<!-- Label for the input field where the user enters the wireless debugging pairing code in a dialog. -->
+	<string name="dialog_adb_pairing_paring_code">配对码</string>
+
+	<!-- Text for an action button that initiates the wireless debugging pairing process. -->
+	<string name="adb_pairing_action_start">开始配对</string>
+
+	<!-- Text for an action button that prompts the user to grant notification permission for wireless debugging pairing. -->
+	<string name="adb_pairing_action_enable_notifications">授予通知权限</string>
+
+	<!-- Instructional text explaining that a notification will guide the user through wireless debugging pairing. -->
+	<string name="adb_pairing_tutorial_content_notification">Code on the Go 的通知将帮助你完成配对 \n请允许 Code on the Go 通过 \'%1$s\' 通知频道显示通知 </string>
+
+	<!-- Message displayed when the user attempts an action that requires wireless debugging pairing, but pairing has not
+		been completed. -->
+	<string name="adb_pair_required">请启用无线调试并按照说明配对调试器 </string>
+
+	<!-- Status message indicating that the application is searching for the ADB connection port. Placeholder %1$d represents
+		the number of times the IDE has tried to find the port. Placeholder %2$d represents the maximum number of attempts to find
+		the port. -->
+	<string name="adb_connection_finding">正在查找 ADB 连接端口（尝试 %1$d/%2$d）…</string>
+
+	<!-- Status message indicating that the application is attempting to connect to the ADB daemon on a specific port. The
+		%1$d is a placeholder for the port number. -->
+	<string name="adb_connection_connecting">正在连接到端口 %1$d 上的 ADB 守护进程…</string>
+
+	<!-- Status message indicating a successful connection to the ADB daemon. -->
+	<string name="adb_connection_succeeded">已成功连接到 ADB 守护进程</string>
+
+	<!-- Status message indicating a failed connection to the ADB daemon. The %1$s is a placeholder for the error reason. -->
+	<string name="adb_connection_failed">连接到 ADB 守护进程失败：%1$s</string>
+
+	<!-- Status message indicating that the application is waiting for the ADB service to become available. -->
+	<string name="adb_connection_waiting_for_service">正在等待服务…</string>
+
+	<!-- Status message indicating that the ADB service has started. -->
+	<string name="adb_connection_done">服务已启动</string>
+
+	<!-- Error message displayed when the application is denied permission to start foreground services, which is necessary
+		for some features. -->
+	<string name="err_foreground_service_denial">Code on the Go 不允许启动前台服务（OP_START_FOREGROUND 被拒绝）</string>
+
+	<!-- Error message displayed when the debugger feature is accessed on a device running an Android version older than
+		11, as it's a requirement. -->
+	<string name="err_debugger_requires_a11">调试器需要 Android 11 或更高版本才能运行 </string>
+	<string name="err_profiler_requires_a11">分析器需要 Android 11 或更高版本才能运行</string>
+
+	<!-- Title of the dialog shown to ask the user to complete the pairing process -->
+	<string name="debugger_setup_title">无线调试配对</string>
+
+	<!-- Text shown to the user in the ADB pairing dialog asking the user to follow the steps -->
+	<string name="debugger_setup_description_header"><![CDATA[<a href="http://localhost:6174/i/debug-enable.html">阅读完整的调试器设置指南</a> 
+	要使用调试器，必须先启用开发者选项 准备好与调试器配对时：]]></string>
+
+	<!-- Steps shown to the user in an ordered list in the ADB pairing dialog -->
+	<string-array name="overlay_restricted_settings_steps">
+		<item><![CDATA[在<b>应用信息</b>界面，点击右上角的三点菜单（⋮） ]]></item>
+		<item><![CDATA[点击<b>允许受限设置</b> ]]></item>
+		<item><![CDATA[打开<b>在其他应用上层显示</b>并为 Code on the Go 开启此选项 ]]></item>
+	</string-array>
+	<string-array name="debugger_setup_pairing_steps">
+		<item><![CDATA[点击<b>开始配对</b> 将显示开发者选项 ]]></item>
+		<item><![CDATA[启用<b>无线调试</b> ]]></item>
+		<item><![CDATA[点击文字<b>无线调试</b>以显示更多选项 ]]></item>
+		<item><![CDATA[点击<b>使用配对码配对设备</b> ]]></item>
+		<item><![CDATA[在提示时输入配对码 将显示成功消息 返回 Code on the Go 后，调试器将已连接 ]]></item>
+	</string-array>
+
+	<!-- Text shown at the bottom of the ADB pairing dialog -->
+	<string name="debugger_setup_description_footer"><![CDATA[部分设备（包括较旧的小米设备）还需要授予 Code on the Go "不受限制的电池使用权限" <a href="http://localhost:6174/i/debug-enable.html">查看更多信息，包括故障排除提示</a> ]]></string>
+
+	<!-- Tooltip Links HTML Template -->
+	<string name="tooltip_links_html_template"><![CDATA[<a href="%1$s" style="color:%2$s;text-decoration:underline;">%3$s</a>]]></string>
+	<string name="title_alert">发送反馈</string>
+
+	<!-- Strings from BaseApplication.java -->
+	<string name="github_discussions_url">https://github.com/appdevforall/CodeOnTheGo/discussions</string>
+	<string name="telegram_channel_url">https://t.me/CodeOnTheGoOfficial</string>
+	<string name="sponsor_url">https://m.androidide.com/donate</string>
+	<string name="support_our_work">支持我们的工作</string>
+	<string name="github_sponsors_url">https://github.com/sponsors/appdevforall</string>
+	<string name="docs_url">http://localhost:6174/i/index.html</string>
+	<string name="privacy_policy_url">https://www.appdevforall.org/wp-content/uploads/2024/08/privacy_notice.pdf</string>
+	<string name="quickstart_url">http://localhost:6174/i/cogo-quickstart.html</string>
+	<string name="adfa_email">info@appdevforall.org</string>
+	<string name="mail_to_adfa">mailto:info@appdevforall.org</string>
+
+	<!-- AI Agent -->
+	<string name="ai_setting_saved">💾 已保存：%1$s</string>
+	<string name="ai_setting_no_model_is_currently_loaded">🤷‍♀️ 当前未加载模型</string>
+	<string name="ai_setting_loading_model_please_wait">🔄 正在加载模型，请稍候…</string>
+	<string name="ai_setting_model_loaded">✅ 模型已加载：%1$s</string>
+	<string name="ai_setting_error_loading_model">❌ 加载模型出错：%1$s</string>
+
+	<!-- Model load errors -->
+	<string name="model_error_engine_init">推理引擎无法初始化 </string>
+	<string name="model_error_copy_failed">无法复制模型文件 </string>
+	<string name="model_error_verification_failed">模型文件验证失败 </string>
+	<string name="model_error_load_failed">加载模型 \'%1$s\' 失败 </string>
+	<string name="model_error_format_unsupported">此模型格式不受支持 </string>
+	<string name="model_error_embedding">所选模型 \'%1$s\' 是一个嵌入模型，专为语义搜索和相似性任务设计 它不能用于聊天或文本生成 \n\n请选择聊天/指令模型（例如名称中带有 \'chat\'、\'instruct\'、\'conversational\' 的模型） </string>
+	<string name="model_error_format_onnx">不支持 ONNX 模型（.onnx） \n\n此应用使用 llama.cpp，仅支持 GGUF 格式（.gguf） \n\n要使用此模型：\n1. 使用 llama.cpp 转换工具将其转换为 GGUF 格式\n2. 或者从 Hugging Face 下载预转换的 GGUF 版本</string>
+	<string name="model_error_format_pytorch">不支持 PyTorch 模型（.pt、.pth、.bin） \n\n此应用使用 llama.cpp，仅支持 GGUF 格式（.gguf） \n\n要使用此模型：\n1. 使用 convert_hf_to_gguf.py 将其转换为 GGUF 格式\n2. 或者从 Hugging Face 下载预转换的 GGUF 版本</string>
+	<string name="model_error_format_safetensors">不直接支持 SafeTensors 模型（.safetensors） \n\n此应用使用 llama.cpp，仅支持 GGUF 格式（.gguf） \n\n要使用此模型：\n1. 使用 convert_hf_to_gguf.py 将其转换为 GGUF 格式\n2. 或者从 Hugging Face 下载预转换的 GGUF 版本</string>
+	<string name="model_error_format_tensorflow">不支持 TensorFlow 模型（.pb） \n\n此应用使用 llama.cpp，仅支持 GGUF 格式（.gguf） \n\n要使用此模型：\n1. 使用适当的转换工具将其转换为 GGUF 格式\n2. 或者从 Hugging Face 下载预转换的 GGUF 版本</string>
+	<string name="model_error_format_tflite">不支持 TensorFlow Lite 模型（.tflite） \n\n此应用使用 llama.cpp，仅支持 GGUF 格式（.gguf） \n\n请选择 GGUF 格式的模型 </string>
+	<string name="model_error_format_ggml">GGML 模型（.ggml）已弃用 \n\n此应用使用较新的 GGUF 格式（.gguf） \n\n要使用此模型：\n1. 使用 convert_llama_ggml_to_gguf.py 将其转换为 GGUF 格式\n2. 或者从 Hugging Face 下载 GGUF 版本</string>
+
+	<string name="ai_disclaimer">免责声明</string>
+	<string name="ai_disclaimer_message">此 AI 代理为实验性功能，可能给出不正确或有危害的答案 使用前请务必备份你的工作，并在使用其建议前仔细检查 我们对由其输出导致的任何错误、缺陷或损害概不负责 使用风险自负 </string>
+    <string name="ai_api_key_not_found">❌ 未找到 Gemini API 密钥 \n如果你最近更新或重新安装了应用，你的 API 密钥可能已被重置 \n请再次在 AI 设置中添加你的 Gemini 密钥 </string>
+
+	<!-- Plugins -->
+	<string name="title_plugin_manager">插件管理器</string>
+
+	<string name="failed_to_save_bitmap_to_file">将位图保存到文件失败</string>
+	<string name="pixel_copy_failed">PixelCopy 失败</string>
+	<string name="failed_to_capture_or_save_screenshot">捕获或保存截图失败</string>
+	<string name="back_to_cogo">返回 Code on the Go</string>
+
+	<!-- URL Consent Dialog -->
+	<string name="url_consent_title">打开外部链接？</string>
+	<string name="url_consent_message">你即将离开 Code on the Go 打开一个外部链接：\n\n%s\n\n是否要继续？</string>
+	<string name="url_consent_cancel">取消</string>
+	<string name="url_consent_proceed">继续</string>
+	<string name="url_consent_dont_ask">不再询问</string>
+
+	<!-- Documentation urls -->
+	<string name="layout_editor_url">http://localhost:6174/i/layout-top.html</string>
+
+
+    <string name="retry">重试</string>
+    <string name="open_ai_settings">打开 AI 设置</string>
+    <string name="new_chat">新建聊天</string>
+    <string name="experimental_ai_use_at_your_own_risk">⚠️ 实验性 AI 使用风险自负 </string>
+    <string name="current_ai_backend">当前 AI 后端</string>
+    <string name="stop_generation">停止生成</string>
+    <string name="send_message">发送消息</string>
+    <string name="upload_image">上传图片</string>
+    <string name="add_context_file">添加上下文文件</string>
+    <string name="type_a_message_or_prompt">输入消息或提示…</string>
+    <string name="ai_setting_initializing_engine">正在初始化引擎</string>
+    <string name="ai_setting_engine_ready">引擎已就绪 </string>
+	<string name="title_image_to_layout">图片转布局</string>
+
+	<!-- Compose Preview -->
+	<string name="preview_error_title">预览错误</string>
+	<string name="preview_empty_title">未找到 @Preview 可组合项</string>
+	<string name="preview_empty_message">向 @Composable 函数添加 @Preview 注解即可在此查看</string>
+	<string name="title_compose_preview">Compose 预览</string>
+	<string name="toggle_preview_mode">切换预览模式</string>
+	<string name="preview_build_required_title">需要构建</string>
+	<string name="preview_build_required_message">请构建项目以启用多文件预览支持</string>
+	<string name="preview_build_project">构建项目</string>
+	<string name="preview_building_project">正在构建项目…</string>
+	<string name="preview_initializing">正在初始化 Compose 预览…</string>
+
+	<!-- Copy Diagnostics -->
+	<string name="msg_diagnostics_copied">诊断信息已复制到剪贴板</string>
+	<string name="msg_no_diagnostics_to_copy">没有可复制的诊断信息</string>
+	<string name="msg_clipboard_copy_failed">复制到剪贴板失败</string>
+    <string name="dismiss">关闭</string>
+
+    <!-- Git -->
+    <string name="repository_url">仓库 URL</string>
+    <string name="local_path">本地路径</string>
+    <string name="use_authentication">使用身份验证</string>
+    <string name="username">用户名</string>
+    <string name="personal_access_token">个人访问令牌</string>
+    <string name="clone_project">克隆项目</string>
+    <string name="destination_directory_not_empty">目标目录不为空</string>
+    <string name="clone_successful">克隆成功！</string>
+    <string name="clone_failed">克隆失败：%1$s</string>
+    <string name="cloning_repo">正在克隆仓库…</string>
+    <string name="pick_folder">选择文件夹</string>
+    <string name="git_title">Git</string>
+    <string name="no_uncommitted_changes">没有未提交的更改</string>
+    <string name="unable_to_load_diff">无法加载差异</string>
+    <string name="diff_viewer">差异查看器</string>
+    <string name="diff_loading">正在加载 Git 差异…</string>
+    <string name="commit_summary">摘要（必填）</string>
+    <string name="commit_description_optional">描述（可选）</string>
+    <string name="commit">提交</string>
+    <string name="view_commit_history">查看提交历史</string>
+    <string name="git_commit_history">Git 提交历史</string>
+    <string name="no_commit_history">无提交历史</string>
+    <string name="commit_not_pushed">此提交尚未推送到远程仓库</string>
+    <string name="commit_pushed">此提交已推送到远程仓库</string>
+    <string name="no_internet_connection">无网络连接 请检查网络后重试 </string>
+    <string name="connection_lost">下载过程中连接中断 请检查网络连接后重试 </string>
+    <string name="desc_file_added">文件已添加</string>
+    <string name="desc_file_modified">文件已修改</string>
+    <string name="desc_file_deleted">文件已删除</string>
+    <string name="desc_file_untracked">文件未跟踪</string>
+    <string name="desc_file_renamed">文件已重命名</string>
+    <string name="desc_file_conflicted">文件有冲突</string>
+    <string name="cancel_clone">取消克隆</string>
+    <string name="initialising_clone">正在初始化克隆…</string>
+    <string name="cancelling_clone">正在取消克隆…</string>
+
+    <!-- Git Preferences -->
+    <string name="idepref_git_summary">设置和更新 Git 配置</string>
+    <string name="idepref_git_author_title">作者身份</string>
+    <string name="idepref_git_author_summary">设置提交时使用的名称和邮箱</string>
+    <string name="idepref_git_user_name_title">用户名</string>
+    <string name="idepref_git_user_name_summary">用作提交中的作者名</string>
+    <string name="idepref_git_user_email_title">用户邮箱</string>
+    <string name="idepref_git_user_email_summary">用作提交中的作者邮箱</string>
+    <string name="idepref_git_author_missing_warning">请在偏好设置中配置 Git 作者以启用提交 \n点击头像查看更多信息 </string>
+    <string name="git_committing_as">将以 %1$s 提交</string>
+    <string name="git_committing_email">邮箱 - %1$s</string>
+    <string name="git_update_config_in_preferences">你可以在偏好设置中更新 Git 配置 </string>
+    <string name="author_not_set">未设置</string>
+    <string name="not_a_git_repo">此项目不是 Git 仓库</string>
+    <string name="current_branch_name">当前分支：%1$s</string>
+    <string name="push">推送</string>
+    <string name="pushing">正在推送…</string>
+    <string name="push_successful">推送成功！</string>
+    <string name="push_failed">推送失败</string>
+    <string name="push_rejected_nonfastforward">推送被拒绝：你的分支落后于远程仓库 请先拉取以解决冲突后再推送 </string>
+    <string name="pull">拉取</string>
+    <string name="pulling">正在拉取…</string>
+    <string name="pull_successful">拉取成功！</string>
+    <string name="pull_failed">拉取失败</string>
+    <string name="git_credentials_title">Git 凭据</string>
+    <string name="git_credentials_message">请输入你的凭据以将更改同步到远程仓库 </string>
+    <string name="git_credentials_clear">清除凭据</string>
+    <string name="repo_authorization_error">身份验证失败 请确保你的个人访问令牌具有 \'repo\' 权限，或尝试清除并重新输入凭据 </string>
+    <string name="info_merge_conflicts">拉取完成，但存在冲突 \n请从列表中选择冲突文件，在编辑器中解决突出显示的问题，保存文件，然后提交更改 </string>
+    <string name="merge_conflicts">合并冲突</string>
+    <string name="abort_merge">中止合并</string>
+    <string name="confirm_abort_merge">确定要中止当前合并吗？所有冲突解决方案将被丢弃 </string>
+    <string name="msg_save_before_git_action">你有未保存的更改 是否要在继续前保存？</string>
+    <string name="no_save_before_git_action">不保存直接继续</string>
+    <string name="save_before_git_action">保存后再继续</string>
+    <string name="mark_as_resolved">标记为已解决</string>
+    <string name="check_all">全选</string>
+    <string name="uncheck_all">取消全选</string>
+
+	<!-- Templates -->
+	<string name="template_exec_info_basepath">正在为 %1$s 开始创建项目</string>
+	<string name="template_exec_warn_identifiers">标识符警告：%1$s</string>
+	<string name="template_exec_warn_suspicious_entry">跳过项目目录外的可疑模板条目：%1$s</string>
+	<string name="template_exec_info_processing">正在处理模板 %1$s</string>
+	<string name="template_exec_error_read_fail">读取模板 %1$s 失败</string>
+	<string name="template_exec_error_parse_line">Pebble 解析错误，位置 %1$s 第 %2$d 行：%3$s</string>
+	<string name="template_exec_error_parse">意外的 Pebble 解析错误，位置 %1$s</string>
+	<string name="template_exec_error_evaluate_line">Pebble 求值错误，位置 %1$s 第 %2$d 行：%3$s</string>
+	<string name="template_exec_error_evaluate">意外的 Pebble 求值错误，位置 %1$s %2$s</string>
+	<string name="template_exec_error_write">写入输出文件失败：%1$s %2$s</string>
+	<string name="template_exec_error_copy">复制二进制条目失败：%1$s %2$s</string>
+	<string name="template_exec_error_process">处理模板条目失败：%1$s %2$s</string>
+	<string name="template_exec_error_terminated">项目创建已停止：%1$s\n\n不完整的项目已被移除 请修正上方提到的模板文件（或选择其他模板）后重试</string>
+	<string name="template_exec_warn_cleanup_failed">无法移除位于 %1$s 的不完整项目 请手动删除后重试</string>
+
+	<string name="template_exec_warn_map_appname">缺少 appName，默认使用 %1$s</string>
+	<string name="template_exec_warn_map_pkgname">缺少 packageName，默认使用 %1$s</string>
+	<string name="template_exec_warn_map_location">缺少 saveLocation，默认使用 %1$s</string>
+	<string name="template_exec_warn_map_agp">缺少 agpVersion，默认使用 %1$s</string>
+	<string name="template_exec_warn_map_kotlin">缺少 kotlinVersion，默认使用 %1$s</string>
+	<string name="template_exec_warn_map_gradle">缺少 gradleVersion，默认使用 %1$s</string>
+	<string name="template_exec_warn_map_compilesdk">缺少 compileSdk，默认使用 %1$s</string>
+	<string name="template_exec_warn_map_targetsdk">缺少 targetSdk，默认使用 %1$s</string>
+	<string name="template_exec_warn_map_javasource_compat">缺少 javaSourceCompat，默认使用 %1$s</string>
+	<string name="template_exec_warn_map_javatarget_compat">缺少 javaTargetCompat，默认使用 %1$s</string>
+	<string name="template_exec_warn_map_javatarget">缺少 javaTarget，默认使用 %1$s</string>
+
+	<string name="template_read_error_archive_json">%1$s 不包含 %2$s</string>
+	<string name="template_read_error_template_load">加载 %1$s 处的模板失败，错误：%2$s</string>
+	<string name="template_read_error_archive_load">加载 %1$s 处的模板存档失败，错误：%2$s</string>
+    <string name="navigate_up">向上导航</string>
+
+	<!-- Profiler -->
+	<string name="profiler_title">分析器</string>
+	<string name="profiler_action_label">分析</string>
+	<string name="profiler_dump_heap">转储堆内存</string>
+	<string name="profiler_cpu_hotspots">CPU 热点</string>
+	<string name="profiler_empty">尚无分析数据 请执行堆转储或 CPU 采样</string>
+	<string name="profiler_col_class">类</string>
+	<string name="profiler_col_count">数量</string>
+	<string name="profiler_col_shallow">浅层大小</string>
+	<string name="profiler_col_retained">保留大小</string>
+	<string name="profiler_col_symbol">符号</string>
+	<string name="profiler_col_self">自身</string>
+	<string name="profiler_col_total">总计</string>
+	<string name="profiler_process_picker_debuggable">可调试</string>
+	<string name="profiler_process_picker_profileable">可分析</string>
+	<string name="profiler_process_picker_pid">%1$s · PID %2$d</string>
+	<string name="profiler_select_process">选择要分析的进程</string>
+	<string name="profiler_no_processes">未找到可调试或可分析的进程</string>
+	<string name="profiler_running">正在从 %1$s 捕获堆转储…</string>
+	<string name="profiler_cpu_not_implemented">CPU 分析功能尚不可用</string>
+	<string name="profiler_service_unavailable">分析器服务不可用 请确保 Shizuku 正在运行</string>
+	<string name="profiler_heap_dump_failed">堆转储失败：%1$s</string>
+	<string name="profiler_retry">返回</string>
+	<string name="profiler_cpu_recording">正在记录 %1$s 的 CPU 使用情况…</string>
+	<string name="profiler_cpu_stop">停止分析</string>
+	<string name="profiler_cpu_processing">正在生成 CPU 报告…</string>
+	<string name="profiler_cpu_failed">CPU 分析失败：%1$s</string>
+	<string name="profiler_cpu_failed_generic">CPU 分析失败</string>
+	<string name="profiler_cpu_no_samples">未捕获到任何 CPU 采样 请尝试延长分析时间</string>
+	<string name="profiler_hide_system_frames">隐藏系统帧</string>
+	<string name="profiler_orientation_toggle">翻转图表方向</string>
+	<string name="profiler_cpu_self">自身 %1$s (%2$s)</string>
+	<string name="profiler_cpu_total">总计 %1$s (%2$s)</string>
+	<string name="profiler_cpu_tap_hint">点击帧以查看详情</string>
+	<string name="profiler_heap_metric_retained">保留大小</string>
+	<string name="profiler_heap_metric_count">实例数</string>
+	<string name="profiler_heap_view_table">类列表</string>
+	<string name="profiler_hide_framework_classes">隐藏框架类</string>
+	<string name="profiler_heap_shallow">浅层 %1$s</string>
+	<string name="profiler_heap_retained">保留 %1$s (%2$s)</string>
+	<string name="profiler_heap_objects">%1$s 个对象</string>
+	<string name="profiler_heap_tap_hint">点击帧以查看对象详情</string>
+	<string name="profiler_cancel">取消</string>
+	<string name="profiler_start_another">开始新任务</string>
+	<string name="profiler_cancelled">分析已取消</string>
+	<string name="profiler_interrupted">分析器服务已断开连接，分析已中断</string>
+    <string name="undock">取消停靠</string>
+
+	<!-- Floating window chrome button accessibility labels (announced by screen readers) -->
+	<string name="floating_window_action_minimize">最小化</string>
+	<string name="floating_window_action_restore">还原</string>
+	<string name="floating_window_action_maximize">最大化</string>
+	<string name="floating_window_action_dock">停靠到编辑器</string>
+	<string name="floating_window_action_close">关闭</string>
+
 </resources>

--- a/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/resources/src/main/res/values-zh-rCN/strings.xml
@@ -124,7 +124,7 @@
 
 	<!-- Project -->
 	<string name="title_first_build">正在设置你的项目</string>
-	<string name="msg_first_build">Code on the Go 正在初始化你的项目，请耐心等待！\n\n设置完成后，屏幕底部将显示"项目已初始化"</string>
+	<string name="msg_first_build">Code on the Go 正在初始化你的项目，请耐心等待！\n\n设置完成后，屏幕底部将显示“项目已初始化”</string>
 	<string name="create_project">创建新项目</string>
 	<string name="minimum_sdk">最低 SDK</string>
 	<string name="new_project">新建项目</string>
@@ -366,7 +366,7 @@
 
 	<!-- Crash Screen -->
 	<string name="msg_ide_crashed">Code on the Go 崩溃了</string>
-	<string name="msg_crash_info">发生内部错误\n\n有助于我们修复问题的详细信息已保存，并将在你的设备下次联网时安全发送\n\n按"确定"后应用将关闭，任何未保存的更改可能会丢失 请重新启动应用以继续 \n\n如果错误再次发生，请尝试重启设备 如果问题仍然存在，请%1$s</string>
+	<string name="msg_crash_info">发生内部错误\n\n有助于我们修复问题的详细信息已保存，并将在你的设备下次联网时安全发送\n\n按“确定”后应用将关闭，任何未保存的更改可能会丢失 请重新启动应用以继续 \n\n如果错误再次发生，请尝试重启设备 如果问题仍然存在，请%1$s</string>
 	<string name="contact_support_team">联系我们的支持团队 </string>
 	<string name="crash_email_subject">应用崩溃报告</string>
 	<string name="crash_email_body">构建编号 - %1$s\n\n请描述应用崩溃时你在做什么：\n\n</string>
@@ -484,7 +484,7 @@
 	<string name="xml_formatting_options">XML 格式化选项</string>
 	<string name="xml_formatting_options_summary">设置 XML 文件的格式化偏好 </string>
 	<string name="idepref_customFont_title">使用自定义字体</string>
-	<string name="idepref_customFont_summary">启用后，将使用 "/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf" 作为编辑器字体 </string>
+	<string name="idepref_customFont_summary">启用后，将使用 “/data/data/com.itsaky.androidide/files/home/.cg/ui/font.ttf” 作为编辑器字体 </string>
 	<string name="msg_installing_apk">正在安装 APK…</string>
 	<string name="msg_action_open_application">你的应用已安装 是否要启动该应用？</string>
 	<string name="msg_action_open_title_application">应用已安装</string>
@@ -501,7 +501,7 @@
 	<string name="msg_package_is_to_long">包名过长</string>
 	<string name="msg_package_not_valid_char_1">字符 \'_\' 不能作为包名段的首字符</string>
 	<string name="msg_package_not_use_digit_first">数字不能作为包名段的首字符</string>
-	<string name="msg_package_not_valid_char_2">字符 "%1$s" 在 Android 应用包名中不允许使用 </string>
+	<string name="msg_package_not_valid_char_2">字符 “%1$s” 在 Android 应用包名中不允许使用 </string>
 	<string name="msg_package_mus_have_dot">包名必须至少包含一个 \'.\' 分隔符 </string>
 
 	<string name="action_import_classes">导入类</string>
@@ -549,7 +549,7 @@
 	<string name="hint_search_tasks">搜索任务…</string>
 	<string name="msg_err_select_tasks">请选择要运行的任务</string>
 	<string name="title_confirmation">确认</string>
-	<string name="msg_tasks_to_run">以下任务将按顺序运行 请再次点击"运行"按钮确认 \n\n%1$s</string>
+	<string name="msg_tasks_to_run">以下任务将按顺序运行 请再次点击“运行”按钮确认 \n\n%1$s</string>
 	<string name="msg_loading_tasks">正在加载任务…</string>
 
 	<string name="ui_category_widgets" translatable="false">Widgets</string>
@@ -731,7 +731,7 @@
 	<string name="msg_project_cache_read_failure">读取项目缓存失败</string>
 	<string name="msg_font_copy_failed">无法保存字体文件 请重试 </string>
 	<string name="msg_files_being_saved">文件保存操作正在进行中！</string>
-	<string name="msg_undock_save_failed">无法保存"%1$s" 取消停靠 </string>
+	<string name="msg_undock_save_failed">无法保存“%1$s” 取消停靠 </string>
 	<string name="title_install_tools">安装开发工具</string>
 	<string name="subtitle_install_tools">\n要安装构建 Android 项目所需的工具，请点击屏幕右下角的按钮\n</string>
 	<string name="msg_install_tools"> </string>
@@ -747,7 +747,7 @@
 	<string name="permission_overlay_unsupported_hint">此设备不支持浮动调试器 </string>
 	<string name="permission_overlay_restricted_settings_hint">如果无法启用此权限，请显示 Code on the Go 的应用信息，点击三点菜单，然后启用受限设置 </string>
 	<string name="permission_overlay_restricted_dialog_title">启用受限设置</string>
-	<string name="permission_overlay_restricted_dialog_message">Android 已关闭"在其他应用上层显示"开关，因为 Code on the Go 是从应用商店外部安装的 要开启它：</string>
+	<string name="permission_overlay_restricted_dialog_message">Android 已关闭“在其他应用上层显示”开关，因为 Code on the Go 是从应用商店外部安装的 要开启它：</string>
 	<string name="permission_overlay_open_app_info">打开应用信息</string>
 	<string name="permission_title_notifications">通知</string>
 	<string name="permission_desc_notifications">允许 Code on the Go 显示通知 </string>
@@ -821,7 +821,7 @@
 	<string name="debugger_error_errno_econnrefused">Code On the Go 的网络访问被系统屏蔽 该应用不允许使用网络，或服务不可用 </string>
 	<string name="debugger_error_debugger_startup_failure">无法启动 Code On the Go 调试器 </string>
 	<string name="debugger_not_ready">调试器尚未准备好进行调试会话 </string>
-	<string name="debugger_error_suggestion_network_restriction">请确保 Code On the Go 有权限访问本地网络 可以在设备的设置中进入 Code On the Go 的"应用信息"界面，检查"数据使用"下是否允许网络访问（具体名称可能因设备而异） \n\n如果允许网络访问但问题仍然存在，请附上日志提交错误报告 </string>
+	<string name="debugger_error_suggestion_network_restriction">请确保 Code On the Go 有权限访问本地网络 可以在设备的设置中进入 Code On the Go 的“应用信息”界面，检查“数据使用”下是否允许网络访问（具体名称可能因设备而异） \n\n如果允许网络访问但问题仍然存在，请附上日志提交错误报告 </string>
 
 	<string name="err_no_activity_to_handle_action">没有 Activity 可以处理操作 %1$s</string>
 
@@ -844,7 +844,7 @@
 	<string name="msg_skipped_invalid_projects">部分文件夹已被跳过，因为它们不是有效的 Android 项目文件夹 </string>
 	<string name="msg_cannot_access_folder">无法访问文件夹 %1$s 请检查存储权限 </string>
 	<string name="msg_no_subfolders">文件夹 %1$s 不包含任何子文件夹 </string>
-	<string name="msg_create_new_project_instruction">点击"新建项目"按钮创建一个新项目 </string>
+	<string name="msg_create_new_project_instruction">点击“新建项目”按钮创建一个新项目 </string>
 	<string name="date">%1$s：%2$s</string>
 	<string name="date_created_label">创建时间</string>
 	<string name="date_modified_label">修改时间</string>
@@ -901,8 +901,8 @@
 
 	<!-- Plugin crash dialog -->
 	<string name="title_plugin_crashed">插件崩溃</string>
-	<string name="msg_plugin_crash">"%1$s"已崩溃（第 %2$d/3 次） </string>
-	<string name="msg_plugin_crash_disabled">"%1$s"因反复崩溃已被禁用 </string>
+	<string name="msg_plugin_crash">“%1$s”已崩溃（第 %2$d/3 次） </string>
+	<string name="msg_plugin_crash_disabled">“%1$s”因反复崩溃已被禁用 </string>
 	<string name="msg_plugin_crash_dev_hint">如果你是插件开发者，请点击信息图标查看崩溃日志 </string>
 	<string name="cd_plugin_crash_view_logs">查看崩溃日志</string>
 	<string name="title_plugin_crash_log">崩溃日志：%1$s</string>


### PR DESCRIPTION
Closes https://github.com/appdevforall/CodeOnTheGo/issues/1580

The replacement `strings.xml` file was submitted by a user in China, and further vetted internally.

Via LLM:
"This replaces an incomplete translation (~452 strings) with a complete one covering all
1,185 strings currently in the English source, including sections that were previously
untranslated in the app: Agent, Plugin Manager, Debugger, and Profiler.

Two corrections were also made during review:
- `err_authority_not_allowed`: "Authority" was previously translated as "权限" (Permission);
  corrected to keep "Authority" as the technical term, matching how other Android
  parameter names are handled elsewhere in the file.
- `privacy_disclosure_message`: updated a stale reference to "Sentry" to "GlitchTip",
  matching the current English source."