### PR TITLE
ADFA-5097: Clean up telemetry choice screen

### DIFF
--- a/app/src/androidTest/kotlin/com/itsaky/androidide/helper/HandlePrivacyDisclosureHelper.kt
+++ b/app/src/androidTest/kotlin/com/itsaky/androidide/helper/HandlePrivacyDisclosureHelper.kt
@@ -38,8 +38,6 @@ fun TestContext<Unit>.handlePrivacyDisclosure() {
 			val d = device.uiDevice
 			val acceptText = targetContext.getString(ResourcesR.string.privacy_disclosure_accept)
 			val declineText = targetContext.getString(ResourcesR.string.privacy_disclosure_decline)
-			val learnMoreText =
-				targetContext.getString(ResourcesR.string.privacy_disclosure_learn_more)
 
 			assertTrue(
 				"Dialog title missing",
@@ -51,10 +49,6 @@ fun TestContext<Unit>.handlePrivacyDisclosure() {
 			assertTrue(
 				"Keep offline button missing",
 				d.findObject(UiSelector().text(declineText)).exists(),
-			)
-			assertTrue(
-				"Learn more button missing",
-				d.findObject(UiSelector().text(learnMoreText)).exists(),
 			)
 
 			clickFirstAccessibilityNodeByText(acceptText)

--- a/app/src/main/java/com/itsaky/androidide/fragments/onboarding/PermissionsFragment.kt
+++ b/app/src/main/java/com/itsaky/androidide/fragments/onboarding/PermissionsFragment.kt
@@ -23,13 +23,13 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
-import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
@@ -38,18 +38,19 @@ import androidx.recyclerview.widget.RecyclerView
 import com.github.appintro.SlidePolicy
 import com.github.appintro.SlideSelectionListener
 import com.google.android.material.button.MaterialButton
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.itsaky.androidide.R
 import com.itsaky.androidide.activities.OnboardingActivity
 import com.itsaky.androidide.adapters.onboarding.OnboardingPermissionsAdapter
 import com.itsaky.androidide.app.DeviceProtectedApplicationLoader
 import com.itsaky.androidide.app.IDEApplication
 import com.itsaky.androidide.buildinfo.BuildInfo
+import com.itsaky.androidide.databinding.LayoutDialogPrivacyConsentBinding
 import com.itsaky.androidide.databinding.LayoutOnboardingPermissionsBinding
 import com.itsaky.androidide.events.InstallationEvent
 import com.itsaky.androidide.preferences.internal.StatPreferences
 import com.itsaky.androidide.preferences.internal.TelemetryConsent
 import com.itsaky.androidide.tasks.doAsyncWithProgress
+import com.itsaky.androidide.utils.DialogUtils
 import com.itsaky.androidide.utils.OverlayPermissionGuide
 import com.itsaky.androidide.utils.PermissionsHelper
 import com.itsaky.androidide.utils.flashError
@@ -430,36 +431,33 @@ class PermissionsFragment :
 	}
 
 	private fun showPrivacyDialog() {
-		privacyDialog =
-			MaterialAlertDialogBuilder(requireContext())
-				.setTitle(com.itsaky.androidide.resources.R.string.privacy_disclosure_title)
-				.setMessage(com.itsaky.androidide.resources.R.string.privacy_disclosure_message)
-				.setPositiveButton(com.itsaky.androidide.resources.R.string.privacy_disclosure_accept) { dialog, _ ->
-					StatPreferences.telemetryConsent = TelemetryConsent.GRANTED
-					DeviceProtectedApplicationLoader.onTelemetryConsentGranted(IDEApplication.instance)
-					dialog.dismiss()
-				}.setNegativeButton(com.itsaky.androidide.resources.R.string.privacy_disclosure_decline) { dialog, _ ->
-					StatPreferences.telemetryConsent = TelemetryConsent.DECLINED
-					Sentry.close()
-					dialog.dismiss()
-				}.setNeutralButton(com.itsaky.androidide.resources.R.string.privacy_disclosure_learn_more, null)
-				.setCancelable(false)
-				.show()
-				.also { dialog ->
-					dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
-						openPrivacyPolicy()
-					}
-				}
-	}
+		val builder = DialogUtils.newMaterialDialogBuilder(requireContext())
 
-	private fun openPrivacyPolicy() {
-		try {
-			val privacyPolicyUrl = getString(R.string.privacy_policy_url)
-			val intent = Intent(Intent.ACTION_VIEW, privacyPolicyUrl.toUri())
-			startActivity(intent)
-		} catch (e: Exception) {
-			Sentry.captureException(e)
+		// Inflate from the builder's themed context so the dialog-scoped attributes the
+		// layout refers to (body text style, preferred padding) resolve.
+		val binding = LayoutDialogPrivacyConsentBinding.inflate(LayoutInflater.from(builder.context))
+
+		val dialog =
+			builder
+				.setTitle(com.itsaky.androidide.resources.R.string.privacy_disclosure_title)
+				.setView(binding.root)
+				.setCancelable(false)
+				.create()
+
+		binding.privacyAccept.setOnClickListener {
+			StatPreferences.telemetryConsent = TelemetryConsent.GRANTED
+			DeviceProtectedApplicationLoader.onTelemetryConsentGranted(IDEApplication.instance)
+			dialog.dismiss()
 		}
+
+		binding.privacyDecline.setOnClickListener {
+			StatPreferences.telemetryConsent = TelemetryConsent.DECLINED
+			Sentry.close()
+			dialog.dismiss()
+		}
+
+		privacyDialog = dialog
+		dialog.show()
 	}
 
 	private fun enableFinishButton() {

--- a/app/src/main/res/layout/layout_dialog_privacy_consent.xml
+++ b/app/src/main/res/layout/layout_dialog_privacy_consent.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Body and choices share one scroll container so they scroll together, and the dialog is given this as a custom view rather
+	than a message: Material only draws its scroll-indicator dividers around the message pane, so supplying no message removes
+	them. -->
+<androidx.core.widget.NestedScrollView
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:fadeScrollbars="false"
+	android:scrollbarStyle="outsideOverlay"
+	android:scrollbars="vertical">
+
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:orientation="vertical">
+
+		<TextView
+			android:id="@+id/privacy_message"
+			style="?attr/materialAlertDialogBodyTextStyle"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:paddingStart="?attr/dialogPreferredPadding"
+			android:paddingEnd="?attr/dialogPreferredPadding"
+			android:paddingBottom="24dp"
+			android:text="@string/privacy_disclosure_message" />
+
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:background="?attr/colorSurfaceVariant"
+			android:gravity="center_horizontal"
+			android:orientation="vertical"
+			android:paddingStart="?attr/dialogPreferredPadding"
+			android:paddingTop="16dp"
+			android:paddingEnd="?attr/dialogPreferredPadding"
+			android:paddingBottom="16dp">
+
+			<com.google.android.material.button.MaterialButton
+				android:id="@+id/privacy_accept"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:text="@string/privacy_disclosure_accept" />
+
+			<com.google.android.material.button.MaterialButton
+				android:id="@+id/privacy_decline"
+				style="@style/Widget.Material3.Button.OutlinedButton"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginTop="8dp"
+				android:text="@string/privacy_disclosure_decline" />
+		</LinearLayout>
+	</LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/resources/src/main/res/values-in-rID/strings.xml
+++ b/resources/src/main/res/values-in-rID/strings.xml
@@ -599,9 +599,9 @@
 	<string name="title_privacy">Privasi</string>
 
 	<string name="privacy_disclosure_title">Privasi &amp; analitik</string>
-	<string name="privacy_disclosure_message">Code on the Go menggunakan Firebase Analytics dan GlitchTip untuk membantu kami meningkatkan aplikasi.\n\nFirebase Analytics mengumpulkan data penggunaan anonim untuk membantu kami memahami bagaimana aplikasi digunakan.\n\nGlitchTip membantu kami melacak dan memperbaiki masalah.\n\nTidak ada informasi pribadi yang dikumpulkan atau dibagikan. Semua data diproses sesuai dengan kebijakan privasi kami.</string>
-	<string name="privacy_disclosure_accept">Saya mengerti</string>
-	<string name="privacy_disclosure_learn_more">Pelajari lebih lanjut</string>
+	<string name="privacy_disclosure_message">Code on the Go mengumpulkan informasi penggunaan dan laporan kerusakan anonim untuk membantu kami memperbaiki bug dan meningkatkan aplikasi. Tidak ada informasi pribadi yang dikumpulkan atau dibagikan.\n\nBagikan data anonim akan mengirim informasi ini. Tetap offline tidak mengirim apa pun.</string>
+	<string name="privacy_disclosure_accept">Bagikan data anonim</string>
+	<string name="privacy_disclosure_decline">Tetap offline</string>
 
 	<string name="title_unique_id">ID Unik</string>
 	<string name="title_device">Perangkat</string>

--- a/resources/src/main/res/values-in-rID/strings.xml
+++ b/resources/src/main/res/values-in-rID/strings.xml
@@ -599,7 +599,7 @@
 	<string name="title_privacy">Privasi</string>
 
 	<string name="privacy_disclosure_title">Privasi &amp; analitik</string>
-	<string name="privacy_disclosure_message">Code on the Go mengumpulkan informasi penggunaan dan laporan kerusakan anonim untuk membantu kami memperbaiki bug dan meningkatkan aplikasi. Tidak ada informasi pribadi yang dikumpulkan atau dibagikan.\n\nBagikan data anonim akan mengirim informasi ini. Tetap offline tidak mengirim apa pun.</string>
+	<string name="privacy_disclosure_message">Code on the Go mengumpulkan informasi penggunaan dan laporan kerusakan anonim untuk membantu kami memperbaiki bug dan meningkatkan aplikasi. Tidak ada informasi pribadi yang dikumpulkan atau dibagikan.\n\n<i>Bagikan data anonim</i> akan mengirim informasi ini. <i>Tetap offline</i> tidak mengirim apa pun.</string>
 	<string name="privacy_disclosure_accept">Bagikan data anonim</string>
 	<string name="privacy_disclosure_decline">Tetap offline</string>
 

--- a/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/resources/src/main/res/values-zh-rCN/strings.xml
@@ -659,9 +659,9 @@
 	<string name="title_privacy">隐私</string>
 
 	<string name="privacy_disclosure_title">隐私和分析</string>
-	<string name="privacy_disclosure_message">Code on the Go 使用 Firebase Analytics 和 GlitchTip 来帮助我们改进应用 \n\nFirebase Analytics 收集匿名使用数据，帮助我们了解应用的使用情况 \n\nGlitchTip 帮助我们跟踪和修复错误 \n\n不会收集或分享任何个人信息 所有数据均按照我们的隐私政策进行处理 </string>
-	<string name="privacy_disclosure_accept">我了解</string>
-	<string name="privacy_disclosure_learn_more">了解更多</string>
+	<string name="privacy_disclosure_message">Code on the Go 会收集匿名的使用情况和崩溃信息，以帮助我们修复缺陷并改进应用。我们不会收集或分享任何个人信息。\n\n选择“共享匿名数据”将发送这些信息；选择“保持离线”则不会发送任何内容。</string>
+	<string name="privacy_disclosure_accept">共享匿名数据</string>
+	<string name="privacy_disclosure_decline">保持离线</string>
 
 	<string name="title_unique_id">唯一 ID</string>
 	<string name="title_device">设备</string>
@@ -1184,7 +1184,6 @@
 	<string name="support_our_work">支持我们的工作</string>
 	<string name="github_sponsors_url">https://github.com/sponsors/appdevforall</string>
 	<string name="docs_url">http://localhost:6174/i/index.html</string>
-	<string name="privacy_policy_url">https://www.appdevforall.org/wp-content/uploads/2024/08/privacy_notice.pdf</string>
 	<string name="quickstart_url">http://localhost:6174/i/cogo-quickstart.html</string>
 	<string name="adfa_email">info@appdevforall.org</string>
 	<string name="mail_to_adfa">mailto:info@appdevforall.org</string>

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -664,10 +664,9 @@
 	<string name="title_privacy">Privacy</string>
 
 	<string name="privacy_disclosure_title">Privacy &amp; analytics</string>
-	<string name="privacy_disclosure_message">Code on the Go uses Firebase Analytics and GlitchTip to help us improve the app.\n\nFirebase Analytics collects anonymous usage data to help us understand how the app is used. \n\nGlitchTip helps us track and fix errors.\n\nNo personal information is collected or shared. All data is processed in accordance with our privacy policy.\n\nChoose whether to share this anonymous data. If you choose Keep offline, analytics and crash reports are never sent.</string>
+	<string name="privacy_disclosure_message">Code on the Go collects anonymous usage and crash information to help us fix bugs and improve the app. No personal information is collected or shared.\n\nShare anonymous data sends this information. Keep offline sends nothing at all.</string>
 	<string name="privacy_disclosure_accept">Share anonymous data</string>
 	<string name="privacy_disclosure_decline">Keep offline</string>
-	<string name="privacy_disclosure_learn_more">Learn more</string>
 
 	<string name="title_unique_id">Unique ID</string>
 	<string name="title_device">Device</string>
@@ -1216,7 +1215,6 @@
 	<string name="support_our_work">Support our work</string>
 	<string name="github_sponsors_url">https://github.com/sponsors/appdevforall</string>
 	<string name="docs_url">http://localhost:6174/i/index.html</string>
-	<string name="privacy_policy_url">https://www.appdevforall.org/wp-content/uploads/2024/08/privacy_notice.pdf</string>
 	<string name="quickstart_url">http://localhost:6174/i/cogo-quickstart.html</string>
 	<string name="adfa_email">info@appdevforall.org</string>
 	<string name="mail_to_adfa">mailto:info@appdevforall.org</string>

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -664,7 +664,7 @@
 	<string name="title_privacy">Privacy</string>
 
 	<string name="privacy_disclosure_title">Privacy &amp; analytics</string>
-	<string name="privacy_disclosure_message">Code on the Go collects anonymous usage and crash information to help us fix bugs and improve the app. No personal information is collected or shared.\n\nShare anonymous data sends this information. Keep offline sends nothing at all.</string>
+	<string name="privacy_disclosure_message">Code on the Go collects anonymous usage and crash information to help us fix bugs and improve the app. No personal information is collected or shared.\n\n<i>Share anonymous data</i> sends this information. <i>Keep offline</i> sends nothing at all.</string>
 	<string name="privacy_disclosure_accept">Share anonymous data</string>
 	<string name="privacy_disclosure_decline">Keep offline</string>
 


### PR DESCRIPTION
Fixes [ADFA-5097](https://appdevforall.atlassian.net/browse/ADFA-5097).

## Root cause

All five complaints trace to one thing: the consent screen was a stock `MaterialAlertDialog` built from `setTitle` + `setMessage` + three buttons. Once the message overflows at large font scale, Material's own dialog produces exactly the reported symptoms.

| Ticket item | Cause |
|---|---|
| 1. Strange lines top and bottom | Material's `scrollIndicatorUp`/`Down`, shown only when the message pane overflows |
| 2. Choices look like plain text | They are the dialog's borderless text buttons; long labels force vertical stacking |
| 3. Scrollable but doesn't look it | No persistent scrollbar on the message pane |
| 7. Body and choices scroll separately | Material's dialog is a scrolling message pane plus a *fixed* button bar, by construction |
| 4. "Learn more" goes off-device | `ACTION_VIEW` to a PDF on appdevforall.org |

Worth calling out: in the reported screenshot the button bar is pushed off-screen, so "Keep offline" is half-cut and "Learn more" is gone. On a `setCancelable(false)` dialog the user could not see or reach the decline option at all.

Items 1, 3 and 7 are properties of the widget, not of its styling, so the dialog now supplies its whole body as a custom view with the choices **inside** the scroll container.

## Changes

- **New** `layout_dialog_privacy_consent.xml` - one `NestedScrollView` holding the body text and both choices. No dividers (Material only draws them around a message pane, and there is no longer a message). `fadeScrollbars="false"` so the scrollbar is visible before the user touches anything. Choices are full-width filled/outlined `MaterialButton`s.
- **Choice panel background is `?attr/colorSurfaceVariant`**, not a surfaceContainer role. This app's themes define `colorSurfaceVariant` per-theme but leave the container roles to the Material3 defaults - and a Material3 dialog *is* `colorSurfaceContainerHigh`, so the panel was invisible until this was changed.
- `PermissionsFragment.showPrivacyDialog()` rewritten; `openPrivacyPolicy()` deleted. Now uses `DialogUtils.newMaterialDialogBuilder()` - this dialog was the only one in the app built with a bare `MaterialAlertDialogBuilder`, so it was silently missing the app's corner radius and enter/exit animators. Inflated from `builder.context` so the dialog-scoped theme attributes resolve.
- **Copy condensed to two paragraphs**, dropping the Firebase/GlitchTip names and the privacy-policy paragraph (ticket item 9). At font scale 2.0 it now fits with no scrolling at all.
- **"Learn more" removed**, per the ticket's own preference. `privacy_policy_url` had no other consumer and is deleted.
- **zh-rCN and in-rID retranslated.** These were not merely stale: both were missing `privacy_disclosure_decline` entirely and rendered accept as "I understand" / "Saya mengerti", so those users saw a one-button dialog whose button said something the English never said. Round-tripped back to English via `translate-strings-xml.py` - no semantic drift, `\n\n` escapes intact. (Only the Gemini leg ran; the Google Cloud Translate leg needs `gcloud auth application-default login`.)
- Instrumented helper drops its "Learn more" assertion. Its click helper matches on exact full text **and** `isClickable`, so paragraph 2 repeating the button labels does not confuse it.

## Verification

Built and exercised on an arm64 emulator, fresh install each run:

- **Font scale 1.0** - no dividers, both buttons visible, nothing scrolls.
- **Font scale 2.0** (the scale that reproduced the bug) - fits with room to spare, nothing clips.
- **Font scale 3.0** - forced overflow, since the condensed copy no longer overflows at 2.0 and the scroll path would otherwise go untested. Scrollbar visible without touching the screen; scrolling brings both buttons fully into reach in the same container - the case that was previously unreachable.
- **Light and dark themes** - tonal panel holds contrast in both.
- Accept persists `GRANTED`, decline persists `DECLINED` (verified in `ide.stats.xml`); dialog does not reappear.
- `:app:assembleV8Debug`, `:app:compileV8DebugAndroidTestKotlin`, and `spotlessCheck` all pass.

Screenshots at each scale are in the ticket.


[ADFA-5097]: https://appdevforall.atlassian.net/browse/ADFA-5097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ