### PR TITLE
ADFA-4927: Remove stale stat-uploader proguard rule

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -157,9 +157,6 @@
 -keep interface okhttp3.** { *; }
 -dontwarn okhttp3.**
 
-# Stat uploader
--keep class com.itsaky.androidide.stats.** { *; }
-
 # Gson
 -keep class * extends com.google.gson.TypeAdapter
 -keep class * implements com.google.gson.TypeAdapterFactory


### PR DESCRIPTION
## Summary
- `com.itsaky.androidide.stats` (the `idestats` module: WorkManager stat uploader, Retrofit service, tests, manifest/gradle entries, strings) was already fully removed in `95f4acd81` (ADFA-664, Aug 2025) — nothing left to delete there.
- The only remaining artifact was a stale proguard `-keep class com.itsaky.androidide.stats.** { *; }` rule at `app/proguard-rules.pro:160-161`, referencing a package that no longer exists. Removed it.
- Verified no references to the package remain anywhere in the repo (source, gradle, manifests, resources).

## Test plan
- [x] Repo-wide grep confirms zero references to `com.itsaky.androidide.stats` / former class names (`StatUploadWorker`, `StatUploadService`, etc.)
- [x] `flox activate -d flox/local -- ./gradlew :app:assembleV8Debug --parallel --max-workers=6` builds successfully with the rule removed
- [x] `spotlessCheck` passes (via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
