### PR TITLE
ADFA-2602: Correct version references in plugin docs and metadata comments

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -519,7 +519,10 @@ class EditorBottomSheet
 
 		private val suppressedGradleWarnings =
 			listOf(
-				"The option setting 'android.aapt2FromMavenOverride=/data/data/com.itsaky.androidide/files/home/android-sdk/build-tools/35.0.0/aapt2' is experimental",
+				// Matched with contains(), so the build-tools version is deliberately left
+				// out: the path moves with Environment.BUILD_TOOLS_VERSION and a hardcoded
+				// version silently stops matching, resurfacing the warning to users.
+				"The option setting 'android.aapt2FromMavenOverride=",
 				"The org.gradle.api.plugins.BasePluginConvention type has been deprecated.",
 				"The org.gradle.api.plugins.Convention type has been deprecated.",
 				"The BasePluginExtension.archivesBaseName property has been deprecated.",

--- a/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
+++ b/app/src/main/java/com/itsaky/androidide/ui/EditorBottomSheet.kt
@@ -518,7 +518,10 @@ class EditorBottomSheet
 
 		private val suppressedGradleWarnings =
 			listOf(
-				"The option setting 'android.aapt2FromMavenOverride=/data/data/com.itsaky.androidide/files/home/android-sdk/build-tools/35.0.0/aapt2' is experimental",
+				// Matched with contains(), so the build-tools version is deliberately left
+				// out: the path moves with Environment.BUILD_TOOLS_VERSION and a hardcoded
+				// version silently stops matching, resurfacing the warning to users.
+				"The option setting 'android.aapt2FromMavenOverride=",
 				"The org.gradle.api.plugins.BasePluginConvention type has been deprecated.",
 				"The org.gradle.api.plugins.Convention type has been deprecated.",
 				"The BasePluginExtension.archivesBaseName property has been deprecated.",

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 kotlin {
 	compilerOptions {
 		// This module's classes ship in the plugin-api coordinate that on-device plugins
-		// compile against, so emit metadata the on-device Kotlin (1.9.22) can read (<= 2.0.0).
+		// compile against, so emit metadata every supported on-device Kotlin can read (<= 2.0.0).
 		apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
 		languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
 	}

--- a/common/src/main/java/com/itsaky/androidide/utils/Environment.java
+++ b/common/src/main/java/com/itsaky/androidide/utils/Environment.java
@@ -46,7 +46,7 @@ public final class Environment {
 	private static final String ANDROIDIDE_PROJECT_CACHE_DIR = SharedEnvironment.PROJECT_CACHE_DIR_NAME;
 	private static final String DATABASE_NAME = "documentation.db";
 
-	public static final String BUILD_TOOLS_VERSION = "35.0.0";
+	public static final String BUILD_TOOLS_VERSION = "36.0.0";
 
 	public static final String PLUGIN_API_JAR_RELATIVE_PATH = "libs/plugin-api.jar";
 

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -39,7 +39,7 @@ in `build.gradle.kts`:
 ```kotlin
 plugins {
     id("com.android.application") version "8.8.2"
-    id("org.jetbrains.kotlin.android") version "2.1.21"
+    id("org.jetbrains.kotlin.android") version "2.3.0"
     id("com.itsaky.androidide.plugins.build")
 }
 
@@ -66,21 +66,31 @@ against — the `:plugin-api` module plus `common`, `eventbus-events`, and
 `idetooltips`. The builder plugin applied above resolves the same way, from the
 injected `com.itsaky.androidide.plugins.build` `1.0.0` marker.
 
-#### Building on-device (offline) pins the AGP/Kotlin versions
+#### Building on-device (offline) pins the AGP/Kotlin/Gradle versions
 
-The `plugins {}` example above uses AGP `8.8.2` / Kotlin `2.1.21` — the versions the
-dev/CI repo resolves online. A plugin built **on-device** resolves AGP and the Kotlin
-Gradle plugin from the harvested on-device `localMvnRepository`, which currently ships
-only **AGP `8.13.1`** and **Kotlin `2.3.0`**. Request those versions for an on-device
-build, or offline resolution of the build plugins fails.
+The `plugins {}` example above uses AGP `8.8.2` / Kotlin `2.3.0` — the versions the
+dev/CI repo resolves online. A plugin built **on-device** resolves its build plugins from
+the harvested on-device `localMvnRepository`, which ships only the versions pinned in
+`org.adfa.constants` — `ANDROID_GRADLE_PLUGIN_VERSION`, `KOTLIN_VERSION` and
+`GRADLE_DISTRIBUTION_VERSION`, currently **AGP `9.3.1`**, **Kotlin `2.3.21`** and
+**Gradle `9.6.1`**. Request those, or offline resolution of the build plugins fails. That
+constants file is authoritative; the numbers here are a snapshot of it.
 
-Also declare AGP `apply false` in the **root** `build.gradle.kts` (as the standard CoGo
-project template does):
+AGP 9 compiles Kotlin itself and **refuses** the `org.jetbrains.kotlin.android` plugin, so
+an on-device build drops it and pins Kotlin through the `kotlin-gradle-plugin` jar on the
+**root** buildscript classpath, which is where AGP 9 takes its compiler from. Declare AGP
+`apply false` in the same root file (as the standard CoGo project template does):
 
 ```kotlin
+buildscript {
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.21")
+    }
+}
+
 plugins {
-    id("com.android.application") apply false version "8.13.1"
-    id("com.android.library") apply false version "8.13.1"
+    id("com.android.application") apply false version "9.3.1"
+    id("com.android.library") apply false version "9.3.1"
 }
 ```
 

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -71,7 +71,7 @@ injected `com.itsaky.androidide.plugins.build` `1.0.0` marker.
 The `plugins {}` example above uses AGP `8.8.2` / Kotlin `2.1.21` — the versions the
 dev/CI repo resolves online. A plugin built **on-device** resolves AGP and the Kotlin
 Gradle plugin from the harvested on-device `localMvnRepository`, which currently ships
-only **AGP `8.11.0`** and **Kotlin `1.9.22`**. Request those versions for an on-device
+only **AGP `8.13.1`** and **Kotlin `2.3.0`**. Request those versions for an on-device
 build, or offline resolution of the build plugins fails.
 
 Also declare AGP `apply false` in the **root** `build.gradle.kts` (as the standard CoGo
@@ -79,8 +79,8 @@ project template does):
 
 ```kotlin
 plugins {
-    id("com.android.application") apply false version "8.11.0"
-    id("com.android.library") apply false version "8.11.0"
+    id("com.android.application") apply false version "8.13.1"
+    id("com.android.library") apply false version "8.13.1"
 }
 ```
 

--- a/eventbus-events/build.gradle.kts
+++ b/eventbus-events/build.gradle.kts
@@ -29,7 +29,7 @@ android {
 kotlin {
 	compilerOptions {
 		// This module's classes ship in the plugin-api coordinate that on-device plugins
-		// compile against, so emit metadata the on-device Kotlin (1.9.22) can read (<= 2.0.0).
+		// compile against, so emit metadata every supported on-device Kotlin can read (<= 2.0.0).
 		apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
 		languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
 	}

--- a/gradle-plugin/src/main/java/com/itsaky/androidide/gradle/COTGSettingsPlugin.kt
+++ b/gradle-plugin/src/main/java/com/itsaky/androidide/gradle/COTGSettingsPlugin.kt
@@ -116,8 +116,13 @@ private fun RepositoryHandler.addMavenRepoIfMissing(
 	logger: Logger,
 	uri: URI,
 ) {
-	if (none { it is MavenArtifactRepository && it.url == uri }) {
-		logger.info("Adding maven repository: $uri")
-		maven { it.url = uri }
+	if (any { it is MavenArtifactRepository && it.url == uri }) {
+		return
 	}
+
+	logger.info("Adding maven repository: $uri")
+	val repo = maven { it.url = uri }
+
+	remove(repo)
+	add(0, repo)
 }

--- a/idetooltips/build.gradle.kts
+++ b/idetooltips/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 kotlin {
 	compilerOptions {
 		// This module's classes ship in the plugin-api coordinate that on-device plugins
-		// compile against, so emit metadata the on-device Kotlin (1.9.22) can read (<= 2.0.0).
+		// compile against, so emit metadata every supported on-device Kotlin can read (<= 2.0.0).
 		apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
 		languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
 	}

--- a/idetooltips/build.gradle.kts
+++ b/idetooltips/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 kotlin {
 	compilerOptions {
 		// This module's classes ship in the plugin-api coordinate that on-device plugins
-		// compile against, so emit metadata the on-device Kotlin (1.9.22) can read (<= 2.0.0).
+		// compile against, so emit metadata every supported on-device Kotlin can read (<= 2.0.0).
 		apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
 		languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
 	}

--- a/plugin-api/build.gradle.kts
+++ b/plugin-api/build.gradle.kts
@@ -22,7 +22,8 @@ android {
 kotlin {
 	compilerOptions {
 		jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-		// Emit metadata the on-device Kotlin compiler (1.9.22) can read (<= 2.0.0).
+		// Emit metadata every supported on-device Kotlin compiler can read (<= 2.0.0), so a
+		// device still on an older bundled toolchain keeps working after a KOTLIN_VERSION bump.
 		// This jar ships in the plugin-api coordinate on-device plugins compile against.
 		apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
 		languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)


### PR DESCRIPTION
PLUGIN_AUTHORING.md told plugin authors to request AGP 8.11.0 and Kotlin
1.9.22 for an on-device build. The harvested localMvnRepository now ships
AGP 9.3.1 and Kotlin 2.3.21, so those instructions produced an
unresolvable build.

The apiVersion/languageVersion pins in common, eventbus-events,
idetooltips and plugin-api stay at 2.0. Their comments named 1.9.22 as the
reason, which no longer holds; the real invariant is that the jar must stay
readable by every supported on-device compiler, including a device still on
an older bundled toolchain after a KOTLIN_VERSION bump. Reworded to say
that instead of naming a version that will keep going stale.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>