### PR TITLE
ADFA-5156: Roll back R8 shrinking to unbreak plugins

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -193,6 +193,17 @@
 -keep class io.sentry.** { *; }
 -dontwarn io.sentry.**
 
+# ADFA-5156: TEMPORARY ROLLBACK of the R8 shrinking re-enabled in ADFA-3604.
+# Plugins load parent-first through a stock DexClassLoader, so they resolve
+# kotlin.** from the app's dex rather than their own bundled stdlib. R8 cannot
+# see plugin call sites, so it strips every stdlib member the IDE itself does
+# not call and plugins die with NoSuchMethodError at runtime (Sketch to UI:
+# ArraysKt.maxOrNull([F)). With -dontobfuscate and -dontoptimize already set,
+# this restores R8 to a pass-through and returns the release build to the
+# configuration shipped before ADFA-3604. Revert once ADFA-5156 lands a
+# targeted fix (keep rules for kotlin.**/kotlinx.coroutines.**).
+-dontshrink
+
 ## Plugin SPI
 ## Plugins are loaded dynamically via DexClassLoader, so R8 cannot see their
 ## implementations of these interfaces. Without these rules, R8 narrows the

--- a/scripts/r8-plugin-impact/README.md
+++ b/scripts/r8-plugin-impact/README.md
@@ -35,7 +35,7 @@ Nothing here has third-party dependencies; the Python is stdlib-only.
 
 # 3. Compare
 uv run --no-project analyze-plugin-impact.py impact \
-    out/reference/full-dump.txt out/candidate/full-dump.txt out/plugins
+	out/reference/full-dump.txt out/candidate/full-dump.txt out/plugins
 ```
 
 To pull the reference APK off a device:

--- a/scripts/r8-plugin-impact/README.md
+++ b/scripts/r8-plugin-impact/README.md
@@ -96,20 +96,40 @@ during the *plugin's* own dexing. They show as `CLASS_ABSENT` and always will;
 they are leaf synthetics with no host counterpart, so they carry no split-brain
 risk.
 
+## Which plugin set to measure
+
+Use the artifact from the last successful **"Update libs from CodeOnTheGo"**
+(`update-libs.yml`) run in the `plugin-examples` repo. That workflow is the only
+one that deploys — it rebuilds every plugin and `scp`s the `.cgp` files to
+`public_html/flags/plugins`, so its artifact is exactly what users have
+installed. `build-plugins.yml` produces CI artifacts only and never deploys.
+
+```bash
+gh run list --workflow=update-libs.yml --limit 5     # find the last success
+gh run download <run-id> -n plugins-cgp -D deployed
+```
+
+Do not measure an ad-hoc local folder of `.cgp` files. Plugin filenames have
+been renamed over time (`templatemanagerplugin` -> `template-manager`,
+`IconsRepository-Plugin` -> `icons-repository`, and others), so a stale local
+copy can silently omit plugins and carry names that no longer exist. Cross-check
+against the workflow's own mapping if in doubt.
+
 ## Baseline from ADFA-5156
 
-Measured 2026-08-15 across 24 plugins, 3,991 call sites, comparing the shipped
+Measured 2026-08-15 against the deployed plugin set (`update-libs.yml` run
+31626494060, 2026-08-12) — 26 plugins, 4,261 call sites — comparing the shipped
 R8-shrunk release against the `-dontshrink` rollback:
 
 | | shipped (shrinking on) | rolled back |
 |---|---:|---:|
-| resolves cleanly | 2,630 | 3,831 |
-| guaranteed `NoSuchMethodError` | 74 (66 real + 8 false positives) | 8 (all false positives) |
-| falls through to plugin dex | 1,287 | 152 (3 D8 synthetics) |
+| resolves cleanly | 2,828 | 4,101 |
+| guaranteed `NoSuchMethodError` | 75 (67 real + 8 false positives) | 8 (all false positives) |
+| falls through to plugin dex | 1,358 | 152 (3 D8 synthetics) |
 
 Zero regressions. Ten plugins carried guaranteed-failure call sites in the
 shipped build: compose-preview 36, sketch-to-ui 20, client-time-tracker 5,
-random-xkcd 5, markdown-previewer 2, project-to-template 2, and ai-assistant /
+random-xkcd 5, ai-assistant 2, markdown-previewer 2, project-to-template 2, and
 ai-literacy-course / keystore-generator / layout-editor 1 each.
 
 **A re-enabled-shrinking build should be measured against these numbers.** The

--- a/scripts/r8-plugin-impact/README.md
+++ b/scripts/r8-plugin-impact/README.md
@@ -1,0 +1,117 @@
+# R8 plugin-impact analysis (ADFA-5156)
+
+**What this is:** tooling to prove whether a release build of the IDE strips
+Kotlin stdlib members that plugins need at runtime.
+
+**Why it exists:** plugins are loaded *parent-first* through a stock
+`DexClassLoader` (`PluginLoader.kt:92-116`, parent passed at
+`PluginManager.kt:603`), so every `kotlin.**` class a plugin references resolves
+from **the IDE's dex**, not from the ~1058 stdlib classes the plugin bundles.
+R8 cannot see plugin call sites, so it strips every stdlib member the IDE itself
+does not call. The net effect is that **a plugin can only call the subset of the
+Kotlin standard library that the IDE also calls**; anything else throws
+`NoSuchMethodError` at runtime.
+
+That failure is invisible at build time. `assemblePlugin` is green, the manifest
+is fine, the `.cgp` is correct. Only on-device execution of the specific code
+path reveals it — which is why this tooling exists.
+
+ADFA-5156 rolled R8 shrinking back (restored `-dontshrink` in
+`app/proguard-rules.pro`) as a stopgap. **Any future attempt to re-enable
+shrinking must be validated with these scripts before shipping.**
+
+## Usage
+
+Nothing here has third-party dependencies; the Python is stdlib-only.
+
+```bash
+# 1. Dump a release APK's dex (do this for the build you want to check,
+#    and for a reference build to compare against)
+./dex-dump.sh /path/to/CodeOnTheGo-v8-release.apk out/candidate
+./dex-dump.sh /path/to/previous-release.apk        out/reference
+
+# 2. Dump every plugin's dex (.cgp files are zips)
+./dex-dump.sh --disassemble /path/to/plugins/*.cgp out/plugins
+
+# 3. Compare
+uv run --no-project analyze-plugin-impact.py impact \
+    out/reference/full-dump.txt out/candidate/full-dump.txt out/plugins
+```
+
+To pull the reference APK off a device:
+
+```bash
+adb shell pm path com.itsaky.androidide            # -> /data/app/.../base.apk
+adb pull <that path> baseline.apk
+```
+
+## Reading the output
+
+Each `kotlin.*`/`kotlinx.*` call site originating in a plugin's own code is
+classified by walking the superclass/interface chain in the host dex:
+
+| verdict | meaning |
+|---|---|
+| `ok` | class present in the IDE dex, method found in its hierarchy |
+| `NoSuchMethod` | class present but method absent. **Guaranteed runtime failure.** This is the ADFA-5156 bug |
+| `CLASS_ABSENT` | class missing from the IDE dex entirely, so the plugin's own bundled copy loads instead |
+
+Calls originating *inside* a plugin's bundled stdlib copy are excluded — that
+copy is shadowed at runtime, so they are not real call sites.
+
+`CLASS_ABSENT` is not automatically a bug. It is how a plugin's own copy gets
+used, and it is fine when the whole subtree is absent. It is dangerous when a
+class is absent but its **supertype is present-and-stripped** in the host: the
+chain jumps back into the host and dies. That is exactly the confusing shape in
+the original report (`ArraysKt` facade dropped, so it loaded from the plugin's
+`classes2.dex`, but its superclass `ArraysKt___ArraysKt` resolved parent-first
+back into the IDE's stripped copy). Use `explain-absent` to inspect.
+
+## Known false positives — read before acting on results
+
+**Methods inherited from the Android boot classpath are reported as
+`NoSuchMethod`.** `java.util.*`, `java.lang.*` and friends are not in the APK,
+so the hierarchy walk runs off the end of what it can see and gives up. Known
+instances, all benign:
+
+- `AbstractMutableSet.addAll` / `containsAll` / `removeAll` / `retainAll` -> `java.util.AbstractSet`
+- `AbstractMutableMap.putAll` -> `java.util.AbstractMap`
+- `IntIterator.hasNext` / `LongIterator.hasNext` -> `java.util.Iterator`
+- `ArrayDeque.iterator` -> `java.util.AbstractList`
+
+Before treating any `NoSuchMethod` as real, run `explain-method` on it and check
+whether the chain exits the APK at a `java.*` link. If it does, it is a false
+positive.
+
+**Kotlin multifile facades declare nothing themselves.** `ArraysKt`,
+`StringsKt`, `CollectionsKt` etc. extend a part class (`ArraysKt___ArraysKt`,
+`StringsKt__StringsKt` — note the varying underscore counts) which holds the
+actual members. Checking a facade directly for a method always fails. The
+hierarchy walk handles this; ad-hoc greps do not.
+
+**D8 build-time synthetics never exist in the host.** Classes like
+`kotlin.UByte$$ExternalSyntheticBackport0` and
+`kotlin.io.path.PathTreeWalk$$ExternalSyntheticApiModelOutline0` are generated
+during the *plugin's* own dexing. They show as `CLASS_ABSENT` and always will;
+they are leaf synthetics with no host counterpart, so they carry no split-brain
+risk.
+
+## Baseline from ADFA-5156
+
+Measured 2026-08-15 across 24 plugins, 3,991 call sites, comparing the shipped
+R8-shrunk release against the `-dontshrink` rollback:
+
+| | shipped (shrinking on) | rolled back |
+|---|---:|---:|
+| resolves cleanly | 2,630 | 3,831 |
+| guaranteed `NoSuchMethodError` | 74 (66 real + 8 false positives) | 8 (all false positives) |
+| falls through to plugin dex | 1,287 | 152 (3 D8 synthetics) |
+
+Zero regressions. Ten plugins carried guaranteed-failure call sites in the
+shipped build: compose-preview 36, sketch-to-ui 20, client-time-tracker 5,
+random-xkcd 5, markdown-previewer 2, project-to-template 2, and ai-assistant /
+ai-literacy-course / keystore-generator / layout-editor 1 each.
+
+**A re-enabled-shrinking build should be measured against these numbers.** The
+target is 0 real `NoSuchMethod` across all plugins, not just the one that
+happened to get reported.

--- a/scripts/r8-plugin-impact/analyze-plugin-impact.py
+++ b/scripts/r8-plugin-impact/analyze-plugin-impact.py
@@ -1,0 +1,301 @@
+"""ADFA-5156 / R8 plugin-impact analysis. See README.md in this directory.
+
+Plugins load parent-first through a stock DexClassLoader, so every kotlin.**
+class a plugin references resolves from the IDE's dex, not from the stdlib the
+plugin bundles. R8 cannot see plugin call sites, so it strips every stdlib
+member the IDE itself does not call, and plugins die with NoSuchMethodError at
+runtime. This tool simulates that resolution so the breakage can be measured
+from a build artifact instead of discovered on a device.
+
+Run this before shipping any release build that re-enables R8 shrinking.
+
+  uv run --no-project analyze-plugin-impact.py impact <ref-dump> <cand-dump> <plugindir>
+  uv run --no-project analyze-plugin-impact.py explain-method <dump> <class> <method>
+  uv run --no-project analyze-plugin-impact.py explain-absent <dump> <plugindir>
+
+Dumps come from dex-dump.sh. IMPORTANT: read the "Known false positives"
+section of README.md before acting on any NoSuchMethod result -- methods
+inherited from the Android boot classpath are reported as missing because
+java.util.* is not in the APK.
+"""
+
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+CLS_RE = re.compile(r"^  Class descriptor  : '([^']+)'")
+SUPER_RE = re.compile(r"^  Superclass        : '([^']+)'")
+IFACE_RE = re.compile(r"^    #\d+              : '([^']+)'")
+NAME_RE = re.compile(r"^      name          : '([^']*)'")
+TYPE_RE = re.compile(r"^      type          : '([^']*)'")
+SECTION_RE = re.compile(
+    r"^  (Direct methods|Virtual methods|Static fields|Instance fields|Interfaces)"
+)
+INVOKE_RE = re.compile(r"invoke-[a-z/-]+ \{[^}]*\}, (L[^;]+;)\.([^:]+):(\([^)]*\)\S*)")
+
+STDLIB_PREFIXES = ("Lkotlin/", "Lkotlinx/")
+
+OK = "OK"
+NO_METHOD = "NO_METHOD"
+CLASS_ABSENT = "CLASS_ABSENT"
+
+
+def parse_host(dump_path):
+    """Index a host (IDE) dex dump.
+
+    Returns {class: {'super': str|None, 'ifaces': [str], 'methods': {'name:sig'}}}
+    """
+    idx = {}
+    cur = None
+    in_ifaces = False
+    pending = None
+    with open(dump_path, "r", errors="replace") as fh:
+        for line in fh:
+            m = CLS_RE.match(line)
+            if m:
+                cur = {"super": None, "ifaces": [], "methods": set()}
+                idx[m.group(1)] = cur
+                in_ifaces = False
+                pending = None
+                continue
+            if cur is None:
+                continue
+            m = SUPER_RE.match(line)
+            if m:
+                cur["super"] = m.group(1)
+                continue
+            m = SECTION_RE.match(line)
+            if m:
+                # Interface entries look like method index lines, so track the
+                # section to tell them apart.
+                in_ifaces = m.group(1) == "Interfaces"
+                continue
+            if in_ifaces:
+                m = IFACE_RE.match(line)
+                if m:
+                    cur["ifaces"].append(m.group(1))
+                continue
+            m = NAME_RE.match(line)
+            if m:
+                pending = m.group(1)
+                continue
+            m = TYPE_RE.match(line)
+            if m and pending is not None:
+                cur["methods"].add(pending + ":" + m.group(1))
+                pending = None
+    return idx
+
+
+def resolve(idx, cls, name, sig):
+    """Walk cls -> superclasses -> interfaces looking for name:sig.
+
+    Returns OK, NO_METHOD, or CLASS_ABSENT. NO_METHOD can be a false positive
+    when the real declaration lives on the Android boot classpath; see README.
+    """
+    if cls not in idx:
+        return CLASS_ABSENT
+    key = name + ":" + sig
+    seen, stack = set(), [cls]
+    while stack:
+        c = stack.pop()
+        if c in seen or c not in idx:
+            continue
+        seen.add(c)
+        e = idx[c]
+        if key in e["methods"]:
+            return OK
+        if e["super"]:
+            stack.append(e["super"])
+        stack.extend(e["ifaces"])
+    return NO_METHOD
+
+
+def parse_plugin(dis_path):
+    """Call sites into kotlin/kotlinx FROM a plugin's own classes.
+
+    Calls originating inside the plugin's bundled stdlib copy are excluded --
+    that copy is shadowed by the host at runtime, so they are not real call
+    sites. Returns {(cls, name, sig): count}.
+    """
+    sites = defaultdict(int)
+    cur = None
+    with open(dis_path, "r", errors="replace") as fh:
+        for line in fh:
+            m = CLS_RE.match(line)
+            if m:
+                cur = m.group(1)
+                continue
+            if cur is None or cur.startswith(STDLIB_PREFIXES):
+                continue
+            m = INVOKE_RE.search(line)
+            if m and m.group(1).startswith(STDLIB_PREFIXES):
+                sites[(m.group(1), m.group(2), m.group(3))] += 1
+    return sites
+
+
+def plugin_dumps(plugindir):
+    for d in sorted(Path(plugindir).iterdir()):
+        if not d.is_dir():
+            continue
+        dis = d / "dis.txt"
+        if dis.exists():
+            yield d.name, dis
+
+
+def cmd_impact(ref_dump, cand_dump, plugindir):
+    sys.stderr.write("indexing reference host dex...\n")
+    ref = parse_host(ref_dump)
+    sys.stderr.write("indexing candidate host dex...\n")
+    cand = parse_host(cand_dump)
+    sys.stderr.write(f"reference classes={len(ref)}  candidate classes={len(cand)}\n")
+
+    rows, regressions, remaining = [], [], defaultdict(set)
+    for name, dis in plugin_dumps(plugindir):
+        sites = parse_plugin(dis)
+        cr, cc = defaultdict(int), defaultdict(int)
+        for (c, n, s) in sites:
+            vr, vc = resolve(ref, c, n, s), resolve(cand, c, n, s)
+            cr[vr] += 1
+            cc[vc] += 1
+            if vr == OK and vc != OK:
+                regressions.append((name, f"{c}.{n}{s}", vr, vc))
+            if vc == NO_METHOD:
+                remaining[name].add(f"{c}.{n}{s}")
+        rows.append((name, len(sites), cr, cc))
+
+    w = 106
+    print(f"\n{'plugin':<26} {'sites':>6} | {'REFERENCE':^28} | {'CANDIDATE':^28}")
+    print(f"{'':<26} {'':>6} | {'ok':>6} {'NoSuchMethod':>13} {'absent':>7} |"
+          f" {'ok':>6} {'NoSuchMethod':>13} {'absent':>7}")
+    print("-" * w)
+    tr, tc = defaultdict(int), defaultdict(int)
+    for name, n, cr, cc in rows:
+        for k in (OK, NO_METHOD, CLASS_ABSENT):
+            tr[k] += cr[k]
+            tc[k] += cc[k]
+        print(f"{name:<26} {n:>6} | {cr[OK]:>6} {cr[NO_METHOD]:>13} {cr[CLASS_ABSENT]:>7} |"
+              f" {cc[OK]:>6} {cc[NO_METHOD]:>13} {cc[CLASS_ABSENT]:>7}")
+    print("-" * w)
+    print(f"{'TOTAL':<26} {sum(r[1] for r in rows):>6} |"
+          f" {tr[OK]:>6} {tr[NO_METHOD]:>13} {tr[CLASS_ABSENT]:>7} |"
+          f" {tc[OK]:>6} {tc[NO_METHOD]:>13} {tc[CLASS_ABSENT]:>7}")
+
+    print("\n=== REGRESSIONS (resolved in reference, broken in candidate) ===")
+    if regressions:
+        for name, sitename, a, b in regressions:
+            print(f"  {name}: {sitename}  {a} -> {b}")
+    else:
+        print("  none")
+
+    print("\n=== NoSuchMethod in candidate ===")
+    print("  Check each against README 'Known false positives' -- boot-classpath")
+    print("  inheritance (java.util.*) is reported here but is not a real failure.")
+    print("  Use: analyze-plugin-impact.py explain-method <cand-dump> <class> <method>")
+    if remaining:
+        for name in sorted(remaining):
+            print(f"  {name}:")
+            for site in sorted(remaining[name]):
+                print(f"      {site}")
+    else:
+        print("  none")
+
+    return 1 if regressions else 0
+
+
+def cmd_explain_method(dump, cls, method):
+    """Trace the resolution chain, showing where it leaves the APK."""
+    idx = parse_host(dump)
+    if cls not in idx:
+        print(f"{cls}: ABSENT from this dex")
+        return 0
+    print(f"{cls}.{method}")
+    seen, stack, outside = set(), [cls], False
+    while stack:
+        c = stack.pop()
+        if c in seen:
+            continue
+        seen.add(c)
+        if c in idx:
+            e = idx[c]
+            decl = any(m.split(":")[0] == method for m in e["methods"])
+            print(f"   in-apk  {c}{'   <-- declares ' + method if decl else ''}")
+            if e["super"]:
+                stack.append(e["super"])
+            stack.extend(e["ifaces"])
+        else:
+            outside = True
+            print(f"   OUTSIDE APK (boot classpath) {c}")
+    if outside:
+        print("\n   Chain exits the APK. If the method is declared on a java.* type,"
+              "\n   this is a FALSE POSITIVE -- see README 'Known false positives'.")
+    return 0
+
+
+def cmd_explain_absent(dump, plugindir):
+    """List CLASS_ABSENT fall-throughs and flag the split-brain shape."""
+    idx = parse_host(dump)
+    absent = defaultdict(set)
+    for name, dis in plugin_dumps(plugindir):
+        for (c, n, s) in parse_plugin(dis):
+            if resolve(idx, c, n, s) == CLASS_ABSENT:
+                absent[name].add(c)
+
+    allcls = set()
+    print("Fall-through classes (absent from the host dex, so the plugin's own copy loads):\n")
+    for p, cs in sorted(absent.items()):
+        print(f"  {p}  ({len(cs)} distinct)")
+        for c in sorted(cs):
+            print(f"      {c}")
+        allcls |= cs
+
+    print("\nPackage rollup:")
+    pkg = defaultdict(int)
+    for c in allcls:
+        pkg[c.rsplit("/", 1)[0]] += 1
+    for p, n in sorted(pkg.items(), key=lambda kv: -kv[1]):
+        print(f"  {n:>3}  {p}")
+
+    print("\nClasses in packages the host DOES ship (inspect these -- a class absent")
+    print("while its supertype is present-and-stripped is the ADFA-5156 shape):")
+    flagged = False
+    for c in sorted(allcls):
+        pkgname = c.rsplit("/", 1)[0]
+        n = sum(1 for k in idx if k.rsplit("/", 1)[0] == pkgname)
+        if n:
+            flagged = True
+            synth = "$$ExternalSynthetic" in c or c.endswith("$DefaultImpls;")
+            note = "  (D8/Kotlin build-time synthetic, expected)" if synth else ""
+            print(f"      {c}   host has {n} others in that package{note}")
+    if not flagged:
+        print("      none -- every absent class is in a package the host does not ship")
+    return 0
+
+
+USAGE = """usage:
+  analyze-plugin-impact.py impact <ref-dump> <cand-dump> <plugindir>
+  analyze-plugin-impact.py explain-method <dump> <class-descriptor> <method>
+  analyze-plugin-impact.py explain-absent <dump> <plugindir>
+
+  <class-descriptor> is dex form, e.g. Lkotlin/collections/AbstractMutableSet;
+"""
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(USAGE, file=sys.stderr)
+        return 2
+    cmd, rest = sys.argv[1], sys.argv[2:]
+    handlers = {
+        "impact": (3, cmd_impact),
+        "explain-method": (3, cmd_explain_method),
+        "explain-absent": (2, cmd_explain_absent),
+    }
+    if cmd not in handlers or len(rest) != handlers[cmd][0]:
+        print(USAGE, file=sys.stderr)
+        return 2
+    return handlers[cmd][1](*rest)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/r8-plugin-impact/analyze-plugin-impact.py
+++ b/scripts/r8-plugin-impact/analyze-plugin-impact.py
@@ -9,9 +9,9 @@ from a build artifact instead of discovered on a device.
 
 Run this before shipping any release build that re-enables R8 shrinking.
 
-  uv run --no-project analyze-plugin-impact.py impact <ref-dump> <cand-dump> <plugindir>
-  uv run --no-project analyze-plugin-impact.py explain-method <dump> <class> <method>
-  uv run --no-project analyze-plugin-impact.py explain-absent <dump> <plugindir>
+uv run --no-project analyze-plugin-impact.py impact <ref-dump> <cand-dump> <plugindir>
+uv run --no-project analyze-plugin-impact.py explain-method <dump> <class> <method>
+uv run --no-project analyze-plugin-impact.py explain-absent <dump> <plugindir>
 
 Dumps come from dex-dump.sh. IMPORTANT: read the "Known false positives"
 section of README.md before acting on any NoSuchMethod result -- methods
@@ -30,7 +30,7 @@ IFACE_RE = re.compile(r"^    #\d+              : '([^']+)'")
 NAME_RE = re.compile(r"^      name          : '([^']*)'")
 TYPE_RE = re.compile(r"^      type          : '([^']*)'")
 SECTION_RE = re.compile(
-    r"^  (Direct methods|Virtual methods|Static fields|Instance fields|Interfaces)"
+	r"^  (Direct methods|Virtual methods|Static fields|Instance fields|Interfaces)"
 )
 INVOKE_RE = re.compile(r"invoke-[a-z/-]+ \{[^}]*\}, (L[^;]+;)\.([^:]+):(\([^)]*\)\S*)")
 
@@ -42,260 +42,260 @@ CLASS_ABSENT = "CLASS_ABSENT"
 
 
 def parse_host(dump_path):
-    """Index a host (IDE) dex dump.
+	"""Index a host (IDE) dex dump.
 
-    Returns {class: {'super': str|None, 'ifaces': [str], 'methods': {'name:sig'}}}
-    """
-    idx = {}
-    cur = None
-    in_ifaces = False
-    pending = None
-    with open(dump_path, "r", errors="replace") as fh:
-        for line in fh:
-            m = CLS_RE.match(line)
-            if m:
-                cur = {"super": None, "ifaces": [], "methods": set()}
-                idx[m.group(1)] = cur
-                in_ifaces = False
-                pending = None
-                continue
-            if cur is None:
-                continue
-            m = SUPER_RE.match(line)
-            if m:
-                cur["super"] = m.group(1)
-                continue
-            m = SECTION_RE.match(line)
-            if m:
-                # Interface entries look like method index lines, so track the
-                # section to tell them apart.
-                in_ifaces = m.group(1) == "Interfaces"
-                continue
-            if in_ifaces:
-                m = IFACE_RE.match(line)
-                if m:
-                    cur["ifaces"].append(m.group(1))
-                continue
-            m = NAME_RE.match(line)
-            if m:
-                pending = m.group(1)
-                continue
-            m = TYPE_RE.match(line)
-            if m and pending is not None:
-                cur["methods"].add(pending + ":" + m.group(1))
-                pending = None
-    return idx
+	Returns {class: {'super': str|None, 'ifaces': [str], 'methods': {'name:sig'}}}
+	"""
+	idx = {}
+	cur = None
+	in_ifaces = False
+	pending = None
+	with open(dump_path, "r", errors="replace") as fh:
+		for line in fh:
+			m = CLS_RE.match(line)
+			if m:
+				cur = {"super": None, "ifaces": [], "methods": set()}
+				idx[m.group(1)] = cur
+				in_ifaces = False
+				pending = None
+				continue
+			if cur is None:
+				continue
+			m = SUPER_RE.match(line)
+			if m:
+				cur["super"] = m.group(1)
+				continue
+			m = SECTION_RE.match(line)
+			if m:
+				# Interface entries look like method index lines, so track the
+				# section to tell them apart.
+				in_ifaces = m.group(1) == "Interfaces"
+				continue
+			if in_ifaces:
+				m = IFACE_RE.match(line)
+				if m:
+					cur["ifaces"].append(m.group(1))
+				continue
+			m = NAME_RE.match(line)
+			if m:
+				pending = m.group(1)
+				continue
+			m = TYPE_RE.match(line)
+			if m and pending is not None:
+				cur["methods"].add(pending + ":" + m.group(1))
+				pending = None
+	return idx
 
 
 def resolve(idx, cls, name, sig):
-    """Walk cls -> superclasses -> interfaces looking for name:sig.
+	"""Walk cls -> superclasses -> interfaces looking for name:sig.
 
-    Returns OK, NO_METHOD, or CLASS_ABSENT. NO_METHOD can be a false positive
-    when the real declaration lives on the Android boot classpath; see README.
-    """
-    if cls not in idx:
-        return CLASS_ABSENT
-    key = name + ":" + sig
-    seen, stack = set(), [cls]
-    while stack:
-        c = stack.pop()
-        if c in seen or c not in idx:
-            continue
-        seen.add(c)
-        e = idx[c]
-        if key in e["methods"]:
-            return OK
-        if e["super"]:
-            stack.append(e["super"])
-        stack.extend(e["ifaces"])
-    return NO_METHOD
+	Returns OK, NO_METHOD, or CLASS_ABSENT. NO_METHOD can be a false positive
+	when the real declaration lives on the Android boot classpath; see README.
+	"""
+	if cls not in idx:
+		return CLASS_ABSENT
+	key = name + ":" + sig
+	seen, stack = set(), [cls]
+	while stack:
+		c = stack.pop()
+		if c in seen or c not in idx:
+			continue
+		seen.add(c)
+		e = idx[c]
+		if key in e["methods"]:
+			return OK
+		if e["super"]:
+			stack.append(e["super"])
+		stack.extend(e["ifaces"])
+	return NO_METHOD
 
 
 def parse_plugin(dis_path):
-    """Call sites into kotlin/kotlinx FROM a plugin's own classes.
+	"""Call sites into kotlin/kotlinx FROM a plugin's own classes.
 
-    Calls originating inside the plugin's bundled stdlib copy are excluded --
-    that copy is shadowed by the host at runtime, so they are not real call
-    sites. Returns {(cls, name, sig): count}.
-    """
-    sites = defaultdict(int)
-    cur = None
-    with open(dis_path, "r", errors="replace") as fh:
-        for line in fh:
-            m = CLS_RE.match(line)
-            if m:
-                cur = m.group(1)
-                continue
-            if cur is None or cur.startswith(STDLIB_PREFIXES):
-                continue
-            m = INVOKE_RE.search(line)
-            if m and m.group(1).startswith(STDLIB_PREFIXES):
-                sites[(m.group(1), m.group(2), m.group(3))] += 1
-    return sites
+	Calls originating inside the plugin's bundled stdlib copy are excluded --
+	that copy is shadowed by the host at runtime, so they are not real call
+	sites. Returns {(cls, name, sig): count}.
+	"""
+	sites = defaultdict(int)
+	cur = None
+	with open(dis_path, "r", errors="replace") as fh:
+		for line in fh:
+			m = CLS_RE.match(line)
+			if m:
+				cur = m.group(1)
+				continue
+			if cur is None or cur.startswith(STDLIB_PREFIXES):
+				continue
+			m = INVOKE_RE.search(line)
+			if m and m.group(1).startswith(STDLIB_PREFIXES):
+				sites[(m.group(1), m.group(2), m.group(3))] += 1
+	return sites
 
 
 def plugin_dumps(plugindir):
-    for d in sorted(Path(plugindir).iterdir()):
-        if not d.is_dir():
-            continue
-        dis = d / "dis.txt"
-        if dis.exists():
-            yield d.name, dis
+	for d in sorted(Path(plugindir).iterdir()):
+		if not d.is_dir():
+			continue
+		dis = d / "dis.txt"
+		if dis.exists():
+			yield d.name, dis
 
 
 def cmd_impact(ref_dump, cand_dump, plugindir):
-    sys.stderr.write("indexing reference host dex...\n")
-    ref = parse_host(ref_dump)
-    sys.stderr.write("indexing candidate host dex...\n")
-    cand = parse_host(cand_dump)
-    sys.stderr.write(f"reference classes={len(ref)}  candidate classes={len(cand)}\n")
+	sys.stderr.write("indexing reference host dex...\n")
+	ref = parse_host(ref_dump)
+	sys.stderr.write("indexing candidate host dex...\n")
+	cand = parse_host(cand_dump)
+	sys.stderr.write(f"reference classes={len(ref)}  candidate classes={len(cand)}\n")
 
-    rows, regressions, remaining = [], [], defaultdict(set)
-    for name, dis in plugin_dumps(plugindir):
-        sites = parse_plugin(dis)
-        cr, cc = defaultdict(int), defaultdict(int)
-        for (c, n, s) in sites:
-            vr, vc = resolve(ref, c, n, s), resolve(cand, c, n, s)
-            cr[vr] += 1
-            cc[vc] += 1
-            if vr == OK and vc != OK:
-                regressions.append((name, f"{c}.{n}{s}", vr, vc))
-            if vc == NO_METHOD:
-                remaining[name].add(f"{c}.{n}{s}")
-        rows.append((name, len(sites), cr, cc))
+	rows, regressions, remaining = [], [], defaultdict(set)
+	for name, dis in plugin_dumps(plugindir):
+		sites = parse_plugin(dis)
+		cr, cc = defaultdict(int), defaultdict(int)
+		for (c, n, s) in sites:
+			vr, vc = resolve(ref, c, n, s), resolve(cand, c, n, s)
+			cr[vr] += 1
+			cc[vc] += 1
+			if vr == OK and vc != OK:
+				regressions.append((name, f"{c}.{n}{s}", vr, vc))
+			if vc == NO_METHOD:
+				remaining[name].add(f"{c}.{n}{s}")
+		rows.append((name, len(sites), cr, cc))
 
-    w = 106
-    print(f"\n{'plugin':<26} {'sites':>6} | {'REFERENCE':^28} | {'CANDIDATE':^28}")
-    print(f"{'':<26} {'':>6} | {'ok':>6} {'NoSuchMethod':>13} {'absent':>7} |"
-          f" {'ok':>6} {'NoSuchMethod':>13} {'absent':>7}")
-    print("-" * w)
-    tr, tc = defaultdict(int), defaultdict(int)
-    for name, n, cr, cc in rows:
-        for k in (OK, NO_METHOD, CLASS_ABSENT):
-            tr[k] += cr[k]
-            tc[k] += cc[k]
-        print(f"{name:<26} {n:>6} | {cr[OK]:>6} {cr[NO_METHOD]:>13} {cr[CLASS_ABSENT]:>7} |"
-              f" {cc[OK]:>6} {cc[NO_METHOD]:>13} {cc[CLASS_ABSENT]:>7}")
-    print("-" * w)
-    print(f"{'TOTAL':<26} {sum(r[1] for r in rows):>6} |"
-          f" {tr[OK]:>6} {tr[NO_METHOD]:>13} {tr[CLASS_ABSENT]:>7} |"
-          f" {tc[OK]:>6} {tc[NO_METHOD]:>13} {tc[CLASS_ABSENT]:>7}")
+	w = 106
+	print(f"\n{'plugin':<26} {'sites':>6} | {'REFERENCE':^28} | {'CANDIDATE':^28}")
+	print(f"{'':<26} {'':>6} | {'ok':>6} {'NoSuchMethod':>13} {'absent':>7} |"
+		f" {'ok':>6} {'NoSuchMethod':>13} {'absent':>7}")
+	print("-" * w)
+	tr, tc = defaultdict(int), defaultdict(int)
+	for name, n, cr, cc in rows:
+		for k in (OK, NO_METHOD, CLASS_ABSENT):
+			tr[k] += cr[k]
+			tc[k] += cc[k]
+		print(f"{name:<26} {n:>6} | {cr[OK]:>6} {cr[NO_METHOD]:>13} {cr[CLASS_ABSENT]:>7} |"
+			f" {cc[OK]:>6} {cc[NO_METHOD]:>13} {cc[CLASS_ABSENT]:>7}")
+	print("-" * w)
+	print(f"{'TOTAL':<26} {sum(r[1] for r in rows):>6} |"
+		f" {tr[OK]:>6} {tr[NO_METHOD]:>13} {tr[CLASS_ABSENT]:>7} |"
+		f" {tc[OK]:>6} {tc[NO_METHOD]:>13} {tc[CLASS_ABSENT]:>7}")
 
-    print("\n=== REGRESSIONS (resolved in reference, broken in candidate) ===")
-    if regressions:
-        for name, sitename, a, b in regressions:
-            print(f"  {name}: {sitename}  {a} -> {b}")
-    else:
-        print("  none")
+	print("\n=== REGRESSIONS (resolved in reference, broken in candidate) ===")
+	if regressions:
+		for name, sitename, a, b in regressions:
+			print(f"  {name}: {sitename}  {a} -> {b}")
+	else:
+		print("  none")
 
-    print("\n=== NoSuchMethod in candidate ===")
-    print("  Check each against README 'Known false positives' -- boot-classpath")
-    print("  inheritance (java.util.*) is reported here but is not a real failure.")
-    print("  Use: analyze-plugin-impact.py explain-method <cand-dump> <class> <method>")
-    if remaining:
-        for name in sorted(remaining):
-            print(f"  {name}:")
-            for site in sorted(remaining[name]):
-                print(f"      {site}")
-    else:
-        print("  none")
+	print("\n=== NoSuchMethod in candidate ===")
+	print("  Check each against README 'Known false positives' -- boot-classpath")
+	print("  inheritance (java.util.*) is reported here but is not a real failure.")
+	print("  Use: analyze-plugin-impact.py explain-method <cand-dump> <class> <method>")
+	if remaining:
+		for name in sorted(remaining):
+			print(f"  {name}:")
+			for site in sorted(remaining[name]):
+				print(f"      {site}")
+	else:
+		print("  none")
 
-    return 1 if regressions else 0
+	return 1 if regressions else 0
 
 
 def cmd_explain_method(dump, cls, method):
-    """Trace the resolution chain, showing where it leaves the APK."""
-    idx = parse_host(dump)
-    if cls not in idx:
-        print(f"{cls}: ABSENT from this dex")
-        return 0
-    print(f"{cls}.{method}")
-    seen, stack, outside = set(), [cls], False
-    while stack:
-        c = stack.pop()
-        if c in seen:
-            continue
-        seen.add(c)
-        if c in idx:
-            e = idx[c]
-            decl = any(m.split(":")[0] == method for m in e["methods"])
-            print(f"   in-apk  {c}{'   <-- declares ' + method if decl else ''}")
-            if e["super"]:
-                stack.append(e["super"])
-            stack.extend(e["ifaces"])
-        else:
-            outside = True
-            print(f"   OUTSIDE APK (boot classpath) {c}")
-    if outside:
-        print("\n   Chain exits the APK. If the method is declared on a java.* type,"
-              "\n   this is a FALSE POSITIVE -- see README 'Known false positives'.")
-    return 0
+	"""Trace the resolution chain, showing where it leaves the APK."""
+	idx = parse_host(dump)
+	if cls not in idx:
+		print(f"{cls}: ABSENT from this dex")
+		return 0
+	print(f"{cls}.{method}")
+	seen, stack, outside = set(), [cls], False
+	while stack:
+		c = stack.pop()
+		if c in seen:
+			continue
+		seen.add(c)
+		if c in idx:
+			e = idx[c]
+			decl = any(m.split(":")[0] == method for m in e["methods"])
+			print(f"   in-apk  {c}{'   <-- declares ' + method if decl else ''}")
+			if e["super"]:
+				stack.append(e["super"])
+			stack.extend(e["ifaces"])
+		else:
+			outside = True
+			print(f"   OUTSIDE APK (boot classpath) {c}")
+	if outside:
+		print("\n   Chain exits the APK. If the method is declared on a java.* type,"
+			"\n   this is a FALSE POSITIVE -- see README 'Known false positives'.")
+	return 0
 
 
 def cmd_explain_absent(dump, plugindir):
-    """List CLASS_ABSENT fall-throughs and flag the split-brain shape."""
-    idx = parse_host(dump)
-    absent = defaultdict(set)
-    for name, dis in plugin_dumps(plugindir):
-        for (c, n, s) in parse_plugin(dis):
-            if resolve(idx, c, n, s) == CLASS_ABSENT:
-                absent[name].add(c)
+	"""List CLASS_ABSENT fall-throughs and flag the split-brain shape."""
+	idx = parse_host(dump)
+	absent = defaultdict(set)
+	for name, dis in plugin_dumps(plugindir):
+		for (c, n, s) in parse_plugin(dis):
+			if resolve(idx, c, n, s) == CLASS_ABSENT:
+				absent[name].add(c)
 
-    allcls = set()
-    print("Fall-through classes (absent from the host dex, so the plugin's own copy loads):\n")
-    for p, cs in sorted(absent.items()):
-        print(f"  {p}  ({len(cs)} distinct)")
-        for c in sorted(cs):
-            print(f"      {c}")
-        allcls |= cs
+	allcls = set()
+	print("Fall-through classes (absent from the host dex, so the plugin's own copy loads):\n")
+	for p, cs in sorted(absent.items()):
+		print(f"  {p}  ({len(cs)} distinct)")
+		for c in sorted(cs):
+			print(f"      {c}")
+		allcls |= cs
 
-    print("\nPackage rollup:")
-    pkg = defaultdict(int)
-    for c in allcls:
-        pkg[c.rsplit("/", 1)[0]] += 1
-    for p, n in sorted(pkg.items(), key=lambda kv: -kv[1]):
-        print(f"  {n:>3}  {p}")
+	print("\nPackage rollup:")
+	pkg = defaultdict(int)
+	for c in allcls:
+		pkg[c.rsplit("/", 1)[0]] += 1
+	for p, n in sorted(pkg.items(), key=lambda kv: -kv[1]):
+		print(f"  {n:>3}  {p}")
 
-    print("\nClasses in packages the host DOES ship (inspect these -- a class absent")
-    print("while its supertype is present-and-stripped is the ADFA-5156 shape):")
-    flagged = False
-    for c in sorted(allcls):
-        pkgname = c.rsplit("/", 1)[0]
-        n = sum(1 for k in idx if k.rsplit("/", 1)[0] == pkgname)
-        if n:
-            flagged = True
-            synth = "$$ExternalSynthetic" in c or c.endswith("$DefaultImpls;")
-            note = "  (D8/Kotlin build-time synthetic, expected)" if synth else ""
-            print(f"      {c}   host has {n} others in that package{note}")
-    if not flagged:
-        print("      none -- every absent class is in a package the host does not ship")
-    return 0
+	print("\nClasses in packages the host DOES ship (inspect these -- a class absent")
+	print("while its supertype is present-and-stripped is the ADFA-5156 shape):")
+	flagged = False
+	for c in sorted(allcls):
+		pkgname = c.rsplit("/", 1)[0]
+		n = sum(1 for k in idx if k.rsplit("/", 1)[0] == pkgname)
+		if n:
+			flagged = True
+			synth = "$$ExternalSynthetic" in c or c.endswith("$DefaultImpls;")
+			note = "  (D8/Kotlin build-time synthetic, expected)" if synth else ""
+			print(f"      {c}   host has {n} others in that package{note}")
+	if not flagged:
+		print("      none -- every absent class is in a package the host does not ship")
+	return 0
 
 
 USAGE = """usage:
-  analyze-plugin-impact.py impact <ref-dump> <cand-dump> <plugindir>
-  analyze-plugin-impact.py explain-method <dump> <class-descriptor> <method>
-  analyze-plugin-impact.py explain-absent <dump> <plugindir>
+analyze-plugin-impact.py impact <ref-dump> <cand-dump> <plugindir>
+analyze-plugin-impact.py explain-method <dump> <class-descriptor> <method>
+analyze-plugin-impact.py explain-absent <dump> <plugindir>
 
-  <class-descriptor> is dex form, e.g. Lkotlin/collections/AbstractMutableSet;
+<class-descriptor> is dex form, e.g. Lkotlin/collections/AbstractMutableSet;
 """
 
 
 def main():
-    if len(sys.argv) < 2:
-        print(USAGE, file=sys.stderr)
-        return 2
-    cmd, rest = sys.argv[1], sys.argv[2:]
-    handlers = {
-        "impact": (3, cmd_impact),
-        "explain-method": (3, cmd_explain_method),
-        "explain-absent": (2, cmd_explain_absent),
-    }
-    if cmd not in handlers or len(rest) != handlers[cmd][0]:
-        print(USAGE, file=sys.stderr)
-        return 2
-    return handlers[cmd][1](*rest)
+	if len(sys.argv) < 2:
+		print(USAGE, file=sys.stderr)
+		return 2
+	cmd, rest = sys.argv[1], sys.argv[2:]
+	handlers = {
+		"impact": (3, cmd_impact),
+		"explain-method": (3, cmd_explain_method),
+		"explain-absent": (2, cmd_explain_absent),
+	}
+	if cmd not in handlers or len(rest) != handlers[cmd][0]:
+		print(USAGE, file=sys.stderr)
+		return 2
+	return handlers[cmd][1](*rest)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+	sys.exit(main())

--- a/scripts/r8-plugin-impact/dex-dump.sh
+++ b/scripts/r8-plugin-impact/dex-dump.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# ADFA-5156 / R8 plugin-impact tooling. See README.md in this directory.
+#
+# Extracts classes*.dex from an APK or .cgp (both are zips) and produces a
+# dexdump text file for analyze-plugin-impact.py to consume.
+#
+#   ./dex-dump.sh <apk-or-cgp> <outdir>                 # one artifact
+#   ./dex-dump.sh --disassemble <cgp>... <outdir>       # many, with bytecode
+#
+# --disassemble (dexdump -d) is required for plugins, because the analysis needs
+# invoke instructions to find call sites. It is NOT needed for the IDE APK,
+# where only the class/method table is read -- and it would be very slow there.
+
+set -uo pipefail
+
+DEXDUMP="${DEXDUMP:-}"
+if [ -z "$DEXDUMP" ]; then
+	# Prefer the newest build-tools install we can find.
+	for sdk in "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}" "$HOME/Android/Sdk" "$HOME/Library/Android/sdk"; do
+		[ -n "$sdk" ] || continue
+		cand=$(ls -d "$sdk"/build-tools/*/dexdump 2>/dev/null | sort -V | tail -1)
+		[ -n "$cand" ] && { DEXDUMP="$cand"; break; }
+	done
+fi
+if [ ! -x "${DEXDUMP:-}" ]; then
+	echo "dexdump not found. Set DEXDUMP=/path/to/build-tools/<ver>/dexdump" >&2
+	exit 1
+fi
+
+DIS=0
+if [ "${1:-}" = "--disassemble" ]; then
+	DIS=1
+	shift
+fi
+
+if [ "$#" -lt 2 ]; then
+	echo "usage: $0 [--disassemble] <apk-or-cgp>... <outdir>" >&2
+	exit 2
+fi
+
+# Last argument is the output directory.
+OUTROOT="${*: -1}"
+set -- "${@:1:$(($#-1))}"
+mkdir -p "$OUTROOT"
+
+for artifact in "$@"; do
+	name=$(basename "$artifact")
+	name="${name%.*}"
+	if [ "$#" -eq 1 ]; then
+		dir="$OUTROOT"          # single artifact: dump straight into outdir
+	else
+		dir="$OUTROOT/$name"    # many: one subdirectory each
+	fi
+	mkdir -p "$dir"
+
+	if ! ls "$dir"/classes*.dex >/dev/null 2>&1; then
+		unzip -q -o "$artifact" 'classes*.dex' -d "$dir" 2>/dev/null
+	fi
+	if ! ls "$dir"/classes*.dex >/dev/null 2>&1; then
+		echo "  $name: no dex found, skipping" >&2
+		continue
+	fi
+
+	out="$dir/full-dump.txt"
+	[ "$DIS" -eq 1 ] && out="$dir/dis.txt"
+	if [ ! -s "$out" ]; then
+		: > "$out"
+		for d in "$dir"/classes*.dex; do
+			if [ "$DIS" -eq 1 ]; then
+				"$DEXDUMP" -d "$d" >> "$out" 2>/dev/null
+			else
+				"$DEXDUMP" "$d" >> "$out" 2>/dev/null
+			fi
+		done
+	fi
+	printf '%-30s %2s dex  %10s lines -> %s\n' \
+		"$name" "$(ls "$dir"/classes*.dex | wc -l | tr -d ' ')" \
+		"$(wc -l < "$out" | tr -d ' ')" "$out"
+done


### PR DESCRIPTION
Temporary rollback to restore plugin functionality. A targeted fix follows next week under the same ticket.

## Problem

Plugins load parent-first through a stock `DexClassLoader` (`PluginLoader.kt:92-116`, parent passed at `PluginManager.kt:603`), so every `kotlin.**` class a plugin references resolves from the IDE's dex, not from the ~1058 stdlib classes the plugin bundles. R8 cannot see plugin call sites, so it strips every stdlib member the IDE itself does not call.

Net effect: **a plugin can only call the subset of the Kotlin standard library that the IDE also calls.** Anything else throws `NoSuchMethodError` at runtime. Sketch to UI fails on every image load with `No static method maxOrNull([F)Ljava/lang/Float; in class ArraysKt`.

## Change

One line: restores the blanket `-dontshrink` that ADFA-3604 (#1596) removed on 2026-07-29.

`-dontobfuscate` and `-dontoptimize` were already set, so this reduces R8 to a pass-through and returns the release build to the configuration shipped before ADFA-3604. `isMinifyEnabled` and `isShrinkResources` are deliberately left alone — resource shrinking and the build wiring are unchanged. That flag is the only R8 switch in the repo.

Chose the rollback over the ticket's proposed `-keep class kotlin.** { *; }` because it returns to a known-shipped-good state rather than a new, untested configuration. With a demo today, that mattered.

## Verification

Dex-scanned both APKs. Baseline pulled from the release install on Samsung RFCT704HEAL (`run-as` reports "package not debuggable", confirming release).

| | baseline (shipped) | rolled back |
|---|---|---|
| kotlin/kotlinx method declarations | 30,669 | 45,371 |
| `ArraysKt`/`CollectionsKt`/`MapsKt`/`FilesKt`/`SequencesKt` facades | absent | present |
| 10 sketch-to-ui stdlib call sites | all stripped | all present |
| `CompletableJob$DefaultImpls.plus` | stripped | present |

Sketch to UI installs, loads an image, and completes detection on-device with zero `NoSuchMethodError` in logcat. Verified against a clean install — the uninstall also clears the stale `codeCacheDir/plugin_dex` the ticket warns can confound results.

## Size cost

659,307,160 -> 706,829,817 bytes, **+47.5 MB (+7.2%)**. Dex 85 MB -> 116 MB; classes 78,757 -> 101,793.

Worth knowing for next week's decision: R8 was buying less than #1596 advertised. That PR measured dex at 28.8 MB / 24,853 classes, but the shipped APK is 85 MB / 78,757 classes — the URGENT follow-ups (#1609, #1610) added `-dontoptimize` plus a set of keep rules that clawed most of it back. The real cost of shrinking at rollback time was ~31 MB of dex, not the ~90 MB the original PR implies.

## Note on the ticket's impact table

It overstates compose-preview. `SendChannel.send`, `Flow.collect`, and `Deferred.await` were already present in the shipped build — they are inherited interface methods, and only the declaring supertype needs to survive. Of the three latent call sites only `CompletableJob.plus` was genuinely missing. Same point applies to the facades: `ArraysKt` and friends declare nothing themselves, they extend the part class (`ArraysKt___ArraysKt`), which is exactly the resolution path the ticket describes.

## Not addressed here

- Targeted keep rules for `kotlin.**` / `kotlinx.coroutines.**` (the real fix, next week)
- `codeCacheDir/plugin_dex` cleanup gap in `PluginManager.kt:1779-1826`
- Null-message handling at `ComputerVisionViewModel.kt:154`

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev not activated in your linked Atlassian organization</strong>
An Atlassian organization admin needs to activate Rovo Dev.
<!-- /Rovo Dev code review status -->

