### PR TITLE
ADFA-4202: Guard tooling-api shadow jar against public-suffix-list regression

### DIFF
--- a/subprojects/tooling-api-impl/build.gradle.kts
+++ b/subprojects/tooling-api-impl/build.gradle.kts
@@ -58,6 +58,11 @@ project.tasks.getByName<Jar>("jar") {
 project.tasks.getByName<ShadowJar>("shadowJar") {
 	finalizedBy("copyJar")
 	entryCompression = ZipEntryCompression.STORED
+
+	// httpclient's public-suffix cookie-domain data, pulled in transitively via sdklib; unused,
+	// no code touches Apache HttpClient directly. Guards against ADFA-4202 regressing into this
+	// shadow jar, which app/build.gradle.kts's packaging.resources.excludes cannot reach.
+	exclude("mozilla/public-suffix-list.txt")
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- ADFA-4202 (drop the unused `mozilla/public-suffix-list.txt` httpclient resource from the APK) was already fixed under ADFA-4551 via `app/build.gradle.kts`'s `packaging.resources.excludes`.
- That exclude only governs the top-level APK resource merge — it can't reach bytes already baked into `tooling-api-impl`'s shadow/fat jar (`tooling-api-all.jar`), which is copied in as a raw asset.
- Adds a matching `exclude(...)` to the `shadowJar` task so a future dependency shift (e.g. sdklib pulling httpclient in differently) can't reintroduce the file through that path.

## Test plan
- [x] `./gradlew :subprojects:tooling-api-impl:jar` builds successfully
- [x] `unzip -l tooling-api-all.jar` confirms `mozilla/public-suffix-list.txt` is absent
- [x] `./gradlew spotlessCheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
