### PR TITLE
ADFA-4909: Annotate Shizuku.newProcess as @Deprecated

### DIFF
--- a/subprojects/shizuku-api/src/main/java/rikka/shizuku/Shizuku.java
+++ b/subprojects/shizuku-api/src/main/java/rikka/shizuku/Shizuku.java
@@ -332,6 +332,7 @@ public class Shizuku {
 	 *             <p>
 	 *             This method is planned to be removed from Shizuku API 14.
 	 */
+	@Deprecated
 	public static ShizukuRemoteProcess newProcess(@NonNull String[] cmd, @Nullable String[] env, @Nullable String dir) {
 		try {
 			return new ShizukuRemoteProcess(requireService().newProcess(cmd, env, dir));


### PR DESCRIPTION
## Summary
- CI reported a `[dep-ann]` javac warning: `Shizuku.newProcess` had a `@deprecated` Javadoc tag but no `@Deprecated` annotation.
- Added the missing `@Deprecated` annotation to match the existing Javadoc.

## Test plan
- [x] `:subprojects:shizuku-api:compileV8DebugJavaWithJavac` — no more `dep-ann` warning
- [x] `:app:compileV8DebugKotlin` — no new warnings (the sole in-repo caller in `PrivilegedActions.kt` already has `@Suppress("DEPRECATION")`)
- [x] `spotlessCheck` passes

Fixes ADFA-4909
