### PR TITLE
ADFA-3604: Fix 2 more R8 shrink bugs (Gson templates, JDI debugger)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -206,9 +206,18 @@
 -keep class com.itsaky.androidide.plugins.** { *; }
 -keep interface com.itsaky.androidide.plugins.** { *; }
 
-## Initial rules to enable when R8 is shrinking to address exceptions
-#-keep class com.sun.tools.jdi.** { *; }
-#-keep class com.sun.jdi.** { *; }
+## ADFA-3604: JDI's SocketAttachingConnector/SocketListeningConnector are
+## loaded via ServiceLoader (META-INF/services), which R8 can't trace, so it
+## stripped their no-arg constructors. This surfaced as
+## "ServiceConfigurationError: Provider ... could not be instantiated" ->
+## "java.lang.Error: no Connectors loaded" from VirtualMachineManagerImpl,
+## which the app then reports to the user as a generic "Network access
+## error" (the debug-connect failure handler always appends a network
+## suggestion regardless of cause) even though this has nothing to do with
+## network permissions. This is exactly the exceptions these rules were
+## anticipating -- enabling them now that shrinking is genuinely on.
+-keep class com.sun.tools.jdi.** { *; }
+-keep class com.sun.jdi.** { *; }
 
 ## R8 Kotlin metadata workaround for Kotlin 2.3.0 compatibility
 ## Suppresses D8 errors when parsing kotlin metadata for StopWatch inline functions

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -112,10 +112,12 @@
 }
 -keep class com.itsaky.androidide.utils.DialogUtils {  public <methods>; }
 
-# APK Metadata
--keep class com.itsaky.androidide.models.ApkMetadata { *; }
--keep class com.itsaky.androidide.models.ArtifactType { *; }
--keep class com.itsaky.androidide.models.MetadataElement { *; }
+# Gson model classes deserialized only via reflection (gson.fromJson(...,
+# X::class.java)), same "R8 strips the unreachable constructor" issue as
+# templates.impl.zip above. Covers OpenedFilesCache/OpenedFile (no prior
+# rule) as well as the APK metadata classes already listed individually.
+-keep class com.itsaky.androidide.models.** { *; }
+-keep class com.itsaky.androidide.lsp.debug.model.** { *; }
 
 # Parcelable
 -keepclassmembers class * implements android.os.Parcelable {
@@ -163,6 +165,13 @@
 -keep class * implements com.google.gson.TypeAdapterFactory
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer
+
+# Gson model classes: nothing calls `new TemplatesIndex(...)` directly --
+# only gson.fromJson(..., TemplatesIndex::class.java) does, via reflection.
+# With no traceable constructor call, R8 strips the constructor and Gson's
+# runtime then reports the class as abstract ("Failed to load template
+# archive ... Abstract classes can't be instantiated!").
+-keep class com.itsaky.androidide.templates.impl.zip.** { *; }
 
 -keepclassmembers,allowobfuscation class * {
   @com.google.gson.annotations.SerializedName <fields>;

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -114,7 +114,7 @@
 
 # Gson model classes deserialized only via reflection (gson.fromJson(...,
 # X::class.java)), same "R8 strips the unreachable constructor" issue as
-# templates.impl.zip above. Covers OpenedFilesCache/OpenedFile (no prior
+# templates.impl.zip below. Covers OpenedFilesCache/OpenedFile (no prior
 # rule) as well as the APK metadata classes already listed individually.
 -keep class com.itsaky.androidide.models.** { *; }
 -keep class com.itsaky.androidide.lsp.debug.model.** { *; }


### PR DESCRIPTION
## Follow-up to #1609 — two more R8 shrink bugs found after that PR merged

#1609 (fixes 1–5 of the R8 shrink/optimize bugs found while verifying ADFA-3604 on-device) was merged to `stage` while this session was still actively testing. This PR carries the two additional fixes found afterward, cherry-picked cleanly onto current `stage`.

## What this PR fixes

6. **Gson model classes reported as "abstract"** — classes only ever constructed via `gson.fromJson(..., X::class.java)` reflection have no traceable `new` call site, so R8 strips their constructor and Gson's runtime then reports them as abstract (`Failed to load template archive ... Abstract classes can't be instantiated!` on `TemplatesIndex`, surfaced as a user-facing error dialog). Found and fixed for every `gson.fromJson` call site in the repo, including two more instances with no prior keep rule at all (`OpenedFilesCache`/`OpenedFile`, breakpoint persistence models).
7. **JDI debugger connector stripped** — `com.sun.tools.jdi`'s `SocketAttachingConnector`/`SocketListeningConnector` are loaded via `ServiceLoader`, which R8 can't trace; stripping their constructors broke the debugger with `Error: no Connectors loaded`, which the app then surfaced to the user as a misleading "Network access error" (the debug-connect failure handler always appends a network-access suggestion regardless of actual cause). This exact fix was already anticipated and left commented out in this file since before shrinking was ever genuinely enabled — just needed uncommenting.

## Verification

Built and installed on a physical ARM device (Samsung Galaxy Note20 Ultra):
- Templates load cleanly (all 9 built-in templates listed with no error)
- Debugger's JDWP listener starts successfully (`Starting JDWP listener`, `startListening`), no dialog
- Zero `FATAL EXCEPTION` in logcat

## Broader smoke test — done

The smoke test recommended below (build/run a project, Java LSP, XML LSP) is now complete, on a release build with all 7 fixes applied:
- **Build/run a project end-to-end**: fresh sample project built, installed, and ran with zero crashes.
- **Java LSP**: `Toast.` completion returned correct members (`Callback`, `LENGTH_LONG`, `LENGTH_SHORT`) with correct types/values.
- **XML LSP**: attribute completion works correctly for real attributes. Turned up one more issue — completion also surfaces `android:__removed0/1/3/4` placeholder entries — but this traces to genuine AOSP placeholder attrs baked into the bundled platform's `attrs.xml` (Google's own reserved slots for deprecated attribute IDs), not to R8/shrinking. R8 never touches bundled asset files, only app bytecode, so this predates ADFA-3604 and reproduces on any build. Filed separately as ADFA-4980 rather than folding it in here.

No further R8 shrink/optimize bugs found. With this PR merged, ADFA-3604's fix set is fully verified on-device across build, Java LSP, Kotlin LSP, XML LSP, templates, and the debugger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
