### PR TITLE
fix: Bound live build output memory

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputBuffer.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputBuffer.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.channels.Channel
 internal class BuildOutputBuffer(
 	private val maxPendingChars: Int = DEFAULT_MAX_PENDING_CHARS,
 	private val maxBatchChars: Int = DEFAULT_MAX_BATCH_CHARS,
+	private val formatOmission: (Long) -> String = ::defaultOmissionMarker,
 ) {
 	data class Batch(
 		val text: String,
@@ -153,13 +154,19 @@ internal class BuildOutputBuffer(
 		right: Int,
 	): Int = (left.toLong() + right).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
 
-	private fun omissionMarker(lineCount: Long): String {
-		val noun = if (lineCount == 1L) "line" else "lines"
-		return "[$lineCount build output $noun omitted]\n"
-	}
+	private fun omissionMarker(lineCount: Long): String = formatOmission(lineCount)
 
 	companion object {
 		private const val DEFAULT_MAX_PENDING_CHARS = 256 * 1024
 		private const val DEFAULT_MAX_BATCH_CHARS = 32 * 1024
+
+		/**
+		 * Fallback marker for callers without a [android.content.Context]; the fragment supplies a
+		 * localized `msg_build_output_lines_omitted` plural instead.
+		 */
+		internal fun defaultOmissionMarker(lineCount: Long): String {
+			val noun = if (lineCount == 1L) "line" else "lines"
+			return "[$lineCount build output $noun omitted]\n"
+		}
 	}
 }

--- a/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputBuffer.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputBuffer.kt
@@ -1,0 +1,146 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.fragments.output
+
+import kotlinx.coroutines.channels.Channel
+
+/**
+ * Thread-safe pending build output with fixed memory and batch budgets.
+ *
+ * Inputs are indivisible: one input larger than [maxBatchChars] is emitted alone, while one larger
+ * than [maxPendingChars] is omitted. Other inputs are never split or reordered.
+ */
+internal class BuildOutputBuffer(
+	private val maxPendingChars: Int = DEFAULT_MAX_PENDING_CHARS,
+	private val maxBatchChars: Int = DEFAULT_MAX_BATCH_CHARS,
+) {
+	data class Batch(
+		val text: String,
+		val sessionGeneration: Int,
+	)
+
+	private sealed interface Entry {
+		val sessionGeneration: Int
+
+		data class Text(
+			val value: String,
+			override val sessionGeneration: Int,
+		) : Entry
+
+		data class Omission(
+			var lineCount: Long,
+			override val sessionGeneration: Int,
+		) : Entry
+	}
+
+	private val entries = ArrayDeque<Entry>()
+	private val available = Channel<Unit>(Channel.CONFLATED)
+	private val lock = Any()
+	private var retainedChars = 0
+	private var omission: Entry.Omission? = null
+
+	internal val pendingChars: Int
+		get() = synchronized(lock) { retainedChars }
+
+	init {
+		require(maxPendingChars > 0) { "maxPendingChars must be positive" }
+		require(maxBatchChars > 0) { "maxBatchChars must be positive" }
+	}
+
+	fun offer(
+		text: String,
+		sessionGeneration: Int,
+	) {
+		if (text.isEmpty()) return
+		val needsNewline = !text.endsWith('\n')
+		val normalizedLength = text.length.toLong() + if (needsNewline) 1 else 0
+		val lineCount = text.count { it == '\n' }.toLong() + if (needsNewline) 1 else 0
+		synchronized(lock) {
+			if (
+				normalizedLength > maxPendingChars.toLong() ||
+				normalizedLength > (maxPendingChars - retainedChars).toLong()
+			) {
+				val existingOmission = omission
+				if (
+					existingOmission?.sessionGeneration == sessionGeneration &&
+					entries.lastOrNull() === existingOmission
+				) {
+					existingOmission.lineCount += lineCount
+				} else {
+					val marker = Entry.Omission(lineCount, sessionGeneration)
+					omission = marker
+					entries.addLast(marker)
+				}
+			} else {
+				val normalized = if (needsNewline) "$text\n" else text
+				entries.addLast(Entry.Text(normalized, sessionGeneration))
+				retainedChars += normalizedLength.toInt()
+			}
+			available.trySend(Unit)
+		}
+	}
+
+	suspend fun takeBatch(): Batch {
+		while (true) {
+			available.receive()
+			val batch = synchronized(lock) { takeAvailableBatch() }
+			if (batch != null) return batch
+		}
+	}
+
+	fun clear() {
+		synchronized(lock) {
+			entries.clear()
+			retainedChars = 0
+			omission = null
+			while (available.tryReceive().isSuccess) {
+				// Discard stale wakeups from the cleared build session.
+			}
+		}
+	}
+
+	private fun takeAvailableBatch(): Batch? {
+		if (entries.isEmpty()) return null
+		val sessionGeneration = entries.first().sessionGeneration
+		val batch = StringBuilder(minOf(retainedChars, maxBatchChars))
+		while (entries.isNotEmpty()) {
+			val entry = entries.first()
+			if (entry.sessionGeneration != sessionGeneration) break
+			val value =
+				when (entry) {
+					is Entry.Text -> entry.value
+					is Entry.Omission -> omissionMarker(entry.lineCount)
+				}
+			if (batch.isNotEmpty() && batch.length + value.length > maxBatchChars) break
+
+			entries.removeFirst()
+			batch.append(value)
+			if (entry is Entry.Text) retainedChars -= entry.value.length
+			if (entry is Entry.Omission && omission === entry) omission = null
+		}
+		if (entries.isNotEmpty()) available.trySend(Unit)
+		return Batch(batch.toString(), sessionGeneration)
+	}
+
+	private fun omissionMarker(lineCount: Long): String = "[$lineCount build output lines omitted]\n"
+
+	companion object {
+		private const val DEFAULT_MAX_PENDING_CHARS = 256 * 1024
+		private const val DEFAULT_MAX_BATCH_CHARS = 32 * 1024
+	}
+}

--- a/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputBuffer.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputBuffer.kt
@@ -22,8 +22,8 @@ import kotlinx.coroutines.channels.Channel
 /**
  * Thread-safe pending build output with fixed memory and batch budgets.
  *
- * Inputs are indivisible: one input larger than [maxBatchChars] is emitted alone, while one larger
- * than [maxPendingChars] is omitted. Other inputs are never split or reordered.
+ * Inputs are indivisible unless one exceeds [maxPendingChars], in which case only its newest tail
+ * is retained. Older pending output is evicted first, while batches preserve the retained order.
  */
 internal class BuildOutputBuffer(
 	private val maxPendingChars: Int = DEFAULT_MAX_PENDING_CHARS,
@@ -31,20 +31,22 @@ internal class BuildOutputBuffer(
 ) {
 	data class Batch(
 		val text: String,
-		val sessionGeneration: Int,
+		val sessionToken: Int,
+		val sourceChars: Int,
 	)
 
 	private sealed interface Entry {
-		val sessionGeneration: Int
+		val sessionToken: Int
 
 		data class Text(
 			val value: String,
-			override val sessionGeneration: Int,
+			override val sessionToken: Int,
 		) : Entry
 
 		data class Omission(
 			var lineCount: Long,
-			override val sessionGeneration: Int,
+			var sourceChars: Int,
+			override val sessionToken: Int,
 		) : Entry
 	}
 
@@ -52,7 +54,6 @@ internal class BuildOutputBuffer(
 	private val available = Channel<Unit>(Channel.CONFLATED)
 	private val lock = Any()
 	private var retainedChars = 0
-	private var omission: Entry.Omission? = null
 
 	internal val pendingChars: Int
 		get() = synchronized(lock) { retainedChars }
@@ -64,33 +65,35 @@ internal class BuildOutputBuffer(
 
 	fun offer(
 		text: String,
-		sessionGeneration: Int,
+		sessionToken: Int,
 	) {
 		if (text.isEmpty()) return
-		val needsNewline = !text.endsWith('\n')
-		val normalizedLength = text.length.toLong() + if (needsNewline) 1 else 0
-		val lineCount = text.count { it == '\n' }.toLong() + if (needsNewline) 1 else 0
+		val normalized = if (text.endsWith('\n')) text else "$text\n"
 		synchronized(lock) {
-			if (
-				normalizedLength > maxPendingChars.toLong() ||
-				normalizedLength > (maxPendingChars - retainedChars).toLong()
-			) {
-				val existingOmission = omission
-				if (
-					existingOmission?.sessionGeneration == sessionGeneration &&
-					entries.lastOrNull() === existingOmission
-				) {
-					existingOmission.lineCount += lineCount
-				} else {
-					val marker = Entry.Omission(lineCount, sessionGeneration)
-					omission = marker
-					entries.addLast(marker)
-				}
-			} else {
-				val normalized = if (needsNewline) "$text\n" else text
-				entries.addLast(Entry.Text(normalized, sessionGeneration))
-				retainedChars += normalizedLength.toInt()
+			val existingOmission = entries.firstOrNull() as? Entry.Omission
+			if (existingOmission != null) entries.removeFirst()
+
+			var retained = normalized
+			var omittedLines = existingOmission?.lineCount ?: 0
+			var omittedChars = existingOmission?.sourceChars ?: 0
+			if (retained.length > maxPendingChars) {
+				val droppedPrefix = retained.dropLast(maxPendingChars)
+				omittedLines += lineCount(droppedPrefix)
+				omittedChars = saturatedAdd(omittedChars, droppedPrefix.length)
+				retained = retained.takeLast(maxPendingChars)
 			}
+			while (retainedChars > maxPendingChars - retained.length) {
+				val evicted = entries.removeFirst() as Entry.Text
+				retainedChars -= evicted.value.length
+				omittedLines += lineCount(evicted.value)
+				omittedChars = saturatedAdd(omittedChars, evicted.value.length)
+			}
+
+			if (omittedLines > 0) {
+				entries.addFirst(Entry.Omission(omittedLines, omittedChars, sessionToken))
+			}
+			entries.addLast(Entry.Text(retained, sessionToken))
+			retainedChars += retained.length
 			available.trySend(Unit)
 		}
 	}
@@ -107,7 +110,6 @@ internal class BuildOutputBuffer(
 		synchronized(lock) {
 			entries.clear()
 			retainedChars = 0
-			omission = null
 			while (available.tryReceive().isSuccess) {
 				// Discard stale wakeups from the cleared build session.
 			}
@@ -116,11 +118,12 @@ internal class BuildOutputBuffer(
 
 	private fun takeAvailableBatch(): Batch? {
 		if (entries.isEmpty()) return null
-		val sessionGeneration = entries.first().sessionGeneration
+		val sessionToken = entries.first().sessionToken
 		val batch = StringBuilder(minOf(retainedChars, maxBatchChars))
+		var sourceChars = 0
 		while (entries.isNotEmpty()) {
 			val entry = entries.first()
-			if (entry.sessionGeneration != sessionGeneration) break
+			if (entry.sessionToken != sessionToken) break
 			val value =
 				when (entry) {
 					is Entry.Text -> entry.value
@@ -130,14 +133,30 @@ internal class BuildOutputBuffer(
 
 			entries.removeFirst()
 			batch.append(value)
-			if (entry is Entry.Text) retainedChars -= entry.value.length
-			if (entry is Entry.Omission && omission === entry) omission = null
+			when (entry) {
+				is Entry.Text -> {
+					retainedChars -= entry.value.length
+					sourceChars = saturatedAdd(sourceChars, entry.value.length)
+				}
+				is Entry.Omission -> sourceChars = saturatedAdd(sourceChars, entry.sourceChars)
+			}
 		}
 		if (entries.isNotEmpty()) available.trySend(Unit)
-		return Batch(batch.toString(), sessionGeneration)
+		return Batch(batch.toString(), sessionToken, sourceChars)
 	}
 
-	private fun omissionMarker(lineCount: Long): String = "[$lineCount build output lines omitted]\n"
+	private fun lineCount(text: String): Long =
+		text.count { it == '\n' }.toLong() + if (text.endsWith('\n')) 0 else 1
+
+	private fun saturatedAdd(
+		left: Int,
+		right: Int,
+	): Int = (left.toLong() + right).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+
+	private fun omissionMarker(lineCount: Long): String {
+		val noun = if (lineCount == 1L) "line" else "lines"
+		return "[$lineCount build output $noun omitted]\n"
+	}
 
 	companion object {
 		private const val DEFAULT_MAX_PENDING_CHARS = 256 * 1024

--- a/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputBuffer.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputBuffer.kt
@@ -28,12 +28,12 @@ import kotlinx.coroutines.channels.Channel
 internal class BuildOutputBuffer(
 	private val maxPendingChars: Int = DEFAULT_MAX_PENDING_CHARS,
 	private val maxBatchChars: Int = DEFAULT_MAX_BATCH_CHARS,
-	private val formatOmission: (Long) -> String = ::defaultOmissionMarker,
 ) {
 	data class Batch(
 		val text: String,
 		val sessionToken: Int,
 		val sourceChars: Int,
+		val omittedLines: Long,
 	)
 
 	private sealed interface Entry {
@@ -122,28 +122,27 @@ internal class BuildOutputBuffer(
 		val sessionToken = entries.first().sessionToken
 		val batch = StringBuilder(minOf(retainedChars, maxBatchChars))
 		var sourceChars = 0
+		var omittedLines = 0L
 		while (entries.isNotEmpty()) {
 			val entry = entries.first()
 			if (entry.sessionToken != sessionToken) break
-			val value =
-				when (entry) {
-					is Entry.Text -> entry.value
-					is Entry.Omission -> omissionMarker(entry.lineCount)
-				}
-			if (batch.isNotEmpty() && batch.length + value.length > maxBatchChars) break
+			if (entry is Entry.Text && batch.isNotEmpty() && batch.length + entry.value.length > maxBatchChars) break
 
 			entries.removeFirst()
-			batch.append(value)
 			when (entry) {
 				is Entry.Text -> {
+					batch.append(entry.value)
 					retainedChars -= entry.value.length
 					sourceChars = saturatedAdd(sourceChars, entry.value.length)
 				}
-				is Entry.Omission -> sourceChars = saturatedAdd(sourceChars, entry.sourceChars)
+				is Entry.Omission -> {
+					omittedLines += entry.lineCount
+					sourceChars = saturatedAdd(sourceChars, entry.sourceChars)
+				}
 			}
 		}
 		if (entries.isNotEmpty()) available.trySend(Unit)
-		return Batch(batch.toString(), sessionToken, sourceChars)
+		return Batch(batch.toString(), sessionToken, sourceChars, omittedLines)
 	}
 
 	private fun lineCount(text: String): Long =
@@ -154,19 +153,8 @@ internal class BuildOutputBuffer(
 		right: Int,
 	): Int = (left.toLong() + right).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
 
-	private fun omissionMarker(lineCount: Long): String = formatOmission(lineCount)
-
 	companion object {
 		private const val DEFAULT_MAX_PENDING_CHARS = 256 * 1024
 		private const val DEFAULT_MAX_BATCH_CHARS = 32 * 1024
-
-		/**
-		 * Fallback marker for callers without a [android.content.Context]; the fragment supplies a
-		 * localized `msg_build_output_lines_omitted` plural instead.
-		 */
-		internal fun defaultOmissionMarker(lineCount: Long): String {
-			val noun = if (lineCount == 1L) "line" else "lines"
-			return "[$lineCount build output $noun omitted]\n"
-		}
 	}
 }

--- a/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
@@ -55,7 +55,20 @@ class BuildOutputFragment :
 
 	override val currentEditor: IDEEditor? get() = editor
 
-	private val outputBuffer = BuildOutputBuffer()
+	private val outputBuffer =
+		BuildOutputBuffer(
+			formatOmission = { lineCount ->
+				val context = context
+				if (context == null) {
+					BuildOutputBuffer.defaultOmissionMarker(lineCount)
+				} else {
+					val quantity = lineCount.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+					context.resources
+						.getQuantityString(R.plurals.msg_build_output_lines_omitted, quantity, quantity)
+						.plus('\n')
+				}
+			},
+		)
 
 	private var searchLayout: EditorSearchLayout? = null
 	private var filterBar: LogFilterBarController? = null
@@ -93,7 +106,13 @@ class BuildOutputFragment :
 
 		viewLifecycleOwner.lifecycleScope.launch {
 			launch {
-				restoreWindowFromViewModel()
+				try {
+					restoreWindowFromViewModel()
+				} catch (e: CancellationException) {
+					throw e
+				} catch (e: Exception) {
+					log.error("Failed to restore build output to the editor", e)
+				}
 				withContext(Dispatchers.Default) { processLogs() }
 			}
 			launch {
@@ -338,10 +357,10 @@ class BuildOutputFragment :
 						}
 					}
 				} else {
-					// Layout timed out; keep waiting so the restored content is not lost.
-					editor.awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
+					// Replace content without waiting indefinitely for an offscreen editor's layout.
 					editorContentMutex.withLock {
-						if (isRestoreCurrent() && editor.appendBatchIfReady(content)) {
+						if (isRestoreCurrent()) {
+							editor.setText(content)
 							editorSourceChars =
 								BuildOutputViewModel.editorSourceCharsAfterRefresh(window.length)
 							updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
@@ -453,7 +472,11 @@ class BuildOutputFragment :
 	) {
 		if (!buildOutputViewModel.isCurrentSession(sessionToken)) return
 		val refreshEditorWindow =
-			BuildOutputViewModel.wouldExceedEditorWindow(editorSourceChars, sourceChars)
+			withContext(Dispatchers.Main) {
+				editorContentMutex.withLock {
+					BuildOutputViewModel.wouldExceedEditorWindow(editorSourceChars, sourceChars)
+				}
+			}
 		val visibleText =
 			BuildOutputViewModel.filterLines(
 				text,

--- a/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
@@ -37,8 +37,6 @@ import com.itsaky.androidide.utils.dpToPx
 import com.itsaky.androidide.utils.flashInfo
 import com.itsaky.androidide.viewmodel.BuildOutputViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
@@ -60,7 +58,7 @@ class BuildOutputFragment :
 
 	override val currentEditor: IDEEditor? get() = editor
 
-	private val logChannel = Channel<String>(Channel.UNLIMITED)
+	private val outputBuffer = BuildOutputBuffer()
 
 	private var searchLayout: EditorSearchLayout? = null
 	private var filterBar: LogFilterBarController? = null
@@ -78,6 +76,11 @@ class BuildOutputFragment :
 	// in-flight batch flush drained before the replacement can detect it and drop itself.
 	@Volatile
 	private var editorContentGeneration = 0
+
+	@Volatile
+	private var visibleEditorChars = 0
+	@Volatile
+	private var editorSourceChars = 0
 	private val noMatchTracker = FilterNoMatchTracker()
 
 	// Reads view state (bar visibility), so evaluate it on the main thread.
@@ -98,7 +101,7 @@ class BuildOutputFragment :
 			launch { restoreWindowFromViewModel() }
 			launch(Dispatchers.Default) { processLogs() }
 			launch {
-				val content = buildOutputViewModel.getFullContent()
+				val content = withContext(Dispatchers.IO) { buildOutputViewModel.getWindowForEditor() }
 				buildOutputViewModel.setCachedSnapshot(content)
 			}
 			launch {
@@ -126,10 +129,14 @@ class BuildOutputFragment :
 			val window = withContext(Dispatchers.IO) { buildOutputViewModel.getWindowForEditor() }
 			val filtered =
 				withContext(Dispatchers.Default) {
-					BuildOutputViewModel.filterLines(window, query, showTimestamps, showDeltas)
+					BuildOutputViewModel.fitEditorWindow(
+						BuildOutputViewModel.filterLines(window, query, showTimestamps, showDeltas),
+					)
 				}
 			withContext(Dispatchers.Main) {
 				editor?.setText(filtered)
+				visibleEditorChars = filtered.length
+				editorSourceChars = window.length
 				val isSourceEmpty = window.isBlank()
 				updateEmptyState(isSourceEmpty = isSourceEmpty, isFilterActive = isFilterActive)
 				if (noMatchTracker.onRender(isSourceEmpty = isSourceEmpty, isFilteredEmpty = filtered.isBlank())) {
@@ -287,57 +294,79 @@ class BuildOutputFragment :
 		}.also { filterBar = it }
 	}
 
-	private suspend fun restoreWindowFromViewModel() {
-		val window = withContext(Dispatchers.IO) { buildOutputViewModel.getWindowForEditor() }
-		val content =
-			BuildOutputViewModel.filterLines(
-				window,
-				buildOutputViewModel.filterText.value,
-				buildOutputViewModel.showTimestamps.value,
-				buildOutputViewModel.showDeltas.value,
-			)
-		val query = buildOutputViewModel.filterText.value
-		val isSourceEmpty = window.isBlank()
-		val isFilteredEmpty = content.isBlank()
+	private suspend fun restoreWindowFromViewModel() =
+		withContext(Dispatchers.Default) {
+			val window = withContext(Dispatchers.IO) { buildOutputViewModel.getWindowForEditor() }
+			val content =
+				BuildOutputViewModel.fitEditorWindow(
+					BuildOutputViewModel.filterLines(
+						window,
+						buildOutputViewModel.filterText.value,
+						buildOutputViewModel.showTimestamps.value,
+						buildOutputViewModel.showDeltas.value,
+					),
+				)
+			val generationAtRestore = editorContentGeneration
+			val visibleCharsAtRestore = visibleEditorChars
+			val sourceCharsAtRestore = editorSourceChars
+			fun isRestoreCurrent() =
+				editorContentGeneration == generationAtRestore &&
+					visibleEditorChars == visibleCharsAtRestore &&
+					editorSourceChars == sourceCharsAtRestore
+			val isSourceEmpty = window.isBlank()
+			val isFilteredEmpty = content.isBlank()
 
-		withContext(Dispatchers.Main) {
-			updateEmptyState(isSourceEmpty = isSourceEmpty, isFilterActive = isFilterActive)
-			noMatchTracker.prime(isFilteredEmpty)
-			if (!isSourceEmpty && isFilteredEmpty) {
-				editor?.setText("")
-				onContentReplaced()
-			}
-		}
-
-		if (content.isEmpty()) return
-		withContext(Dispatchers.Main) {
-			val editor = this@BuildOutputFragment.editor ?: return@withContext
-			val layoutCompleted =
-				withTimeoutOrNull(LAYOUT_TIMEOUT_MS) {
-					editor.awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
+			withContext(Dispatchers.Main) {
+				updateEmptyState(isSourceEmpty = isSourceEmpty, isFilterActive = isFilterActive)
+				noMatchTracker.prime(isFilteredEmpty)
+				if (!isSourceEmpty && isFilteredEmpty) {
+					editorContentMutex.withLock {
+						if (isRestoreCurrent()) {
+							editor?.setText("")
+							visibleEditorChars = 0
+							editorSourceChars = window.length
+							onContentReplaced()
+						}
+					}
 				}
-			if (layoutCompleted != null) {
-				editor.appendBatch(content)
-				updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
-			} else {
-				// Timeout: defer append until layout is ready so content is not lost
-				val generationAtRestore = editorContentGeneration
-				val job =
-					viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
-						editor.run {
-							awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
-							editorContentMutex.withLock {
-								if (editorContentGeneration == generationAtRestore) {
-									appendBatch(content)
-									updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
+			}
+
+			if (content.isEmpty()) return@withContext
+			withContext(Dispatchers.Main) {
+				val editor = this@BuildOutputFragment.editor ?: return@withContext
+				val layoutCompleted =
+					withTimeoutOrNull(LAYOUT_TIMEOUT_MS) {
+						editor.awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
+					}
+				if (layoutCompleted != null) {
+					editorContentMutex.withLock {
+						if (isRestoreCurrent()) {
+							editor.appendBatch(content)
+							visibleEditorChars += content.length
+							editorSourceChars = window.length
+							updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
+						}
+					}
+				} else {
+					// Timeout: defer append until layout is ready so content is not lost
+					val job =
+						viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+							editor.run {
+								awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
+								editorContentMutex.withLock {
+									if (isRestoreCurrent()) {
+										appendBatch(content)
+										visibleEditorChars += content.length
+										editorSourceChars = window.length
+										updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
+									}
 								}
 							}
 						}
-					}
-				job.join()
+					job.join()
+				}
 			}
 		}
-	}
 
 	override fun onDestroyView() {
 		searchLayout = null
@@ -351,13 +380,13 @@ class BuildOutputFragment :
 		// Avoid forcing the activityViewModels lazy init (which calls requireActivity())
 		// when the fragment is detached, otherwise an IllegalStateException is thrown.
 		if (!isAdded || activity == null) return
-		while (logChannel.tryReceive().isSuccess) {
-			// Discard: these lines belong to the session being cleared.
-		}
 		// Invalidate in-flight flushes before deleting content, so a batch drained from the
-		// channel earlier cannot re-seed the cleared session.
+		// buffer earlier cannot re-seed the cleared session.
 		sessionGeneration++
+		outputBuffer.clear()
 		editorContentGeneration++
+		visibleEditorChars = 0
+		editorSourceChars = 0
 		noMatchTracker.reset()
 		buildOutputViewModel.clear()
 		super.clearOutput()
@@ -377,55 +406,22 @@ class BuildOutputFragment :
 
 	fun appendOutput(output: String?) {
 		if (!output.isNullOrEmpty()) {
-			logChannel.trySend(output)
-		}
-	}
-
-	/**
-	 * Ensures the string ends with a newline character (`\n`).
-	 * Useful for maintaining correct formatting when concatenating log lines.
-	 */
-	private fun String.ensureNewline(): String = if (endsWith('\n')) this else "$this\n"
-
-	/**
-	 * Immediately drains (consumes) all available messages from the channel into the [buffer].
-	 *
-	 * This is a **non-blocking** operation that enables batching, grouping hundreds of pending lines
-	 * into a single memory operation to avoid saturating the UI queue.
-	 */
-	private fun ReceiveChannel<String>.drainTo(buffer: StringBuilder) {
-		var result = tryReceive()
-		while (result.isSuccess) {
-			val line = result.getOrNull()
-			if (!line.isNullOrEmpty()) {
-				buffer.append(line.ensureNewline())
-			}
-			result = tryReceive()
+			outputBuffer.offer(output, sessionGeneration)
 		}
 	}
 
 	/**
 	 * Main log orchestrator: Consumes, Batches, and Dispatches.
 	 *
-	 * 1. Suspends (zero CPU usage) until the first log arrives.
-	 * 2. Wakes up and drains the entire queue (Batching).
-	 * 3. Sends the complete block to the UI in a single pass.
+	 * Suspends until bounded output is available, then sends one bounded batch to the UI.
 	 */
-	private suspend fun processLogs() =
-		with(StringBuilder()) {
-			for (firstLine in logChannel) {
-				val sessionGenAtDrain = sessionGeneration
-				val editorGenAtDrain = editorContentGeneration
-				append(firstLine.ensureNewline())
-				logChannel.drainTo(this)
-
-				if (isNotEmpty()) {
-					val batchText = toString()
-					clear()
-					flushToEditor(batchText, sessionGenAtDrain, editorGenAtDrain)
-				}
-			}
+	private suspend fun processLogs() {
+		while (true) {
+			val batch = outputBuffer.takeBatch()
+			val editorGenAtDrain = editorContentGeneration
+			flushToEditor(batch.text, batch.sessionGeneration, editorGenAtDrain)
 		}
+	}
 
 	/**
 	 * Performs the safe UI update on the Main Thread.
@@ -443,7 +439,10 @@ class BuildOutputFragment :
 			// A clear (new build) after this batch was drained invalidates session append.
 			if (sessionGen != sessionGeneration) return
 
-			buildOutputViewModel.append(text)
+			buildOutputViewModel.append(text) { sessionGen == sessionGeneration }
+			if (sessionGen != sessionGeneration) return
+			val refreshEditorWindow =
+				BuildOutputViewModel.wouldExceedEditorWindow(editorSourceChars, text.length)
 
 			// The session file always gets the full text; the editor only shows matching lines
 			val visibleText =
@@ -453,13 +452,41 @@ class BuildOutputFragment :
 					buildOutputViewModel.showTimestamps.value,
 					buildOutputViewModel.showDeltas.value,
 				)
-			if (visibleText.isEmpty()) {
+			if (visibleText.isEmpty() && !refreshEditorWindow) {
+				withContext(Dispatchers.Main) {
+					if (sessionGen == sessionGeneration) editorSourceChars += text.length
+				}
 				return
 			}
+			val refreshedWindow =
+				if (refreshEditorWindow) {
+					val window = withContext(Dispatchers.IO) { buildOutputViewModel.getWindowForEditor() }
+					withContext(Dispatchers.Default) {
+						Pair(
+							BuildOutputViewModel.fitEditorWindow(
+								BuildOutputViewModel.filterLines(
+									window,
+									buildOutputViewModel.filterText.value,
+									buildOutputViewModel.showTimestamps.value,
+									buildOutputViewModel.showDeltas.value,
+								),
+							),
+							window.length,
+						)
+					}
+				} else {
+					null
+				}
 
 			withContext(Dispatchers.Main) {
 				updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
-				if (visibleText.isEmpty()) {
+				if (editorGen != editorContentGeneration) return@withContext
+				if (refreshedWindow != null) {
+					editorContentGeneration++
+					editor?.setText(refreshedWindow.first)
+					visibleEditorChars = refreshedWindow.first.length
+					editorSourceChars = refreshedWindow.second
+					onContentReplaced()
 					return@withContext
 				}
 				editor?.run {
@@ -471,6 +498,8 @@ class BuildOutputFragment :
 						// clearOutput() or renderFiltered() may have run since the file append.
 						if (editorGen == editorContentGeneration) {
 							appendBatch(visibleText)
+							visibleEditorChars += visibleText.length
+							editorSourceChars += text.length
 							updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
 						}
 					} else {
@@ -481,6 +510,8 @@ class BuildOutputFragment :
 								editorContentMutex.withLock {
 									if (editorGen == editorContentGeneration) {
 										appendBatch(visibleText)
+										visibleEditorChars += visibleText.length
+										editorSourceChars += text.length
 										updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
 									}
 								}

--- a/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
@@ -36,6 +36,7 @@ import com.itsaky.androidide.utils.BasicBuildInfo
 import com.itsaky.androidide.utils.dpToPx
 import com.itsaky.androidide.utils.flashInfo
 import com.itsaky.androidide.viewmodel.BuildOutputViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -52,10 +53,6 @@ class BuildOutputFragment :
 	ViewOptionsOutputFragment {
 	private val buildOutputViewModel: BuildOutputViewModel by activityViewModels()
 
-	companion object {
-		private const val LAYOUT_TIMEOUT_MS = 2000L
-	}
-
 	override val currentEditor: IDEEditor? get() = editor
 
 	private val outputBuffer = BuildOutputBuffer()
@@ -67,18 +64,15 @@ class BuildOutputFragment :
 	// so a re-render never misses or duplicates a concurrently flushed batch.
 	private val editorContentMutex = Mutex()
 
-	// Bumped only when a build session is cleared (new build) so live streaming logs
-	// are never dropped from the disk session file during filter re-renders.
-	@Volatile
-	private var sessionGeneration = 0
+	// Keeps producer-side disk appends ordered and provides an atomic restore snapshot boundary.
+	private val appendMutex = Mutex()
 
 	// Bumped on every wholesale content replacement (filtered re-render or clear) so an
 	// in-flight batch flush drained before the replacement can detect it and drop itself.
 	@Volatile
 	private var editorContentGeneration = 0
 
-	@Volatile
-	private var visibleEditorChars = 0
+	// Written on Main and read by the background batch processor.
 	@Volatile
 	private var editorSourceChars = 0
 	private val noMatchTracker = FilterNoMatchTracker()
@@ -98,11 +92,9 @@ class BuildOutputFragment :
 		setupSearchLayout()
 
 		viewLifecycleOwner.lifecycleScope.launch {
-			launch { restoreWindowFromViewModel() }
-			launch(Dispatchers.Default) { processLogs() }
 			launch {
-				val content = withContext(Dispatchers.IO) { buildOutputViewModel.getWindowForEditor() }
-				buildOutputViewModel.setCachedSnapshot(content)
+				restoreWindowFromViewModel()
+				withContext(Dispatchers.Default) { processLogs() }
 			}
 			launch {
 				combine(
@@ -124,19 +116,23 @@ class BuildOutputFragment :
 		showTimestamps: Boolean = buildOutputViewModel.showTimestamps.value,
 		showDeltas: Boolean = buildOutputViewModel.showDeltas.value,
 	) {
-		editorContentMutex.withLock {
-			editorContentGeneration++
-			val window = withContext(Dispatchers.IO) { buildOutputViewModel.getWindowForEditor() }
-			val filtered =
-				withContext(Dispatchers.Default) {
-					BuildOutputViewModel.fitEditorWindow(
-						BuildOutputViewModel.filterLines(window, query, showTimestamps, showDeltas),
-					)
-				}
+		val renderGeneration =
 			withContext(Dispatchers.Main) {
-				editor?.setText(filtered)
-				visibleEditorChars = filtered.length
-				editorSourceChars = window.length
+				editorContentGeneration++
+				editorContentGeneration
+			}
+		val window =
+			snapshotEditorWindow()
+		val filtered =
+			withContext(Dispatchers.Default) {
+				BuildOutputViewModel.filterLines(window, query, showTimestamps, showDeltas)
+			}
+		withContext(Dispatchers.Main) {
+			editorContentMutex.withLock {
+				if (renderGeneration != editorContentGeneration) return@withLock
+				val editor = editor ?: return@withLock
+				editor.setText(filtered)
+				editorSourceChars = BuildOutputViewModel.editorSourceCharsAfterRefresh(window.length)
 				val isSourceEmpty = window.isBlank()
 				updateEmptyState(isSourceEmpty = isSourceEmpty, isFilterActive = isFilterActive)
 				if (noMatchTracker.onRender(isSourceEmpty = isSourceEmpty, isFilteredEmpty = filtered.isBlank())) {
@@ -296,23 +292,16 @@ class BuildOutputFragment :
 
 	private suspend fun restoreWindowFromViewModel() =
 		withContext(Dispatchers.Default) {
-			val window = withContext(Dispatchers.IO) { buildOutputViewModel.getWindowForEditor() }
-			val content =
-				BuildOutputViewModel.fitEditorWindow(
-					BuildOutputViewModel.filterLines(
-						window,
-						buildOutputViewModel.filterText.value,
-						buildOutputViewModel.showTimestamps.value,
-						buildOutputViewModel.showDeltas.value,
-					),
-				)
 			val generationAtRestore = editorContentGeneration
-			val visibleCharsAtRestore = visibleEditorChars
-			val sourceCharsAtRestore = editorSourceChars
-			fun isRestoreCurrent() =
-				editorContentGeneration == generationAtRestore &&
-					visibleEditorChars == visibleCharsAtRestore &&
-					editorSourceChars == sourceCharsAtRestore
+			val window = snapshotEditorWindow()
+			val content =
+				BuildOutputViewModel.filterLines(
+					window,
+					buildOutputViewModel.filterText.value,
+					buildOutputViewModel.showTimestamps.value,
+					buildOutputViewModel.showDeltas.value,
+				)
+			fun isRestoreCurrent() = editorContentGeneration == generationAtRestore
 			val isSourceEmpty = window.isBlank()
 			val isFilteredEmpty = content.isBlank()
 
@@ -322,10 +311,12 @@ class BuildOutputFragment :
 				if (!isSourceEmpty && isFilteredEmpty) {
 					editorContentMutex.withLock {
 						if (isRestoreCurrent()) {
-							editor?.setText("")
-							visibleEditorChars = 0
-							editorSourceChars = window.length
-							onContentReplaced()
+							editor?.run {
+								setText("")
+								editorSourceChars =
+									BuildOutputViewModel.editorSourceCharsAfterRefresh(window.length)
+								onContentReplaced()
+							}
 						}
 					}
 				}
@@ -340,30 +331,22 @@ class BuildOutputFragment :
 					}
 				if (layoutCompleted != null) {
 					editorContentMutex.withLock {
-						if (isRestoreCurrent()) {
-							editor.appendBatch(content)
-							visibleEditorChars += content.length
-							editorSourceChars = window.length
+						if (isRestoreCurrent() && editor.appendBatchIfReady(content)) {
+							editorSourceChars =
+								BuildOutputViewModel.editorSourceCharsAfterRefresh(window.length)
 							updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
 						}
 					}
 				} else {
-					// Timeout: defer append until layout is ready so content is not lost
-					val job =
-						viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
-							editor.run {
-								awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
-								editorContentMutex.withLock {
-									if (isRestoreCurrent()) {
-										appendBatch(content)
-										visibleEditorChars += content.length
-										editorSourceChars = window.length
-										updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
-									}
-								}
-							}
+					// Layout timed out; keep waiting so the restored content is not lost.
+					editor.awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
+					editorContentMutex.withLock {
+						if (isRestoreCurrent() && editor.appendBatchIfReady(content)) {
+							editorSourceChars =
+								BuildOutputViewModel.editorSourceCharsAfterRefresh(window.length)
+							updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
 						}
-					job.join()
+					}
 				}
 			}
 		}
@@ -371,6 +354,8 @@ class BuildOutputFragment :
 	override fun onDestroyView() {
 		searchLayout = null
 		filterBar = null
+		editorContentGeneration++
+		editorSourceChars = 0
 		editor?.release()
 		super.onDestroyView()
 	}
@@ -380,12 +365,8 @@ class BuildOutputFragment :
 		// Avoid forcing the activityViewModels lazy init (which calls requireActivity())
 		// when the fragment is detached, otherwise an IllegalStateException is thrown.
 		if (!isAdded || activity == null) return
-		// Invalidate in-flight flushes before deleting content, so a batch drained from the
-		// buffer earlier cannot re-seed the cleared session.
-		sessionGeneration++
 		outputBuffer.clear()
 		editorContentGeneration++
-		visibleEditorChars = 0
 		editorSourceChars = 0
 		noMatchTracker.reset()
 		buildOutputViewModel.clear()
@@ -405,10 +386,33 @@ class BuildOutputFragment :
 	}
 
 	fun appendOutput(output: String?) {
-		if (!output.isNullOrEmpty()) {
-			outputBuffer.offer(output, sessionGeneration)
+		val text = output ?: return
+		if (text.isEmpty()) return
+		val sessionToken = buildOutputViewModel.currentSessionToken
+		lifecycleScope.launch {
+			appendMutex.withLock {
+				val normalized =
+					withContext(Dispatchers.Default) {
+						if (text.endsWith('\n')) text else "$text\n"
+					}
+				if (
+					buildOutputViewModel.append(normalized, sessionToken) &&
+					buildOutputViewModel.isCurrentSession(sessionToken)
+				) {
+					outputBuffer.offer(normalized, sessionToken)
+				}
+			}
 		}
 	}
+
+	private suspend fun snapshotEditorWindow(): String =
+		appendMutex.withLock {
+			val snapshot = withContext(Dispatchers.IO) { buildOutputViewModel.getWindowForEditor() }
+			// The snapshot already contains everything persisted before this boundary.
+			outputBuffer.clear()
+			buildOutputViewModel.setCachedSnapshot(snapshot)
+			snapshot
+		}
 
 	/**
 	 * Main log orchestrator: Consumes, Batches, and Dispatches.
@@ -419,107 +423,122 @@ class BuildOutputFragment :
 		while (true) {
 			val batch = outputBuffer.takeBatch()
 			val editorGenAtDrain = editorContentGeneration
-			flushToEditor(batch.text, batch.sessionGeneration, editorGenAtDrain)
+			try {
+				flushToEditor(
+					batch.text,
+					batch.sourceChars,
+					batch.sessionToken,
+					editorGenAtDrain,
+				)
+			} catch (e: CancellationException) {
+				throw e
+			} catch (e: Exception) {
+				log.error("Failed to flush a build output batch to the editor", e)
+			}
 		}
 	}
 
 	/**
 	 * Performs the safe UI update on the Main Thread.
 	 *
-	 * Appends to the session file on a background dispatcher before switching to Main.
+	 * Applies output already persisted by the producer before switching to Main.
 	 * Uses [IDEEditor.awaitLayout] to guarantee the editor has physical dimensions (width > 0)
 	 * before attempting to insert text, preventing the Sora library's `ArrayIndexOutOfBoundsException`.
 	 */
 	private suspend fun flushToEditor(
 		text: String,
-		sessionGen: Int,
+		sourceChars: Int,
+		sessionToken: Int,
 		editorGen: Int,
 	) {
-		editorContentMutex.withLock {
-			// A clear (new build) after this batch was drained invalidates session append.
-			if (sessionGen != sessionGeneration) return
-
-			buildOutputViewModel.append(text) { sessionGen == sessionGeneration }
-			if (sessionGen != sessionGeneration) return
-			val refreshEditorWindow =
-				BuildOutputViewModel.wouldExceedEditorWindow(editorSourceChars, text.length)
-
-			// The session file always gets the full text; the editor only shows matching lines
-			val visibleText =
-				BuildOutputViewModel.filterLines(
-					text,
-					buildOutputViewModel.filterText.value,
-					buildOutputViewModel.showTimestamps.value,
-					buildOutputViewModel.showDeltas.value,
-				)
-			if (visibleText.isEmpty() && !refreshEditorWindow) {
-				withContext(Dispatchers.Main) {
-					if (sessionGen == sessionGeneration) editorSourceChars += text.length
-				}
-				return
-			}
-			val refreshedWindow =
-				if (refreshEditorWindow) {
-					val window = withContext(Dispatchers.IO) { buildOutputViewModel.getWindowForEditor() }
-					withContext(Dispatchers.Default) {
-						Pair(
-							BuildOutputViewModel.fitEditorWindow(
-								BuildOutputViewModel.filterLines(
-									window,
-									buildOutputViewModel.filterText.value,
-									buildOutputViewModel.showTimestamps.value,
-									buildOutputViewModel.showDeltas.value,
-								),
-							),
-							window.length,
-						)
+		if (!buildOutputViewModel.isCurrentSession(sessionToken)) return
+		val refreshEditorWindow =
+			BuildOutputViewModel.wouldExceedEditorWindow(editorSourceChars, sourceChars)
+		val visibleText =
+			BuildOutputViewModel.filterLines(
+				text,
+				buildOutputViewModel.filterText.value,
+				buildOutputViewModel.showTimestamps.value,
+				buildOutputViewModel.showDeltas.value,
+			)
+		val refreshedWindow =
+			if (refreshEditorWindow) {
+				val window =
+					appendMutex.withLock {
+						val snapshot = buildOutputViewModel.getCachedContentSnapshot()
+						outputBuffer.clear()
+						snapshot
 					}
-				} else {
-					null
+				withContext(Dispatchers.Default) {
+					Pair(
+						BuildOutputViewModel.filterLines(
+							window,
+							buildOutputViewModel.filterText.value,
+							buildOutputViewModel.showTimestamps.value,
+							buildOutputViewModel.showDeltas.value,
+						),
+						window.length,
+					)
 				}
+			} else {
+				null
+			}
 
-			withContext(Dispatchers.Main) {
+		withContext(Dispatchers.Main) {
+			editorContentMutex.withLock {
+				if (
+					editorGen != editorContentGeneration ||
+					!buildOutputViewModel.isCurrentSession(sessionToken)
+				) {
+					return@withLock
+				}
+				val editor = editor ?: return@withLock
 				updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
-				if (editorGen != editorContentGeneration) return@withContext
 				if (refreshedWindow != null) {
 					editorContentGeneration++
-					editor?.setText(refreshedWindow.first)
-					visibleEditorChars = refreshedWindow.first.length
-					editorSourceChars = refreshedWindow.second
+					editor.setText(refreshedWindow.first)
+					editorSourceChars =
+						BuildOutputViewModel.editorSourceCharsAfterRefresh(refreshedWindow.second)
 					onContentReplaced()
-					return@withContext
+					return@withLock
 				}
-				editor?.run {
-					val layoutCompleted =
-						withTimeoutOrNull(LAYOUT_TIMEOUT_MS) {
-							awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
-						}
-					if (layoutCompleted != null) {
-						// clearOutput() or renderFiltered() may have run since the file append.
-						if (editorGen == editorContentGeneration) {
-							appendBatch(visibleText)
-							visibleEditorChars += visibleText.length
-							editorSourceChars += text.length
-							updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
-						}
-					} else {
-						// Timeout: defer append until layout is ready (same as restoreWindowFromViewModel)
-						viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
-							editor?.run {
-								awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
-								editorContentMutex.withLock {
-									if (editorGen == editorContentGeneration) {
-										appendBatch(visibleText)
-										visibleEditorChars += visibleText.length
-										editorSourceChars += text.length
-										updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
-									}
-								}
-							}
-						}
+				if (visibleText.isEmpty()) {
+					editorSourceChars += sourceChars
+					return@withLock
+				}
+
+				val layoutCompleted =
+					withTimeoutOrNull(LAYOUT_TIMEOUT_MS) {
+						editor.awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
+					}
+				if (layoutCompleted != null) {
+					if (editor.appendBatchIfReady(visibleText)) {
+						editorSourceChars += sourceChars
+					}
+				} else {
+					editor.awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
+					if (
+						editorGen == editorContentGeneration &&
+						buildOutputViewModel.isCurrentSession(sessionToken) &&
+						editor.appendBatchIfReady(visibleText)
+					) {
+						editorSourceChars += sourceChars
+						updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
 					}
 				}
 			}
 		}
+	}
+
+	private fun IDEEditor.appendBatchIfReady(text: String): Boolean {
+		if (!isReadyToAppend) return false
+		val previousLength = this.text.length
+		appendBatch(text)
+		return this.text.length == previousLength + text.length
+	}
+
+	companion object {
+		private const val LAYOUT_TIMEOUT_MS = 2000L
+		private val log = org.slf4j.LoggerFactory.getLogger(BuildOutputFragment::class.java)
 	}
 }

--- a/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/output/BuildOutputFragment.kt
@@ -55,20 +55,7 @@ class BuildOutputFragment :
 
 	override val currentEditor: IDEEditor? get() = editor
 
-	private val outputBuffer =
-		BuildOutputBuffer(
-			formatOmission = { lineCount ->
-				val context = context
-				if (context == null) {
-					BuildOutputBuffer.defaultOmissionMarker(lineCount)
-				} else {
-					val quantity = lineCount.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
-					context.resources
-						.getQuantityString(R.plurals.msg_build_output_lines_omitted, quantity, quantity)
-						.plus('\n')
-				}
-			},
-		)
+	private val outputBuffer = BuildOutputBuffer()
 
 	private var searchLayout: EditorSearchLayout? = null
 	private var filterBar: LogFilterBarController? = null
@@ -325,17 +312,16 @@ class BuildOutputFragment :
 			val isFilteredEmpty = content.isBlank()
 
 			withContext(Dispatchers.Main) {
-				updateEmptyState(isSourceEmpty = isSourceEmpty, isFilterActive = isFilterActive)
-				noMatchTracker.prime(isFilteredEmpty)
-				if (!isSourceEmpty && isFilteredEmpty) {
-					editorContentMutex.withLock {
-						if (isRestoreCurrent()) {
-							editor?.run {
-								setText("")
-								editorSourceChars =
-									BuildOutputViewModel.editorSourceCharsAfterRefresh(window.length)
-								onContentReplaced()
-							}
+				editorContentMutex.withLock {
+					if (!isRestoreCurrent()) return@withLock
+					updateEmptyState(isSourceEmpty = isSourceEmpty, isFilterActive = isFilterActive)
+					noMatchTracker.prime(isFilteredEmpty)
+					if (!isSourceEmpty && isFilteredEmpty) {
+						editor?.run {
+							setText("")
+							editorSourceChars =
+								BuildOutputViewModel.editorSourceCharsAfterRefresh(window.length)
+							onContentReplaced()
 						}
 					}
 				}
@@ -346,7 +332,11 @@ class BuildOutputFragment :
 				val editor = this@BuildOutputFragment.editor ?: return@withContext
 				val layoutCompleted =
 					withTimeoutOrNull(LAYOUT_TIMEOUT_MS) {
-						editor.awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
+						editor.awaitLayout {
+							if (isRestoreCurrent()) {
+								updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
+							}
+						}
 					}
 				if (layoutCompleted != null) {
 					editorContentMutex.withLock {
@@ -360,10 +350,16 @@ class BuildOutputFragment :
 					// Replace content without waiting indefinitely for an offscreen editor's layout.
 					editorContentMutex.withLock {
 						if (isRestoreCurrent()) {
-							editor.setText(content)
-							editorSourceChars =
-								BuildOutputViewModel.editorSourceCharsAfterRefresh(window.length)
-							updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
+							val contentReplaced =
+								runCatching { editor.setText(content) }
+									.onFailure { log.error("Failed to restore build output before editor layout", it) }
+									.isSuccess
+							if (contentReplaced) {
+								editorSourceChars =
+									BuildOutputViewModel.editorSourceCharsAfterRefresh(window.length)
+								updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
+								onContentReplaced()
+							}
 						}
 					}
 				}
@@ -405,6 +401,7 @@ class BuildOutputFragment :
 	}
 
 	fun appendOutput(output: String?) {
+		if (!isAdded || activity == null) return
 		val text = output ?: return
 		if (text.isEmpty()) return
 		val sessionToken = buildOutputViewModel.currentSessionToken
@@ -446,6 +443,7 @@ class BuildOutputFragment :
 				flushToEditor(
 					batch.text,
 					batch.sourceChars,
+					batch.omittedLines,
 					batch.sessionToken,
 					editorGenAtDrain,
 				)
@@ -464,19 +462,18 @@ class BuildOutputFragment :
 	 * Uses [IDEEditor.awaitLayout] to guarantee the editor has physical dimensions (width > 0)
 	 * before attempting to insert text, preventing the Sora library's `ArrayIndexOutOfBoundsException`.
 	 */
-	private suspend fun flushToEditor(
+	internal suspend fun flushToEditor(
 		text: String,
 		sourceChars: Int,
+		omittedLines: Long,
 		sessionToken: Int,
 		editorGen: Int,
 	) {
 		if (!buildOutputViewModel.isCurrentSession(sessionToken)) return
+		// A filter render or clear can make this snapshot stale; the generation check before applying
+		// the batch makes that harmless without adding a Main-thread dispatch to every batch.
 		val refreshEditorWindow =
-			withContext(Dispatchers.Main) {
-				editorContentMutex.withLock {
-					BuildOutputViewModel.wouldExceedEditorWindow(editorSourceChars, sourceChars)
-				}
-			}
+			BuildOutputViewModel.wouldExceedEditorWindow(editorSourceChars, sourceChars)
 		val visibleText =
 			BuildOutputViewModel.filterLines(
 				text,
@@ -508,6 +505,20 @@ class BuildOutputFragment :
 			}
 
 		withContext(Dispatchers.Main) {
+			val editor = editor ?: return@withContext
+			val needsAppend = refreshedWindow == null && (visibleText.isNotEmpty() || omittedLines > 0)
+			if (needsAppend) {
+				val layoutCompleted =
+					withTimeoutOrNull(LAYOUT_TIMEOUT_MS) {
+						editor.awaitLayout {
+							if (editorGen == editorContentGeneration) {
+								updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
+							}
+						}
+					}
+				// The batch is already persisted and will be recovered by the next window snapshot.
+				if (layoutCompleted == null) return@withContext
+			}
 			editorContentMutex.withLock {
 				if (
 					editorGen != editorContentGeneration ||
@@ -515,7 +526,6 @@ class BuildOutputFragment :
 				) {
 					return@withLock
 				}
-				val editor = editor ?: return@withLock
 				updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
 				if (refreshedWindow != null) {
 					editorContentGeneration++
@@ -525,32 +535,25 @@ class BuildOutputFragment :
 					onContentReplaced()
 					return@withLock
 				}
-				if (visibleText.isEmpty()) {
+				val omissionMarker =
+					if (omittedLines > 0) formatOmissionMarker(omittedLines) else ""
+				val textToAppend = omissionMarker + visibleText
+				if (textToAppend.isEmpty()) {
 					editorSourceChars += sourceChars
 					return@withLock
 				}
-
-				val layoutCompleted =
-					withTimeoutOrNull(LAYOUT_TIMEOUT_MS) {
-						editor.awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
-					}
-				if (layoutCompleted != null) {
-					if (editor.appendBatchIfReady(visibleText)) {
-						editorSourceChars += sourceChars
-					}
-				} else {
-					editor.awaitLayout(onForceVisible = { updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive) })
-					if (
-						editorGen == editorContentGeneration &&
-						buildOutputViewModel.isCurrentSession(sessionToken) &&
-						editor.appendBatchIfReady(visibleText)
-					) {
-						editorSourceChars += sourceChars
-						updateEmptyState(isSourceEmpty = false, isFilterActive = isFilterActive)
-					}
+				if (editor.appendBatchIfReady(textToAppend)) {
+					editorSourceChars += sourceChars
 				}
 			}
 		}
+	}
+
+	private fun formatOmissionMarker(lineCount: Long): String {
+		val quantity = lineCount.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+		return resources
+			.getQuantityString(R.plurals.msg_build_output_lines_omitted, quantity, lineCount)
+			.plus('\n')
 	}
 
 	private fun IDEEditor.appendBatchIfReady(text: String): Boolean {

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/BuildOutputViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/BuildOutputViewModel.kt
@@ -90,10 +90,14 @@ class BuildOutputViewModel(
 	 * Appends text to the session file. File I/O is performed on a background dispatcher; call from
 	 * any thread. Prefer calling before switching to Main so disk write does not block the UI.
 	 */
-	suspend fun append(text: String) {
+	suspend fun append(
+		text: String,
+		isCurrentSession: () -> Boolean = { true },
+	) {
 		if (text.isEmpty()) return
 		withContext(Dispatchers.IO) {
 			lock.withLock {
+				if (!isCurrentSession()) return@withLock
 				try {
 					FileOutputStream(sessionFile, true).use {
 						it.write(text.toByteArray(StandardCharsets.UTF_8))
@@ -108,12 +112,12 @@ class BuildOutputViewModel(
 	}
 
 	/**
-	 * Returns the last [WINDOW_SIZE_CHARS] characters from the session file for the editor to
+	 * Returns the last [EDITOR_WINDOW_MAX_CHARS] characters from the session file for the editor to
 	 * display (e.g. initial view or after rotation). Returns empty string if no content.
 	 */
 	fun getWindowForEditor(): String =
 		lock.withLock {
-			readTailFromFile(sessionFile, WINDOW_SIZE_CHARS)
+			readTailFromFile(sessionFile, EDITOR_WINDOW_MAX_CHARS)
 		}
 
 	/**
@@ -194,6 +198,20 @@ class BuildOutputViewModel(
 	}
 
 	companion object {
+		internal const val EDITOR_WINDOW_MAX_CHARS = 512 * 1024
+
+		internal fun wouldExceedEditorWindow(
+			currentChars: Int,
+			incomingChars: Int,
+		): Boolean = currentChars > EDITOR_WINDOW_MAX_CHARS - incomingChars
+
+		internal fun fitEditorWindow(content: String): String =
+			if (content.length <= EDITOR_WINDOW_MAX_CHARS) {
+				content
+			} else {
+				content.takeLast(EDITOR_WINDOW_MAX_CHARS)
+			}
+
 		// Must mirror formatLinePrefix exactly; the round-trip is covered by BuildOutputFilterTest.
 		// Anchored to line start so timestamp-shaped text inside a message is never stripped.
 		private val PREFIX_REGEX =
@@ -261,10 +279,8 @@ class BuildOutputViewModel(
 		}
 
 		private const val SESSION_FILE_NAME = "build_output_session.txt"
-		private const val WINDOW_SIZE_CHARS = 512 * 1024
-
 		/** Max length of [cachedContentSnapshot] to bound memory. */
-		private const val CACHE_SNAPSHOT_MAX_CHARS = WINDOW_SIZE_CHARS
+		private const val CACHE_SNAPSHOT_MAX_CHARS = EDITOR_WINDOW_MAX_CHARS
 		private val log = org.slf4j.LoggerFactory.getLogger(BuildOutputViewModel::class.java)
 	}
 }

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/BuildOutputViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/BuildOutputViewModel.kt
@@ -292,7 +292,7 @@ class BuildOutputViewModel(
 
 		private const val SESSION_FILE_NAME = "build_output_session.txt"
 		/** Max length of [cachedContentSnapshot] to bound memory. */
-		private const val CACHE_SNAPSHOT_MAX_CHARS = EDITOR_WINDOW_MAX_CHARS
+		private const val CACHE_SNAPSHOT_MAX_CHARS = 128 * 1024
 		private val log = org.slf4j.LoggerFactory.getLogger(BuildOutputViewModel::class.java)
 	}
 }

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/BuildOutputViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/BuildOutputViewModel.kt
@@ -47,6 +47,16 @@ class BuildOutputViewModel(
 ) : AndroidViewModel(application) {
 	private val lock = ReentrantLock()
 
+	@Volatile
+	private var sessionGeneration = 0
+
+	/** Token for output produced by the current build session. */
+	val currentSessionToken: Int
+		get() = sessionGeneration
+
+	/** Returns whether [token] still belongs to the current build session. */
+	fun isCurrentSession(token: Int): Boolean = token == sessionGeneration
+
 	/**
 	 * Case-insensitive line filter applied to the *editor view* of the build output.
 	 * The session file always receives the unfiltered text.
@@ -88,24 +98,26 @@ class BuildOutputViewModel(
 
 	/**
 	 * Appends text to the session file. File I/O is performed on a background dispatcher; call from
-	 * any thread. Prefer calling before switching to Main so disk write does not block the UI.
+	 * any thread. [sessionToken] values invalidated by [clear] are rejected inside the file lock.
 	 */
 	suspend fun append(
 		text: String,
-		isCurrentSession: () -> Boolean = { true },
-	) {
-		if (text.isEmpty()) return
-		withContext(Dispatchers.IO) {
+		sessionToken: Int,
+	): Boolean {
+		if (text.isEmpty()) return false
+		return withContext(Dispatchers.IO) {
 			lock.withLock {
-				if (!isCurrentSession()) return@withLock
+				if (!isCurrentSession(sessionToken)) return@withLock false
 				try {
 					FileOutputStream(sessionFile, true).use {
 						it.write(text.toByteArray(StandardCharsets.UTF_8))
 					}
 					cachedContentSnapshot =
 						(cachedContentSnapshot + text).takeLast(CACHE_SNAPSHOT_MAX_CHARS)
+					true
 				} catch (e: Exception) {
 					log.error("Failed to append build output to session file", e)
+					false
 				}
 			}
 		}
@@ -163,6 +175,7 @@ class BuildOutputViewModel(
 	 */
 	fun clear() {
 		lock.withLock {
+			sessionGeneration++
 			cachedContentSnapshot = ""
 			try {
 				if (sessionFile.exists()) {
@@ -199,18 +212,17 @@ class BuildOutputViewModel(
 
 	companion object {
 		internal const val EDITOR_WINDOW_MAX_CHARS = 512 * 1024
+		private const val EDITOR_WINDOW_REFRESH_CHARS = 128 * 1024
+		private const val EDITOR_WINDOW_REFRESH_BASE_CHARS =
+			EDITOR_WINDOW_MAX_CHARS - EDITOR_WINDOW_REFRESH_CHARS
 
 		internal fun wouldExceedEditorWindow(
 			currentChars: Int,
 			incomingChars: Int,
 		): Boolean = currentChars > EDITOR_WINDOW_MAX_CHARS - incomingChars
 
-		internal fun fitEditorWindow(content: String): String =
-			if (content.length <= EDITOR_WINDOW_MAX_CHARS) {
-				content
-			} else {
-				content.takeLast(EDITOR_WINDOW_MAX_CHARS)
-			}
+		internal fun editorSourceCharsAfterRefresh(windowChars: Int): Int =
+			windowChars.coerceAtMost(EDITOR_WINDOW_REFRESH_BASE_CHARS)
 
 		// Must mirror formatLinePrefix exactly; the round-trip is covered by BuildOutputFilterTest.
 		// Anchored to line start so timestamp-shaped text inside a message is never stripped.

--- a/app/src/main/java/com/itsaky/androidide/viewmodel/BuildOutputViewModel.kt
+++ b/app/src/main/java/com/itsaky/androidide/viewmodel/BuildOutputViewModel.kt
@@ -46,6 +46,9 @@ class BuildOutputViewModel(
 	application: Application,
 ) : AndroidViewModel(application) {
 	private val lock = ReentrantLock()
+	private val cachedContentSnapshot = StringBuilder()
+	// Reused until clear/onCleared so noisy builds do not open and close the file per line.
+	private var sessionOutputStream: FileOutputStream? = null
 
 	@Volatile
 	private var sessionGeneration = 0
@@ -73,24 +76,15 @@ class BuildOutputViewModel(
 	val showLineNumbers = MutableStateFlow(EditorPreferences.outputLineNumbers)
 
 	/**
-	 * Thread-safe snapshot of content for synchronous [getShareableContent] without blocking.
-	 * Updated on [append] and [clear]; primed on restore via [setCachedSnapshot].
-	 * Capped at [CACHE_SNAPSHOT_MAX_CHARS] to bound memory.
+	 * Returns the thread-safe cached snapshot for synchronous share/copy. Updated on [append] and
+	 * [clear], primed on restore via [setCachedSnapshot], and capped at
+	 * [CACHE_SNAPSHOT_MAX_CHARS].
 	 */
-	@Volatile
-	private var cachedContentSnapshot: String = ""
-
-	/** Returns the current cached snapshot for share/copy (non-blocking). */
-	fun getCachedContentSnapshot(): String = cachedContentSnapshot
+	fun getCachedContentSnapshot(): String = lock.withLock { cachedContentSnapshot.toString() }
 
 	/** Updates the cached snapshot (e.g. after loading full content on restore). Capped to [CACHE_SNAPSHOT_MAX_CHARS]. */
 	fun setCachedSnapshot(content: String) {
-		cachedContentSnapshot =
-			if (content.length <= CACHE_SNAPSHOT_MAX_CHARS) {
-				content
-			} else {
-				content.takeLast(CACHE_SNAPSHOT_MAX_CHARS)
-			}
+		lock.withLock { replaceCachedSnapshot(content) }
 	}
 
 	private val sessionFile: File
@@ -109,13 +103,16 @@ class BuildOutputViewModel(
 			lock.withLock {
 				if (!isCurrentSession(sessionToken)) return@withLock false
 				try {
-					FileOutputStream(sessionFile, true).use {
-						it.write(text.toByteArray(StandardCharsets.UTF_8))
-					}
-					cachedContentSnapshot =
-						(cachedContentSnapshot + text).takeLast(CACHE_SNAPSHOT_MAX_CHARS)
+					val output =
+						sessionOutputStream
+							?: FileOutputStream(sessionFile, true).also {
+								sessionOutputStream = it
+							}
+					output.write(text.toByteArray(StandardCharsets.UTF_8))
+					appendCachedSnapshot(text)
 					true
 				} catch (e: Exception) {
+					closeSessionOutputStream()
 					log.error("Failed to append build output to session file", e)
 					false
 				}
@@ -176,7 +173,8 @@ class BuildOutputViewModel(
 	fun clear() {
 		lock.withLock {
 			sessionGeneration++
-			cachedContentSnapshot = ""
+			closeSessionOutputStream()
+			cachedContentSnapshot.setLength(0)
 			try {
 				if (sessionFile.exists()) {
 					sessionFile.delete()
@@ -184,6 +182,37 @@ class BuildOutputViewModel(
 			} catch (e: Exception) {
 				log.error("Failed to delete build output session file", e)
 			}
+		}
+	}
+
+	override fun onCleared() {
+		lock.withLock { closeSessionOutputStream() }
+		super.onCleared()
+	}
+
+	private fun appendCachedSnapshot(text: String) {
+		if (text.length >= CACHE_SNAPSHOT_MAX_CHARS) {
+			replaceCachedSnapshot(text)
+			return
+		}
+		val overflow = cachedContentSnapshot.length + text.length - CACHE_SNAPSHOT_MAX_CHARS
+		if (overflow > 0) cachedContentSnapshot.delete(0, overflow)
+		cachedContentSnapshot.append(text)
+	}
+
+	private fun replaceCachedSnapshot(content: String) {
+		cachedContentSnapshot.setLength(0)
+		val start = (content.length - CACHE_SNAPSHOT_MAX_CHARS).coerceAtLeast(0)
+		cachedContentSnapshot.append(content, start, content.length)
+	}
+
+	private fun closeSessionOutputStream() {
+		try {
+			sessionOutputStream?.close()
+		} catch (e: Exception) {
+			log.error("Failed to close build output session file", e)
+		} finally {
+			sessionOutputStream = null
 		}
 	}
 
@@ -292,7 +321,7 @@ class BuildOutputViewModel(
 
 		private const val SESSION_FILE_NAME = "build_output_session.txt"
 		/** Max length of [cachedContentSnapshot] to bound memory. */
-		private const val CACHE_SNAPSHOT_MAX_CHARS = 128 * 1024
+		private const val CACHE_SNAPSHOT_MAX_CHARS = EDITOR_WINDOW_MAX_CHARS
 		private val log = org.slf4j.LoggerFactory.getLogger(BuildOutputViewModel::class.java)
 	}
 }

--- a/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputBufferTest.kt
+++ b/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputBufferTest.kt
@@ -142,6 +142,19 @@ class BuildOutputBufferTest {
 		}
 
 	@Test
+	fun `append cache retains a smaller tail than the editor window`() =
+		runTest {
+			val viewModel = BuildOutputViewModel(ApplicationProvider.getApplicationContext<Application>())
+			viewModel.clear()
+			val output = "x".repeat(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS - 1) + "\n"
+			assertThat(viewModel.append(output, viewModel.currentSessionToken)).isTrue()
+			assertThat(viewModel.getCachedContentSnapshot()).isEqualTo(output.takeLast(128 * 1024))
+			assertThat(viewModel.getWindowForEditor()).isEqualTo(output)
+			assertThat(viewModel.getFullContent()).isEqualTo(output)
+			viewModel.clear()
+		}
+
+	@Test
 	fun `window refresh uses hysteresis after reaching the editor limit`() {
 		val batchChars = 32 * 1024
 		var sourceChars = BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS

--- a/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputBufferTest.kt
+++ b/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputBufferTest.kt
@@ -17,15 +17,19 @@
 
 package com.itsaky.androidide.fragments.output
 
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import com.itsaky.androidide.viewmodel.BuildOutputViewModel
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class BuildOutputBufferTest {
 	private fun BuildOutputBuffer.offer(text: String) {
-		offer(text, sessionGeneration = 0)
+		offer(text, sessionToken = 0)
 	}
 
 	@Test
@@ -36,7 +40,7 @@ class BuildOutputBufferTest {
 			buffer.offer("first")
 			buffer.offer("second\n")
 
-			assertEquals("first\nsecond\n", buffer.takeBatch().text)
+			assertThat(buffer.takeBatch().text).isEqualTo("first\nsecond\n")
 		}
 
 	@Test
@@ -50,10 +54,10 @@ class BuildOutputBufferTest {
 
 			val first = buffer.takeBatch().text
 			val second = buffer.takeBatch().text
-			assertEquals("aa\nbb\n", first)
-			assertEquals("cc\n", second)
-			assertTrue(first.length <= 6)
-			assertTrue(second.length <= 6)
+			assertThat(first).isEqualTo("aa\nbb\n")
+			assertThat(second).isEqualTo("cc\n")
+			assertThat(first.length).isAtMost(6)
+			assertThat(second.length).isAtMost(6)
 		}
 
 	@Test
@@ -63,43 +67,36 @@ class BuildOutputBufferTest {
 
 			buffer.offer("oversized")
 
-			assertEquals("oversized\n", buffer.takeBatch().text)
+			assertThat(buffer.takeBatch().text).isEqualTo("oversized\n")
 		}
 
 	@Test
-	fun `overflow is coalesced before retained output resumes`() =
+	fun `overflow evicts oldest output and keeps newest output`() =
+		runTest {
+			val buffer = BuildOutputBuffer(maxPendingChars = 11, maxBatchChars = 128)
+
+			buffer.offer("one")
+			buffer.offer("two")
+			buffer.offer("three")
+			buffer.offer("four")
+
+			val batch = buffer.takeBatch()
+			assertThat(batch.text).isEqualTo("[2 build output lines omitted]\nthree\nfour\n")
+			assertThat(batch.sourceChars).isEqualTo(19)
+			assertThat(buffer.pendingChars).isAtMost(11)
+		}
+
+	@Test
+	fun `oversized input retains its newest bounded tail`() =
 		runTest {
 			val buffer = BuildOutputBuffer(maxPendingChars = 8, maxBatchChars = 128)
 
-			buffer.offer("one")
-			buffer.offer("two")
-			buffer.offer("dropped one")
-			buffer.offer("dropped two\nand three")
+			buffer.offer("0123456789")
 
-			assertEquals(
-				"one\ntwo\n[3 build output lines omitted]\n",
-				buffer.takeBatch().text,
-			)
-			assertTrue(buffer.pendingChars <= 8)
-		}
-
-	@Test
-	fun `overflow after resumed output starts a new omission marker`() =
-		runTest {
-			val buffer = BuildOutputBuffer(maxPendingChars = 8, maxBatchChars = 4)
-
-			buffer.offer("one")
-			buffer.offer("two")
-			buffer.offer("first dropped")
-			assertEquals("one\n", buffer.takeBatch().text)
-
-			buffer.offer("new")
-			buffer.offer("second dropped")
-
-			assertEquals("two\n", buffer.takeBatch().text)
-			assertEquals("[1 build output lines omitted]\n", buffer.takeBatch().text)
-			assertEquals("new\n", buffer.takeBatch().text)
-			assertEquals("[1 build output lines omitted]\n", buffer.takeBatch().text)
+			val batch = buffer.takeBatch()
+			assertThat(batch.text).isEqualTo("[1 build output line omitted]\n3456789\n")
+			assertThat(batch.sourceChars).isEqualTo(11)
+			assertThat(buffer.pendingChars).isEqualTo(0)
 		}
 
 	@Test
@@ -112,45 +109,57 @@ class BuildOutputBufferTest {
 			buffer.clear()
 			buffer.offer("new")
 
-			assertEquals("new\n", buffer.takeBatch().text)
+			assertThat(buffer.takeBatch().text).isEqualTo("new\n")
 		}
 
 	@Test
-	fun `in-flight batch keeps the session generation from its producer`() =
+	fun `in-flight batch keeps the session token from its producer`() =
 		runTest {
 			val buffer = BuildOutputBuffer(maxPendingChars = 64, maxBatchChars = 64)
 
-			buffer.offer("old", sessionGeneration = 3)
+			buffer.offer("old", sessionToken = 3)
 			val inFlight = buffer.takeBatch()
 			buffer.clear()
-			buffer.offer("new", sessionGeneration = 4)
+			buffer.offer("new", sessionToken = 4)
 
-			assertEquals(3, inFlight.sessionGeneration)
-			assertEquals(4, buffer.takeBatch().sessionGeneration)
+			assertThat(inFlight.sessionToken).isEqualTo(3)
+			assertThat(buffer.takeBatch().sessionToken).isEqualTo(4)
 		}
 
 	@Test
-	fun `repeated live batches refresh to the newest bounded editor tail`() {
-		val chunk = "x".repeat(200 * 1024)
-		val newest = "newest build output\n"
-		var session = ""
-		var visible = ""
-		var refreshCount = 0
+	fun `clear invalidates stale view model session tokens`() =
+		runTest {
+			val viewModel =
+				BuildOutputViewModel(ApplicationProvider.getApplicationContext<Application>())
+			viewModel.clear()
+			val staleToken = viewModel.currentSessionToken
 
-		for (batch in listOf(chunk, chunk, chunk + newest)) {
-			session += batch
-			visible =
-				if (BuildOutputViewModel.wouldExceedEditorWindow(visible.length, batch.length)) {
-					refreshCount++
-					session.takeLast(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS)
-				} else {
-					visible + batch
-				}
+			assertThat(viewModel.append("old\n", staleToken)).isTrue()
+			viewModel.clear()
+
+			assertThat(viewModel.append("stale\n", staleToken)).isFalse()
+			assertThat(viewModel.getFullContent()).isEmpty()
 		}
 
-		assertEquals(1, refreshCount)
-		assertTrue(visible.length <= BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS)
-		assertTrue(visible.endsWith(newest))
+	@Test
+	fun `window refresh uses hysteresis after reaching the editor limit`() {
+		val batchChars = 32 * 1024
+		var sourceChars = BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS
+		var refreshCount = 0
+
+		repeat(6) {
+			if (BuildOutputViewModel.wouldExceedEditorWindow(sourceChars, batchChars)) {
+				refreshCount++
+				sourceChars =
+					BuildOutputViewModel.editorSourceCharsAfterRefresh(
+						BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS,
+					)
+			} else {
+				sourceChars += batchChars
+			}
+		}
+
+		assertThat(refreshCount).isEqualTo(2)
 	}
 
 	@Test
@@ -171,11 +180,11 @@ class BuildOutputBufferTest {
 					showTimestamps = true,
 					showDeltas = true,
 				)
-			sourceChars = window.length
+			sourceChars = BuildOutputViewModel.editorSourceCharsAfterRefresh(window.length)
 		}
 
-		assertEquals("", visible)
-		assertEquals(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS, sourceChars)
+		assertThat(visible).isEmpty()
+		assertThat(sourceChars).isLessThan(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS)
 	}
 
 	@Test
@@ -191,6 +200,6 @@ class BuildOutputBufferTest {
 				showDeltas = false,
 			)
 
-		assertEquals("newest output\n", visible)
+		assertThat(visible).isEqualTo("newest output\n")
 	}
 }

--- a/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputBufferTest.kt
+++ b/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputBufferTest.kt
@@ -1,0 +1,196 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.fragments.output
+
+import com.itsaky.androidide.viewmodel.BuildOutputViewModel
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BuildOutputBufferTest {
+	private fun BuildOutputBuffer.offer(text: String) {
+		offer(text, sessionGeneration = 0)
+	}
+
+	@Test
+	fun `output below limits is emitted in order with one trailing newline`() =
+		runTest {
+			val buffer = BuildOutputBuffer(maxPendingChars = 64, maxBatchChars = 64)
+
+			buffer.offer("first")
+			buffer.offer("second\n")
+
+			assertEquals("first\nsecond\n", buffer.takeBatch().text)
+		}
+
+	@Test
+	fun `output is split into bounded batches without reordering`() =
+		runTest {
+			val buffer = BuildOutputBuffer(maxPendingChars = 64, maxBatchChars = 6)
+
+			buffer.offer("aa")
+			buffer.offer("bb")
+			buffer.offer("cc")
+
+			val first = buffer.takeBatch().text
+			val second = buffer.takeBatch().text
+			assertEquals("aa\nbb\n", first)
+			assertEquals("cc\n", second)
+			assertTrue(first.length <= 6)
+			assertTrue(second.length <= 6)
+		}
+
+	@Test
+	fun `one indivisible input may exceed the batch limit`() =
+		runTest {
+			val buffer = BuildOutputBuffer(maxPendingChars = 64, maxBatchChars = 4)
+
+			buffer.offer("oversized")
+
+			assertEquals("oversized\n", buffer.takeBatch().text)
+		}
+
+	@Test
+	fun `overflow is coalesced before retained output resumes`() =
+		runTest {
+			val buffer = BuildOutputBuffer(maxPendingChars = 8, maxBatchChars = 128)
+
+			buffer.offer("one")
+			buffer.offer("two")
+			buffer.offer("dropped one")
+			buffer.offer("dropped two\nand three")
+
+			assertEquals(
+				"one\ntwo\n[3 build output lines omitted]\n",
+				buffer.takeBatch().text,
+			)
+			assertTrue(buffer.pendingChars <= 8)
+		}
+
+	@Test
+	fun `overflow after resumed output starts a new omission marker`() =
+		runTest {
+			val buffer = BuildOutputBuffer(maxPendingChars = 8, maxBatchChars = 4)
+
+			buffer.offer("one")
+			buffer.offer("two")
+			buffer.offer("first dropped")
+			assertEquals("one\n", buffer.takeBatch().text)
+
+			buffer.offer("new")
+			buffer.offer("second dropped")
+
+			assertEquals("two\n", buffer.takeBatch().text)
+			assertEquals("[1 build output lines omitted]\n", buffer.takeBatch().text)
+			assertEquals("new\n", buffer.takeBatch().text)
+			assertEquals("[1 build output lines omitted]\n", buffer.takeBatch().text)
+		}
+
+	@Test
+	fun `clear resets pending output and overflow accounting`() =
+		runTest {
+			val buffer = BuildOutputBuffer(maxPendingChars = 4, maxBatchChars = 64)
+
+			buffer.offer("kept")
+			buffer.offer("dropped")
+			buffer.clear()
+			buffer.offer("new")
+
+			assertEquals("new\n", buffer.takeBatch().text)
+		}
+
+	@Test
+	fun `in-flight batch keeps the session generation from its producer`() =
+		runTest {
+			val buffer = BuildOutputBuffer(maxPendingChars = 64, maxBatchChars = 64)
+
+			buffer.offer("old", sessionGeneration = 3)
+			val inFlight = buffer.takeBatch()
+			buffer.clear()
+			buffer.offer("new", sessionGeneration = 4)
+
+			assertEquals(3, inFlight.sessionGeneration)
+			assertEquals(4, buffer.takeBatch().sessionGeneration)
+		}
+
+	@Test
+	fun `repeated live batches refresh to the newest bounded editor tail`() {
+		val chunk = "x".repeat(200 * 1024)
+		val newest = "newest build output\n"
+		var session = ""
+		var visible = ""
+		var refreshCount = 0
+
+		for (batch in listOf(chunk, chunk, chunk + newest)) {
+			session += batch
+			visible =
+				if (BuildOutputViewModel.wouldExceedEditorWindow(visible.length, batch.length)) {
+					refreshCount++
+					session.takeLast(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS)
+				} else {
+					visible + batch
+				}
+		}
+
+		assertEquals(1, refreshCount)
+		assertTrue(visible.length <= BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS)
+		assertTrue(visible.endsWith(newest))
+	}
+
+	@Test
+	fun `filtered editor refreshes when hidden source output advances the window`() {
+		val oldMatch = "old match\n"
+		val hidden = "x".repeat(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS)
+		var session = oldMatch
+		var sourceChars = session.length
+		var visible = oldMatch
+
+		session += hidden
+		if (BuildOutputViewModel.wouldExceedEditorWindow(sourceChars, hidden.length)) {
+			val window = session.takeLast(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS)
+			visible =
+				BuildOutputViewModel.filterLines(
+					window,
+					query = "match",
+					showTimestamps = true,
+					showDeltas = true,
+				)
+			sourceChars = window.length
+		}
+
+		assertEquals("", visible)
+		assertEquals(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS, sourceChars)
+	}
+
+	@Test
+	fun `refreshed tail applies filtering and timing visibility`() {
+		val prefix = BuildOutputViewModel.formatLinePrefix(1_722_000_000_000L, 42L)
+		val tail = prefix + "ignored\n" + prefix + "newest output\n"
+
+		val visible =
+			BuildOutputViewModel.filterLines(
+				tail,
+				query = "newest",
+				showTimestamps = false,
+				showDeltas = false,
+			)
+
+		assertEquals("newest output\n", visible)
+	}
+}

--- a/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputBufferTest.kt
+++ b/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputBufferTest.kt
@@ -81,7 +81,8 @@ class BuildOutputBufferTest {
 			buffer.offer("four")
 
 			val batch = buffer.takeBatch()
-			assertThat(batch.text).isEqualTo("[2 build output lines omitted]\nthree\nfour\n")
+			assertThat(batch.text).isEqualTo("three\nfour\n")
+			assertThat(batch.omittedLines).isEqualTo(2)
 			assertThat(batch.sourceChars).isEqualTo(19)
 			assertThat(buffer.pendingChars).isAtMost(11)
 		}
@@ -94,7 +95,8 @@ class BuildOutputBufferTest {
 			buffer.offer("0123456789")
 
 			val batch = buffer.takeBatch()
-			assertThat(batch.text).isEqualTo("[1 build output line omitted]\n3456789\n")
+			assertThat(batch.text).isEqualTo("3456789\n")
+			assertThat(batch.omittedLines).isEqualTo(1)
 			assertThat(batch.sourceChars).isEqualTo(11)
 			assertThat(buffer.pendingChars).isEqualTo(0)
 		}
@@ -142,15 +144,20 @@ class BuildOutputBufferTest {
 		}
 
 	@Test
-	fun `append cache retains a smaller tail than the editor window`() =
+	fun `repeated appends retain the complete editor window in the bounded cache`() =
 		runTest {
 			val viewModel = BuildOutputViewModel(ApplicationProvider.getApplicationContext<Application>())
 			viewModel.clear()
-			val output = "x".repeat(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS - 1) + "\n"
-			assertThat(viewModel.append(output, viewModel.currentSessionToken)).isTrue()
-			assertThat(viewModel.getCachedContentSnapshot()).isEqualTo(output.takeLast(128 * 1024))
-			assertThat(viewModel.getWindowForEditor()).isEqualTo(output)
-			assertThat(viewModel.getFullContent()).isEqualTo(output)
+			val first = "a".repeat(384 * 1024)
+			val second = "b".repeat(256 * 1024)
+			val fullOutput = first + second
+			assertThat(viewModel.append(first, viewModel.currentSessionToken)).isTrue()
+			assertThat(viewModel.append(second, viewModel.currentSessionToken)).isTrue()
+			assertThat(viewModel.getCachedContentSnapshot())
+				.isEqualTo(fullOutput.takeLast(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS))
+			assertThat(viewModel.getWindowForEditor())
+				.isEqualTo(fullOutput.takeLast(BuildOutputViewModel.EDITOR_WINDOW_MAX_CHARS))
+			assertThat(viewModel.getFullContent()).isEqualTo(fullOutput)
 			viewModel.clear()
 		}
 

--- a/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputFragmentDetachedTest.kt
+++ b/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputFragmentDetachedTest.kt
@@ -25,13 +25,14 @@ import org.robolectric.RobolectricTestRunner
 /**
  * Regression test for ADFA-3472.
  *
- * [BuildOutputFragment.clearOutput] and [BuildOutputFragment.getShareableContent] touch
+ * [BuildOutputFragment.clearOutput], [BuildOutputFragment.getShareableContent], and
+ * [BuildOutputFragment.appendOutput] touch
  * `buildOutputViewModel`, which is created via `by activityViewModels()`. Forcing that lazy
  * delegate while the fragment is detached calls `requireActivity()`, which throws an
  * [IllegalStateException] ("not attached to an activity"). The run-tasks dialog / config-change
  * path can invoke these methods on a detached fragment, crashing the app (Sentry ADFA-3472).
  *
- * The fix guards both methods with `if (!isAdded || activity == null) return`. These tests
+ * The fix guards all three methods with `if (!isAdded || activity == null) return`. These tests
  * assert that a detached fragment does NOT crash and returns the safe no-op values.
  *
  * Mutation-mindset: on the pre-fix code (no guard), both calls force the activityViewModels
@@ -39,34 +40,43 @@ import org.robolectric.RobolectricTestRunner
  */
 @RunWith(RobolectricTestRunner::class)
 class BuildOutputFragmentDetachedTest {
+	/** Verifies clearOutput() is a safe no-op on a detached fragment instead of crashing. */
+	@Test
+	fun `clearOutput on a detached fragment does not crash`() {
+		// A freshly-constructed fragment that was never added to an activity is "detached":
+		// isAdded == false and activity == null, exactly the run-tasks / config-change state
+		// in which the Sentry crash was observed.
+		val fragment = BuildOutputFragment()
 
-  /** Verifies clearOutput() is a safe no-op on a detached fragment instead of crashing. */
-  @Test
-  fun `clearOutput on a detached fragment does not crash`() {
-    // A freshly-constructed fragment that was never added to an activity is "detached":
-    // isAdded == false and activity == null, exactly the run-tasks / config-change state
-    // in which the Sentry crash was observed.
-    val fragment = BuildOutputFragment()
+		assertThat(fragment.isAdded).isFalse()
 
-    assertThat(fragment.isAdded).isFalse()
+		// Pre-fix: this forces the `by activityViewModels()` delegate, which calls
+		// requireActivity() on a detached fragment and throws IllegalStateException.
+		// Post-fix: the guard returns early, no exception.
+		fragment.clearOutput()
+	}
 
-    // Pre-fix: this forces the `by activityViewModels()` delegate, which calls
-    // requireActivity() on a detached fragment and throws IllegalStateException.
-    // Post-fix: the guard returns early, no exception.
-    fragment.clearOutput()
-  }
+	/** Verifies getShareableContent() returns an empty string on a detached fragment instead of crashing. */
+	@Test
+	fun `getShareableContent on a detached fragment returns empty without crashing`() {
+		val fragment = BuildOutputFragment()
 
-  /** Verifies getShareableContent() returns an empty string on a detached fragment instead of crashing. */
-  @Test
-  fun `getShareableContent on a detached fragment returns empty without crashing`() {
-    val fragment = BuildOutputFragment()
+		assertThat(fragment.isAdded).isFalse()
 
-    assertThat(fragment.isAdded).isFalse()
+		// Pre-fix: forces the activityViewModels delegate -> requireActivity() -> ISE.
+		// Post-fix: guard returns "" without touching the view model.
+		val content = fragment.getShareableContent()
 
-    // Pre-fix: forces the activityViewModels delegate -> requireActivity() -> ISE.
-    // Post-fix: guard returns "" without touching the view model.
-    val content = fragment.getShareableContent()
+		assertThat(content).isEmpty()
+	}
 
-    assertThat(content).isEmpty()
-  }
+	/** Verifies appendOutput() is a safe no-op on a detached fragment instead of crashing. */
+	@Test
+	fun `appendOutput on a detached fragment does not crash`() {
+		val fragment = BuildOutputFragment()
+
+		assertThat(fragment.isAdded).isFalse()
+
+		fragment.appendOutput("build output")
+	}
 }

--- a/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputFragmentTest.kt
+++ b/app/src/test/java/com/itsaky/androidide/fragments/output/BuildOutputFragmentTest.kt
@@ -1,0 +1,87 @@
+/*
+ *  This file is part of AndroidIDE.
+ *
+ *  AndroidIDE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  AndroidIDE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.itsaky.androidide.fragments.output
+
+import android.view.View
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModelProvider
+import com.google.common.truth.Truth.assertThat
+import com.itsaky.androidide.R
+import com.itsaky.androidide.app.BaseApplication
+import com.itsaky.androidide.viewmodel.BuildOutputViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = BuildOutputFragmentTest.TestApp::class)
+class BuildOutputFragmentTest {
+	open class TestApp : BaseApplication()
+
+	private val testDispatcher = StandardTestDispatcher()
+
+	@Before
+	fun setUp() {
+		Dispatchers.setMain(testDispatcher)
+	}
+
+	@After
+	fun tearDown() {
+		Dispatchers.resetMain()
+	}
+
+	@Test
+	fun `offscreen batch times out without blocking later editor work`() =
+		runTest(testDispatcher) {
+			val controller = Robolectric.buildActivity(FragmentActivity::class.java)
+			controller.get().setTheme(R.style.Theme_AndroidIDE)
+			val activity = controller.setup().get()
+			try {
+				val fragment = BuildOutputFragment()
+				activity.supportFragmentManager
+					.beginTransaction()
+					.add(android.R.id.content, fragment)
+					.commitNow()
+				testDispatcher.scheduler.advanceUntilIdle()
+
+				val editor = checkNotNull(fragment.editor)
+				editor.visibility = View.GONE
+				editor.layout(0, 0, 0, 0)
+				val viewModel = ViewModelProvider(activity)[BuildOutputViewModel::class.java]
+				val sessionToken = viewModel.currentSessionToken
+
+				fragment.flushToEditor("first\n", 6, 0, sessionToken, 0)
+				fragment.flushToEditor("second\n", 7, 0, sessionToken, 0)
+
+				assertThat(editor.text.toString()).isEmpty()
+			} finally {
+				controller.destroy()
+			}
+		}
+}

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -687,6 +687,10 @@
 	<string name="msg_emptyview_diagnostics">Open a file to show its diagnostic results</string>
 	<string name="log_filter_hint">Filter lines</string>
 	<string name="msg_no_filter_matches">No matching log entries found.</string>
+	<plurals name="msg_build_output_lines_omitted">
+		<item quantity="one">[%1$d build output line omitted]</item>
+		<item quantity="other">[%1$d build output lines omitted]</item>
+	</plurals>
 	<string name="msg_no_search_matches">No search matches found.</string>
 	<string name="log_action_filter">Filter</string>
 	<string name="log_action_search">Search</string>


### PR DESCRIPTION
Large-project builds can make the editor UI stutter, freeze, and eventually restart with an `OutOfMemoryError`; the reporter reproduced it with Xed-Editor while the default Compose template remained stable. The latest stack trace anchors the allocation failure in `BuildOutputFragment.processLogs`, where an unlimited channel is drained into an unbounded `StringBuilder`. Although `BuildOutputViewModel` now stores output in a file and limits restored/cached content to a 512 KiB tail, the live editor still appends every processed line for the duration of a build. The fix must bound both pending batches and the live editor document without changing the build-service-to-fragment call path.

## Summary

Introduce a small production-consumed `BuildOutputBuffer` that accepts the fragment's incoming strings, emits size-limited batches in order, and enforces a fixed pending-output budget; when a producer burst exceeds that budget, coalesce the dropped count into one explicit omission marker rather than retaining an unlimited backlog. Update `BuildOutputFragment` to consume those bounded batches, keep the existing session-generation checks, and replace the live editor content with the filtered tail from `BuildOutputViewModel` whenever appending would exceed the editor window instead of allowing the Sora document to grow for the whole build. Move the editor-window limit into an internal `BuildOutputViewModel` contract used by both file-tail reads and the fragment so restore and live-stream behavior cannot diverge.

## Test plan

- A burst whose total size is below the pending and batch limits is emitted in original order, with missing trailing newlines normalized exactly once.
- Input larger than one batch is split across bounded batches without duplicating or reordering retained lines, and no emitted batch grows beyond the limit except for one indivisible oversized input line handled according to the documented cap policy.
- When producers exceed the pending-output budget, memory stays bounded and the next consumed output contains a single omission marker with the accumulated dropped-line count before normal ordered output resumes.
- Repeated live batches that cross the 512 KiB editor limit trigger a tail refresh; the visible document remains within the shared window limit and ends with the newest build output.
- Clearing for a new build resets queued output, overflow accounting, and visible-window accounting so stale lines or omission markers cannot enter the new session.
- Filtering and timestamp/delta visibility are applied to the refreshed tail just as they are to ordinary live batches, while the session file remains the source for the unfiltered retained output.

Fixes #1367
