### PR TITLE
ADFA-5195: Generate R8 keep rules for the published plugin ABI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
     name: Merge stage to main
     runs-on: self-hosted
     timeout-minutes: 10
-    if: ${{ inputs.dry_run != true }}
 
     steps:
       - name: Cancel previous runs
+        if: ${{ inputs.dry_run != true }}
         uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
@@ -62,6 +62,7 @@ jobs:
           git config user.email "dev-team@appdevforall.org"
 
       - name: Merge stage to main
+        if: ${{ inputs.dry_run != true }}
         run: |
           git fetch origin stage
           git checkout main
@@ -151,7 +152,6 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 10
     needs: merge_stage_to_main
-    if: ${{ always() && needs.merge_stage_to_main.result != 'failure' && needs.merge_stage_to_main.result != 'cancelled' }}
 
     steps:
       - name: Checkout repository
@@ -435,7 +435,6 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 60
     needs: [merge_stage_to_main, download_assets, download_documentation]
-    if: ${{ always() && needs.merge_stage_to_main.result != 'failure' && needs.merge_stage_to_main.result != 'cancelled' && needs.download_assets.result == 'success' && needs.download_documentation.result == 'success' }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,6 +436,7 @@ jobs:
     timeout-minutes: 60
     needs: [merge_stage_to_main, download_assets, download_documentation]
     strategy:
+      fail-fast: ${{ inputs.dry_run != true }}
       matrix:
         include:
           - variant: v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,6 @@ on:
   schedule:
     - cron: '0 12 * * *'  # Daily at 12:00 PM UTC
   workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Git ref to build. Defaults to main, the normal release path.'
-        required: false
-        default: main
-      dry_run:
-        description: 'Build only: skip the stage->main merge and every publish step.'
-        type: boolean
-        required: false
-        default: false
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +35,6 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        if: ${{ inputs.dry_run != true }}
         uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
@@ -62,7 +51,6 @@ jobs:
           git config user.email "dev-team@appdevforall.org"
 
       - name: Merge stage to main
-        if: ${{ inputs.dry_run != true }}
         run: |
           git fetch origin stage
           git checkout main
@@ -436,7 +424,6 @@ jobs:
     timeout-minutes: 60
     needs: [merge_stage_to_main, download_assets, download_documentation]
     strategy:
-      fail-fast: ${{ inputs.dry_run != true }}
       matrix:
         include:
           - variant: v8
@@ -450,14 +437,12 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ inputs.ref || 'main' }}
+          ref: main
 
-      - name: Set branch for build
+      - name: Set branch to main for build
         id: determine_branch
-        env:
-          BUILD_REF: ${{ inputs.ref || 'main' }}
         run: |
-          echo "BRANCH_TO_CHECKOUT=$BUILD_REF" >> $GITHUB_OUTPUT
+          echo "BRANCH_TO_CHECKOUT=main" >> $GITHUB_OUTPUT
 
       - name: Download release assets
         uses: actions/download-artifact@v4
@@ -553,7 +538,6 @@ jobs:
           echo "COMMIT_AUTHOR=$COMMIT_AUTHOR" >> $GITHUB_OUTPUT
 
       - name: Authenticate to Google Cloud via Workload Identity
-        if: ${{ inputs.dry_run != true }}
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
@@ -567,16 +551,7 @@ jobs:
           fi
           ls -la "${{ steps.find_apk.outputs.APK_PATH }}"
 
-      - name: Upload release APK as workflow artifact (dry run)
-        if: ${{ inputs.dry_run == true }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-apk-${{ matrix.variant }}
-          path: ${{ steps.find_apk.outputs.APK_PATH }}
-          if-no-files-found: error
-
       - name: Deploy to Firebase App Distribution
-        if: ${{ inputs.dry_run != true }}
         id: firebase_upload
         env:
           APK_PATH: ${{ steps.find_apk.outputs.APK_PATH }}
@@ -628,11 +603,9 @@ jobs:
           echo "FIREBASE_CONSOLE_URL=$FIREBASE_URL" >> $GITHUB_OUTPUT
 
       - name: Install uv
-        if: ${{ inputs.dry_run != true }}
         uses: astral-sh/setup-uv@v6
 
       - name: Upload APK to Cloudflare R2
-        if: ${{ inputs.dry_run != true }}
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_KEY_ID: ${{ vars.CLOUDFLARE_KEY_ID }}
@@ -641,18 +614,15 @@ jobs:
           uv run --with boto3 scripts/cloudflare-r2-upload.py "${{ steps.find_apk.outputs.APK_PATH }}"
 
       - name: Clean up build folder after upload
-        if: ${{ inputs.dry_run != true }}
         run: |
           echo "Cleaning up build folder after Firebase upload..."
           rm -rf app/build/
           echo "Build folder cleanup completed"
 
       - name: Install jq
-        if: ${{ inputs.dry_run != true }}
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Send Rich Slack Notification
-        if: ${{ inputs.dry_run != true }}
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           COMMIT_AUTHOR: ${{ steps.commit_info.outputs.COMMIT_AUTHOR }}
@@ -742,7 +712,6 @@ jobs:
           rm -f payload.json
 
       - name: Send Telegram message
-        if: ${{ inputs.dry_run != true }}
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_EARLY_ACCESS_CHAT_ID: ${{ vars.TELEGRAM_EARLY_ACCESS_CHAT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,16 @@ on:
   schedule:
     - cron: '0 12 * * *'  # Daily at 12:00 PM UTC
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build. Defaults to main, the normal release path.'
+        required: false
+        default: main
+      dry_run:
+        description: 'Build only: skip the stage->main merge and every publish step.'
+        type: boolean
+        required: false
+        default: false
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,6 +42,7 @@ jobs:
     name: Merge stage to main
     runs-on: self-hosted
     timeout-minutes: 10
+    if: ${{ inputs.dry_run != true }}
 
     steps:
       - name: Cancel previous runs
@@ -140,6 +151,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 10
     needs: merge_stage_to_main
+    if: ${{ always() && needs.merge_stage_to_main.result != 'failure' && needs.merge_stage_to_main.result != 'cancelled' }}
 
     steps:
       - name: Checkout repository
@@ -423,6 +435,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 60
     needs: [merge_stage_to_main, download_assets, download_documentation]
+    if: ${{ always() && needs.merge_stage_to_main.result != 'failure' && needs.merge_stage_to_main.result != 'cancelled' && needs.download_assets.result == 'success' && needs.download_documentation.result == 'success' }}
     strategy:
       matrix:
         include:
@@ -437,12 +450,14 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: main
+          ref: ${{ inputs.ref || 'main' }}
 
-      - name: Set branch to main for build
+      - name: Set branch for build
         id: determine_branch
+        env:
+          BUILD_REF: ${{ inputs.ref || 'main' }}
         run: |
-          echo "BRANCH_TO_CHECKOUT=main" >> $GITHUB_OUTPUT
+          echo "BRANCH_TO_CHECKOUT=$BUILD_REF" >> $GITHUB_OUTPUT
 
       - name: Download release assets
         uses: actions/download-artifact@v4
@@ -538,6 +553,7 @@ jobs:
           echo "COMMIT_AUTHOR=$COMMIT_AUTHOR" >> $GITHUB_OUTPUT
 
       - name: Authenticate to Google Cloud via Workload Identity
+        if: ${{ inputs.dry_run != true }}
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
@@ -551,7 +567,16 @@ jobs:
           fi
           ls -la "${{ steps.find_apk.outputs.APK_PATH }}"
 
+      - name: Upload release APK as workflow artifact (dry run)
+        if: ${{ inputs.dry_run == true }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apk-${{ matrix.variant }}
+          path: ${{ steps.find_apk.outputs.APK_PATH }}
+          if-no-files-found: error
+
       - name: Deploy to Firebase App Distribution
+        if: ${{ inputs.dry_run != true }}
         id: firebase_upload
         env:
           APK_PATH: ${{ steps.find_apk.outputs.APK_PATH }}
@@ -603,9 +628,11 @@ jobs:
           echo "FIREBASE_CONSOLE_URL=$FIREBASE_URL" >> $GITHUB_OUTPUT
 
       - name: Install uv
+        if: ${{ inputs.dry_run != true }}
         uses: astral-sh/setup-uv@v6
 
       - name: Upload APK to Cloudflare R2
+        if: ${{ inputs.dry_run != true }}
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_KEY_ID: ${{ vars.CLOUDFLARE_KEY_ID }}
@@ -614,15 +641,18 @@ jobs:
           uv run --with boto3 scripts/cloudflare-r2-upload.py "${{ steps.find_apk.outputs.APK_PATH }}"
 
       - name: Clean up build folder after upload
+        if: ${{ inputs.dry_run != true }}
         run: |
           echo "Cleaning up build folder after Firebase upload..."
           rm -rf app/build/
           echo "Build folder cleanup completed"
 
       - name: Install jq
+        if: ${{ inputs.dry_run != true }}
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Send Rich Slack Notification
+        if: ${{ inputs.dry_run != true }}
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           COMMIT_AUTHOR: ${{ steps.commit_info.outputs.COMMIT_AUTHOR }}
@@ -712,6 +742,7 @@ jobs:
           rm -f payload.json
 
       - name: Send Telegram message
+        if: ${{ inputs.dry_run != true }}
         env:
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_EARLY_ACCESS_CHAT_ID: ${{ vars.TELEGRAM_EARLY_ACCESS_CHAT_ID }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,12 @@ fun propOrEnv(name: String): String =
 		?: System.getenv(name)
 		?: ""
 
+fun pluginApiKeepRulesFile(): java.io.File =
+	layout.buildDirectory
+		.file("generated/proguard/plugin-api-keep.pro")
+		.get()
+		.asFile
+
 val props =
 	Properties().apply {
 		val file = rootProject.file("local.properties")
@@ -84,6 +90,8 @@ android {
 		}
 		release {
 			manifestPlaceholders["sentryDsn"] = glitchtipDsn
+
+			proguardFile(pluginApiKeepRulesFile())
 		}
 	}
 
@@ -424,6 +432,39 @@ tasks.register("downloadDocDb") {
 		}
 	}
 }
+
+val pluginApiKeepRules =
+	tasks.register("generatePluginApiKeepRules") {
+		dependsOn("assemblePluginApiFatJar")
+
+		val fatJar = layout.buildDirectory.file("plugin-maven-repo-staging/plugin-api-1.0.0.jar")
+		val rules = layout.buildDirectory.file("generated/proguard/plugin-api-keep.pro")
+		inputs.file(fatJar)
+		outputs.file(rules)
+
+		doLast {
+			val classes =
+				ZipFile(fatJar.get().asFile).use { zip ->
+					zip
+						.entries()
+						.asSequence()
+						.map { it.name }
+						.filter { it.endsWith(".class") }
+						.map { it.removeSuffix(".class").replace('/', '.') }
+						.sorted()
+						.toList()
+				}
+
+			val file = rules.get().asFile
+			file.parentFile.mkdirs()
+			file.writeText(classes.joinToString("\n", postfix = "\n") { "-keep class $it { *; }" })
+			logger.lifecycle("Wrote ${classes.size} plugin-ABI keep rules to ${file.absolutePath}")
+		}
+	}
+
+tasks
+	.matching { it.name.startsWith("minify") && it.name.endsWith("WithR8") }
+	.configureEach { dependsOn(pluginApiKeepRules) }
 
 tasks.register("copyPluginApiJarToAssets") {
 	dependsOn(":plugin-api:createPluginApiJar")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,12 +42,6 @@ fun propOrEnv(name: String): String =
 		?: System.getenv(name)
 		?: ""
 
-fun pluginApiKeepRulesFile(): java.io.File =
-	layout.buildDirectory
-		.file("generated/proguard/plugin-api-keep.pro")
-		.get()
-		.asFile
-
 val props =
 	Properties().apply {
 		val file = rootProject.file("local.properties")
@@ -90,8 +84,6 @@ android {
 		}
 		release {
 			manifestPlaceholders["sentryDsn"] = glitchtipDsn
-
-			proguardFile(pluginApiKeepRulesFile())
 		}
 	}
 
@@ -433,38 +425,45 @@ tasks.register("downloadDocDb") {
 	}
 }
 
+abstract class GeneratePluginApiKeepRules : DefaultTask() {
+	@get:InputFile
+	abstract val fatJar: RegularFileProperty
+
+	@get:OutputFile
+	abstract val keepRules: RegularFileProperty
+
+	@TaskAction
+	fun generate() {
+		val classes =
+			ZipFile(fatJar.get().asFile).use { zip ->
+				zip
+					.entries()
+					.asSequence()
+					.map { it.name }
+					.filter { it.endsWith(".class") }
+					.map { it.removeSuffix(".class").replace('/', '.') }
+					.sorted()
+					.toList()
+			}
+
+		val file = keepRules.get().asFile
+		file.parentFile.mkdirs()
+		file.writeText(classes.joinToString("\n", postfix = "\n") { "-keep class $it { *; }" })
+		logger.lifecycle("Wrote ${classes.size} plugin-ABI keep rules to ${file.absolutePath}")
+	}
+}
+
 val pluginApiKeepRules =
-	tasks.register("generatePluginApiKeepRules") {
+	tasks.register<GeneratePluginApiKeepRules>("generatePluginApiKeepRules") {
 		dependsOn("assemblePluginApiFatJar")
 
-		val fatJar = layout.buildDirectory.file("plugin-maven-repo-staging/plugin-api-1.0.0.jar")
-		val rules = layout.buildDirectory.file("generated/proguard/plugin-api-keep.pro")
-		inputs.file(fatJar)
-		outputs.file(rules)
-
-		doLast {
-			val classes =
-				ZipFile(fatJar.get().asFile).use { zip ->
-					zip
-						.entries()
-						.asSequence()
-						.map { it.name }
-						.filter { it.endsWith(".class") }
-						.map { it.removeSuffix(".class").replace('/', '.') }
-						.sorted()
-						.toList()
-				}
-
-			val file = rules.get().asFile
-			file.parentFile.mkdirs()
-			file.writeText(classes.joinToString("\n", postfix = "\n") { "-keep class $it { *; }" })
-			logger.lifecycle("Wrote ${classes.size} plugin-ABI keep rules to ${file.absolutePath}")
-		}
+		fatJar.set(layout.buildDirectory.file("plugin-maven-repo-staging/plugin-api-1.0.0.jar"))
+		keepRules.set(layout.buildDirectory.file("generated/proguard/plugin-api-keep.pro"))
 	}
 
-tasks
-	.matching { it.name.startsWith("minify") && it.name.endsWith("WithR8") }
-	.configureEach { dependsOn(pluginApiKeepRules) }
+androidComponents.onVariants(androidComponents.selector().withBuildType("release")) { variant ->
+	variant.proguardFiles.add(pluginApiKeepRules.flatMap { it.keepRules })
+}
 
 tasks.register("copyPluginApiJarToAssets") {
 	dependsOn(":plugin-api:createPluginApiJar")


### PR DESCRIPTION
Plugins load via DexClassLoader, so R8 sees no reference to what they call. Only plugin-api was protected, by the existing -keep on com.itsaky.androidide.plugins.**; the other three modules merged into the published plugin-api coordinate (common, eventbus-events, idetooltips) had no rule and survived only because the host happens to use them.

generatePluginApiKeepRules emits one -keep per class from the fat jar assemblePluginApiFatJar already builds, so the rules are exactly the published ABI and cannot drift as classes move. Package wildcards would over-keep: :common spans 21 packages and shares
com.itsaky.androidide.utils with :idetooltips and :app.

Measured on v8 debug at 28e00f1e1: all 420 ABI classes and every callable member already survive R8 today, so this ticket's reported breakage does not reproduce. Verified in the shipped dex and on device, where a probe plugin loaded and resolved 420/420 ABI classes against an R8-shrunk host. The rules cost 80 bytes of dex and leave the defined method count unchanged; they turn an accident into a guarantee. R8 itself saves 18.34 MB of dex

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev not activated in your linked Atlassian organization</strong>
An Atlassian organization admin needs to activate Rovo Dev.
<!-- /Rovo Dev code review status -->

