### PR TITLE
ADFA-5223: Fix Indonesian "resource" mistranslated as "sumber" (source)

### DIFF
--- a/apk-viewer-plugin/src/main/res/values-in/strings.xml
+++ b/apk-viewer-plugin/src/main/res/values-in/strings.xml
@@ -15,7 +15,7 @@
     <string name="section_apk_structure">Struktur APK</string>
     <string name="section_key_files">File Utama</string>
     <string name="section_native_libraries">Pustaka Native (%d)</string>
-    <string name="section_resource_directories">Direktori Sumber (%d)</string>
+    <string name="section_resource_directories">Direktori Sumber Daya (%d)</string>
     <string name="section_large_files">File Besar (&gt;100KB)</string>
     <string name="section_apk_metadata">Metadata APK</string>
 

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -18,9 +18,9 @@
 <resources>
     <!--  Required by F-Droid-->
     <string name="pref_use_simple_local_prompt">Gunakan prompt sederhana</string>
-    <string name="msg_strings_injection_failed">Gagal memperbarui sumber string yang dihasilkan.</string>
-    <string name="msg_strings_injection_file_not_found">Tidak dapat menemukan file sumber string proyek.</string>
-    <string name="msg_strings_injection_parser_unsupported">Perangkat ini tidak mendukung konfigurasi parser XML yang diperlukan untuk memperbarui sumber string yang dihasilkan.</string>
-    <string name="msg_strings_injection_invalid_xml">Sumber string yang dihasilkan bukan XML yang valid.</string>
+    <string name="msg_strings_injection_failed">Gagal memperbarui sumber daya string yang dihasilkan.</string>
+    <string name="msg_strings_injection_file_not_found">Tidak dapat menemukan file sumber daya string proyek.</string>
+    <string name="msg_strings_injection_parser_unsupported">Perangkat ini tidak mendukung konfigurasi parser XML yang diperlukan untuk memperbarui sumber daya string yang dihasilkan.</string>
+    <string name="msg_strings_injection_invalid_xml">Sumber daya string yang dihasilkan bukan XML yang valid.</string>
     <string name="msg_floating_window_open_failed">Tidak dapat membuka “%1$s” di jendela mengambang.</string>
 </resources>

--- a/resources/src/main/res/values-in-rID/strings.xml
+++ b/resources/src/main/res/values-in-rID/strings.xml
@@ -240,7 +240,7 @@
 	<string name="new_file">File baru</string>
 	<string name="create_auto_layout">Buat file layout</string>
 	<string name="new_java_class">Class Java baru</string>
-	<string name="new_xml_resource">Sumber XML baru</string>
+	<string name="new_xml_resource">Sumber daya XML baru</string>
 	<string name="new_folder">Folder baru</string>
 	<string name="title_confirm_delete">Konfirmasi penghapusan</string>
 	<string name="msg_confirm_delete">Apakah Anda yakin ingin menghapus:\n%s?</string>


### PR DESCRIPTION
Follow-up to #1703. Fixes [ADFA-5223](https://appdevforall.atlassian.net/browse/ADFA-5223).

The Indonesian localization rendered the Android term **"resource" as "sumber"**, which means *source*. The correct term is **"sumber daya"** — what Google's own Indonesian Android documentation uses. `Sumber` alone is only right for *source* in the source-code / open-source sense.

Six user-facing strings, 6 lines across 3 files. Five came in with #1703; `new_xml_resource` is pre-existing.

| File | Key | Before | After |
|---|---|---|---|
| `app/…/values-in/strings.xml` | `msg_strings_injection_failed` | Gagal memperbarui **sumber** string… | …**sumber daya** string… |
| | `msg_strings_injection_file_not_found` | …file **sumber** string proyek. | …file **sumber daya** string proyek. |
| | `msg_strings_injection_invalid_xml` | **Sumber** string yang dihasilkan… | **Sumber daya** string yang dihasilkan… |
| | `msg_strings_injection_parser_unsupported` | …memperbarui **sumber** string… | …memperbarui **sumber daya** string… |
| `apk-viewer-plugin/…/values-in/strings.xml` | `section_resource_directories` | Direktori **Sumber** (%d) | Direktori **Sumber Daya** (%d) |
| `resources/…/values-in-rID/strings.xml` | `new_xml_resource` | **Sumber** XML baru | **Sumber daya** XML baru |

## Deliberately not changed

`sumber` is correct in these — they really do mean *source*:

- `idepref_java_diagnosticsEnabled_summary` — "file sumber Java" (Java **source** files)
- `title_open_source_licenses` / `summary_open_source_licenses` — "sumber terbuka" (**open source**)
- `view_source` (markdown-preview-plugin) — "Sumber" (view **source**)

## Verification

Each changed value was round-tripped back to English through **both** Gemini and Google Cloud Translate.

Before — both engines independently returned *source*:

```
section_resource_directories
  EN  : Resource Directories (%d)
  ID  : Direktori Sumber (%d)
  gem : Source Directories (%d)
  goog: Source Directory (%d)
```

After — both return *resource*:

```
section_resource_directories
  EN  : Resource Directories (%d)
  ID  : Direktori Sumber Daya (%d)
  gem : Resource Directories (%d)
  goog: Resource Directory (%d)

msg_strings_injection_failed
  EN  : Failed to update generated string resources.
  ID  : Gagal memperbarui sumber daya string yang dihasilkan.
  gem : Failed to update generated string resources.
  goog: Failed to update the generated string resource.
```

All six now back-translate as "resource"; three return the English source verbatim.

Also checked: `%d` / `%1$s` placeholders intact, all three files parse as well-formed XML, and the three legitimate `sumber` uses above are untouched.

No UI layout change — text-only, and the replacement is two words where there was one, so no new truncation risk beyond what the English already has. Not separately re-verified at 2x font scale for that reason.


[ADFA-5223]: https://appdevforall.atlassian.net/browse/ADFA-5223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ