### PR TITLE
URGENT ADFA-3604: Fix R8 shrink/optimize crashes live on stage

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -4,6 +4,16 @@
 -dontnote **
 -dontobfuscate
 
+# ADFA-3604: R8's optimize pass (inlining/method merging) can silently
+# retarget a call to the wrong method when it fails to parse Kotlin 2.3.0
+# metadata (see "R8: An error occurred when parsing kotlin metadata" in the
+# build log) -- observed corrupting calls to utils.TestModeUtilsKt.isTestMode
+# into calls to the unrelated, device-missing dalvik.system.VMRuntime.isTestMode,
+# crashing every release build on launch. Shrinking (dead-code removal) is
+# what actually cuts dex size; the optimize passes are the risky part given
+# this R8/Kotlin version mismatch, so disable only optimization.
+-dontoptimize
+
 -keep class javax.** { *; }
 -keep class jdkx.** { *; }
 
@@ -18,6 +28,42 @@
 
 # Builder model implementations
 -keep class com.itsaky.androidide.builder.model.** { *; }
+
+# lsp/kotlin registers its own IntelliJ project/application services -- some
+# by class name in lsp/kotlin/src/main/resources/META-INF/kt-lsp/kt-lsp.xml,
+# the rest via ::class literals in
+# lsp/kotlin/.../registrar/AnalysisApiServiceProviders.kt, which PicoContainer
+# then instantiates reflectively via each class's no-arg constructor. A
+# ::class literal doesn't count as an actual `new` call to R8, so it kept
+# stripping "unused" no-arg constructors one class at a time as each was
+# discovered on-device (ClassNotFoundException on DirectInheritorsProvider,
+# then a PicoInitializationException on ModuleDependentsProvider's missing
+# constructor). Keep the whole package rather than list every implementation
+# class in AnalysisApiServiceProviders.kt individually.
+-keep class com.itsaky.androidide.lsp.kotlin.compiler.services.** { *; }
+
+# Kotlin Analysis API (bundled in subprojects/kotlin-analysis-api, used by the
+# Kotlin LSP). subprojects/kotlin-analysis-api/consumer-rules.pro keeps every
+# class this jar's own IntelliJ plugin XML descriptors and ServiceLoader
+# entries reference by name, but on-device testing kept surfacing distinct
+# reflection paths that narrow list didn't cover -- not just inside this jar,
+# but in other lsp/kotlin runtime dependencies too (Caffeine picks a cache
+# implementation from dozens of codegenned variant classes at runtime; a
+# protobuf-lite message field is resolved by name string; lsp/kotlin's own
+# kt-lsp.xml above; and a NullPointerException deep in IntelliJ's own
+# JavaCoreApplicationEnvironment bootstrap, verified absent on an unshrunk
+# debug build). Each fix was quick but the next gap kept appearing elsewhere
+# in the same dependency graph, so rather than keep discovering them one
+# on-device crash at a time, keep every runtime dependency lsp/kotlin pulls in
+# whole. This gives up the dex-size reduction for this whole dependency graph;
+# see ADFA-3604 for the size trade-off.
+-keep class org.jetbrains.kotlin.** { *; }
+-keep class com.github.benmanes.caffeine.** { *; }
+-keep class kotlin.reflect.** { *; }
+-keep class kotlin.script.** { *; }
+-keep class kotlinx.coroutines.internal.** { *; }
+-keep class one.util.streamex.** { *; }
+-keep class gnu.trove.** { *; }
 
 # Eclipse
 -keep class org.eclipse.** { *; }
@@ -87,6 +133,14 @@
 }
 
 -keep class com.itsaky.androidide.treesitter.** { *; }
+
+# Protobuf lite: the generated runtime resolves message fields by name via
+# reflection (the info string baked into newMessageInfo()), so shrinking a
+# "field with no direct bytecode reference" breaks it at runtime with a
+# NoSuchFieldException (observed on SyncMetaModels$SyncMeta.projectModelInfo_).
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite {
+    <fields>;
+}
 
 # Retrofit 2
 -dontwarn retrofit2.**


### PR DESCRIPTION
## 🚨 Urgent: fixes a release-build crash currently live on `stage`

PR #1596 (ADFA-3604) merged to `stage` on 2026-07-29 **before on-device verification**. On-device testing (done afterward) found that the merged version crashes **every release build immediately on launch**:

```
FATAL EXCEPTION: main
java.lang.NoSuchMethodError: No static method isTestMode()Z in class Ldalvik/system/VMRuntime;
	at com.itsaky.androidide.app.IDEApplication.<clinit>(SourceFile:43)
```

R8's optimize pass silently retargets a call to Code On the Go's own `isTestMode()` utility to the unrelated, device-missing `dalvik.system.VMRuntime.isTestMode()`, because it fails to parse Kotlin 2.3.0 metadata correctly (see the pre-existing `StopWatch` workaround comment in `app/proguard-rules.pro` for the same root cause hit before). **Anyone building a release APK from current `stage` will hit this.**

## What this PR fixes

On-device testing surfaced seven distinct R8 shrink/optimize bugs. All are fixed here:

1. **Launch crash (the urgent one)** — R8's optimize pass retargets `isTestMode()` to `VMRuntime.isTestMode()`. Fixed with `-dontoptimize`; shrinking (dead-code removal) is what actually cuts dex size, optimization was the unsafe part given the R8/Kotlin version mismatch.
2. **Protobuf-lite field removal** — the generated runtime resolves message fields by name via reflection; shrinking removed `SyncMetaModels$SyncMeta.projectModelInfo_`, crashing project sync.
3. **CoGo's own LSP service registrations** — `lsp/kotlin` registers services via `::class` literals (`AnalysisApiServiceProviders.kt`) that PicoContainer instantiates reflectively; R8 stripped "unused" no-arg constructors one at a time as each was discovered (`ClassNotFoundException`, then `PicoInitializationException`). Fixed by keeping the whole `lsp.kotlin.compiler.services` package.
4. **Caffeine's runtime cache class selection** — picks an implementation from dozens of codegenned variants at runtime; not traceable by R8.
5. **A `NullPointerException` deep in IntelliJ's `JavaCoreApplicationEnvironment` bootstrap** — verified absent on an unshrunk debug build, confirming it's shrink-caused, not environmental.
6. **Gson model classes reported as "abstract"** — classes only ever constructed via `gson.fromJson(..., X::class.java)` reflection have no traceable `new` call site, so R8 strips their constructor and Gson's runtime then reports them as abstract (`Failed to load template archive ... Abstract classes can't be instantiated!` on `TemplatesIndex`). Found and fixed for every `gson.fromJson` call site in the repo, including two more instances with no prior keep rule at all (`OpenedFilesCache`/`OpenedFile`, breakpoint persistence models).
7. **JDI debugger connector stripped** — `com.sun.tools.jdi`'s `SocketAttachingConnector`/`SocketListeningConnector` are loaded via `ServiceLoader`, which R8 can't trace; stripping their constructors broke the debugger with `Error: no Connectors loaded`, which the app then surfaced to the user as a misleading "Network access error" (the debug-connect failure handler always appends a network-access suggestion regardless of actual cause). This exact fix was already anticipated and left commented out in this file since before shrinking was ever genuinely enabled — just needed uncommenting.

Each fix revealed another gap elsewhere in the same dependency graph, so rather than keep discovering them one on-device crash at a time, this keeps the whole `lsp/kotlin` runtime dependency graph whole (`org.jetbrains.kotlin`, Caffeine, kotlin-reflect, kotlin-script, coroutines-internal, streamex, Trove).

## Verification

Built and installed on a physical ARM device (Samsung Galaxy Note20 Ultra):
- Clean app launch, full onboarding flow, project init — no crashes
- `KotlinLanguageServer: Kotlin project initialized` with no errors (previously: `NullPointerException` / `ClassNotFoundException` / `PicoInitializationException` / `IllegalStateException`, one per fix)
- A live, accurate Kotlin diagnostic ("Expecting member declaration") confirming the analysis engine correctly parses and resolves code post-shrink
- Templates load cleanly (all 9 built-in templates listed with no error) after fix #6
- Debugger's JDWP listener starts successfully after fix #7 (`Starting JDWP listener`, `startListening`), no dialog
- Zero `FATAL EXCEPTION` in logcat across the whole session

## Size impact

Release DEX settles at **~85 MB** (down from the 119.4 MB pre-ADFA-3604 baseline). This is short of the 28.8 MB originally reported on #1596 — that number came from a build that silently corrupted the Kotlin LSP; this is the verified-correct number.

## Test plan

- [x] Physical device install + launch + onboarding — no crash
- [x] Kotlin project init succeeds with no errors in logcat
- [x] Live Kotlin diagnostics confirmed working
- [x] Template listing loads without error
- [x] Debugger JDWP listener starts without error
- [ ] Broader smoke test (Java LSP, XML LSP, build/run a project) recommended before considering this fully closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


