### PR TITLE
ADFA-5401: Guard the shared tree-sitter query

### DIFF
--- a/editor-api/src/main/java/com/itsaky/androidide/treesitter/api/tsUtils.kt
+++ b/editor-api/src/main/java/com/itsaky/androidide/treesitter/api/tsUtils.kt
@@ -35,53 +35,53 @@ internal val log = LoggerFactory.getLogger("TsUtilsKt")
  * This method does not close the [TSQueryCursor] instance.
  */
 inline fun <ResultT> TSQueryCursor.safeExecQueryCursor(
-  query: TSQuery,
-  tree: TSTree?,
-  recycleNodeAfterUse: Boolean = true,
-  crossinline matchCondition: (TSQueryMatch?) -> Boolean = { true },
-  crossinline whileTrue: (TSQueryMatch?) -> Boolean = { true },
-  crossinline onClosedOrEdited: () -> Unit = {},
-  debugName: String = "",
-  debugLogging: Boolean = false,
-  crossinline action: (TSQueryMatch) -> ResultT
+query: TSQuery,
+tree: TSTree?,
+recycleNodeAfterUse: Boolean = true,
+crossinline matchCondition: (TSQueryMatch?) -> Boolean = { true },
+crossinline whileTrue: (TSQueryMatch?) -> Boolean = { true },
+crossinline onClosedOrEdited: () -> Unit = {},
+debugName: String = "",
+debugLogging: Boolean = false,
+crossinline action: (TSQueryMatch) -> ResultT
 ): ResultT? {
 
-  if (tree == null || !tree.canAccess()) {
-    if (debugLogging) {
-      log.debug("$debugName: Cannot execute query, tree is null or not accessible", "tree=$tree",
-        "tree.canAccess=${tree?.canAccess()}")
-    }
-    return null
-  }
+if (tree == null || !tree.canAccess()) {
+	if (debugLogging) {
+	log.debug("$debugName: Cannot execute query, tree is null or not accessible", "tree=$tree",
+		"tree.canAccess=${tree?.canAccess()}")
+	}
+	return null
+}
 
-  val rootNode = tree.rootNode
-  if (!rootNode.canAccess() || rootNode.hasChanges()) {
-    if (debugLogging) {
-      log.debug(
-        "$debugName, Cannot execute query, tree's root node is not accessible or has been edited",
-        "rootNode=$rootNode", "rootNode.canAccess=${rootNode.canAccess()}",
-        "rootNode.hasChanges=${rootNode.canAccess() && rootNode.hasChanges()}")
-    }
-    return null
-  }
+val rootNode = tree.rootNode
+if (!rootNode.canAccess() || rootNode.hasChanges()) {
+	if (debugLogging) {
+	log.debug(
+		"$debugName, Cannot execute query, tree's root node is not accessible or has been edited",
+		"rootNode=$rootNode", "rootNode.canAccess=${rootNode.canAccess()}",
+		"rootNode.hasChanges=${rootNode.canAccess() && rootNode.hasChanges()}")
+	}
+	return null
+}
 
-  return safeExecQueryCursor(
-    query = query,
-    node = rootNode,
-    recycleNodeAfterUse = recycleNodeAfterUse,
-    matchCondition = {
-      val result = tree.canAccess() && matchCondition(it)
-      if (!result && debugLogging) {
-        log.debug("$debugName: tree.canAccess=${tree.canAccess()}")
-      }
-      result
-    },
-    whileTrue = whileTrue,
-    onClosedOrEdited = onClosedOrEdited,
-    debugName = debugName,
-    debugLogging = debugLogging,
-    action = action
-  )
+return safeExecQueryCursor(
+	query = query,
+	node = rootNode,
+	recycleNodeAfterUse = recycleNodeAfterUse,
+	matchCondition = {
+	val result = tree.canAccess() && matchCondition(it)
+	if (!result && debugLogging) {
+		log.debug("$debugName: tree.canAccess=${tree.canAccess()}")
+	}
+	result
+	},
+	whileTrue = whileTrue,
+	onClosedOrEdited = onClosedOrEdited,
+	debugName = debugName,
+	debugLogging = debugLogging,
+	action = action
+)
 }
 
 /**
@@ -92,95 +92,95 @@ inline fun <ResultT> TSQueryCursor.safeExecQueryCursor(
  * This method does not close the [TSQueryCursor] instance.
  */
 inline fun <ResultT> TSQueryCursor.safeExecQueryCursor(
-  query: TSQuery,
-  node: TSNode,
-  recycleNodeAfterUse: Boolean = true,
-  crossinline matchCondition: (TSQueryMatch?) -> Boolean = { true },
-  crossinline whileTrue: (TSQueryMatch?) -> Boolean = { true },
-  crossinline onClosedOrEdited: () -> Unit = {},
-  debugName: String = "",
-  debugLogging: Boolean = false,
-  crossinline action: (TSQueryMatch) -> ResultT
+query: TSQuery,
+node: TSNode,
+recycleNodeAfterUse: Boolean = true,
+crossinline matchCondition: (TSQueryMatch?) -> Boolean = { true },
+crossinline whileTrue: (TSQueryMatch?) -> Boolean = { true },
+crossinline onClosedOrEdited: () -> Unit = {},
+debugName: String = "",
+debugLogging: Boolean = false,
+crossinline action: (TSQueryMatch) -> ResultT
 ): ResultT? {
 
-  return doSafeExecQueryCursor(
-    query = query,
-    node = node,
-    recycleNodeAfterUse = recycleNodeAfterUse,
-    matchCondition = { match ->
-      match != null && canAccess() && node.canAccess() && !node.hasChanges() && matchCondition(
-        match)
-    },
-    whileTrue = whileTrue,
-    onClosedOrEdited = onClosedOrEdited,
-    debugName = debugName,
-    debugLogging = debugLogging,
-    action = action)
+return doSafeExecQueryCursor(
+	query = query,
+	node = node,
+	recycleNodeAfterUse = recycleNodeAfterUse,
+	matchCondition = { match ->
+	match != null && canAccess() && node.canAccess() && !node.hasChanges() && matchCondition(
+		match)
+	},
+	whileTrue = whileTrue,
+	onClosedOrEdited = onClosedOrEdited,
+	debugName = debugName,
+	debugLogging = debugLogging,
+	action = action)
 }
 
 @PublishedApi
 internal inline fun <ResultT> TSQueryCursor.doSafeExecQueryCursor(
-  query: TSQuery,
-  node: TSNode,
-  recycleNodeAfterUse: Boolean = true,
-  crossinline matchCondition: (TSQueryMatch?) -> Boolean,
-  crossinline whileTrue: (TSQueryMatch?) -> Boolean,
-  crossinline onClosedOrEdited: () -> Unit,
-  debugName: String = "",
-  debugLogging: Boolean = false,
-  crossinline action: (TSQueryMatch) -> ResultT
+query: TSQuery,
+node: TSNode,
+recycleNodeAfterUse: Boolean = true,
+crossinline matchCondition: (TSQueryMatch?) -> Boolean,
+crossinline whileTrue: (TSQueryMatch?) -> Boolean,
+crossinline onClosedOrEdited: () -> Unit,
+debugName: String = "",
+debugLogging: Boolean = false,
+crossinline action: (TSQueryMatch) -> ResultT
 ): ResultT? {
 
-  if (!query.canAccess()) {
-    if (debugLogging) {
-      log.debug("$debugName: Cannot execute query, query is not accessible")
-    }
-    return null
-  }
+if (!query.canAccess()) {
+	if (debugLogging) {
+	log.debug("$debugName: Cannot execute query, query is not accessible")
+	}
+	return null
+}
 
-  if (!node.canAccess() || node.hasChanges()) {
-    if (debugLogging) {
-      log.debug("$debugName: Cannot execute query, node is not accessible or has been edited",
-        "node.canAccess=${node.canAccess()}",
-        "node.hasChanges=${node.canAccess() && node.hasChanges()}")
-    }
-    return null
-  }
+if (!node.canAccess() || node.hasChanges()) {
+	if (debugLogging) {
+	log.debug("$debugName: Cannot execute query, node is not accessible or has been edited",
+		"node.canAccess=${node.canAccess()}",
+		"node.hasChanges=${node.canAccess() && node.hasChanges()}")
+	}
+	return null
+}
 
-  exec(query, node)
-  var match = nextMatch()
-  while (matchCondition(match) && whileTrue(match)) {
+exec(query, node)
+var match = nextMatch()
+while (matchCondition(match) && whileTrue(match)) {
 
-    val result = action(match)
+	val result = action(match)
 
-    if (!matchCondition(match)) {
-      if (debugLogging) {
-        log.debug(
-          "$debugName: Cannot proceed with query operation.",
-          "cursor.canAccess=${canAccess()}",
-          "query.canAccess=${query.canAccess()}",
-          "node.canAccess=${node.canAccess()}",
-          "node.hasChanges=${node.canAccess() && node.hasErrors()}"
-        )
-      }
-      onClosedOrEdited()
-      break
-    }
+	if (!matchCondition(match)) {
+	if (debugLogging) {
+		log.debug(
+		"$debugName: Cannot proceed with query operation.",
+		"cursor.canAccess=${canAccess()}",
+		"query.canAccess=${query.canAccess()}",
+		"node.canAccess=${node.canAccess()}",
+		"node.hasChanges=${node.canAccess() && node.hasErrors()}"
+		)
+	}
+	onClosedOrEdited()
+	break
+	}
 
-    (match as? TreeSitterQueryMatch?)?.recycle()
+	(match as? TreeSitterQueryMatch?)?.recycle()
 
-    // if the action does not produce any output and simply returns Unit (void)
-    // then ignore the result and continue with the capture
-    if (result != Unit && result != null) {
-      return result
-    }
+	// if the action does not produce any output and simply returns Unit (void)
+	// then ignore the result and continue with the capture
+	if (result != Unit && result != null) {
+	return result
+	}
 
-    match = nextMatch()
-  }
+	match = nextMatch()
+}
 
-  if (recycleNodeAfterUse && node is TreeSitterNode && !node.isRecycled) {
-    node.recycle()
-  }
+if (recycleNodeAfterUse && node is TreeSitterNode && !node.isRecycled) {
+	node.recycle()
+}
 
-  return null
+return null
 }

--- a/editor-api/src/main/java/com/itsaky/androidide/treesitter/api/tsUtils.kt
+++ b/editor-api/src/main/java/com/itsaky/androidide/treesitter/api/tsUtils.kt
@@ -108,8 +108,12 @@ return doSafeExecQueryCursor(
 	node = node,
 	recycleNodeAfterUse = recycleNodeAfterUse,
 	matchCondition = { match ->
-	match != null && canAccess() && node.canAccess() && !node.hasChanges() && matchCondition(
-		match)
+	// query.canAccess() belongs here, not only in the pre-loop check below: the query is shared
+	// between the analyzer, the span generator and the bracket matcher, and whoever frees it does
+	// so on another thread. Without it, a free landing mid-loop makes the next nextMatch()
+	// dereference a dangling TSQuery and take the process down (ADFA-5401).
+	match != null && canAccess() && query.canAccess() && node.canAccess() && !node.hasChanges() &&
+		matchCondition(match)
 	},
 	whileTrue = whileTrue,
 	onClosedOrEdited = onClosedOrEdited,

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
@@ -71,6 +71,7 @@ import kotlinx.coroutines.launch
 import java.util.TreeMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -94,6 +95,9 @@ class LineSpansGenerator(
 	companion object {
 		const val CACHE_THRESHOLD = 100
 		const val TAG = "LineSpansGenerator"
+
+		/** Upper bound on waiting for an in-flight query when tearing the generator down. */
+		private const val SHUTDOWN_TIMEOUT_MS = 500L
 
 		/**
 		 * Delay in milliseconds to batch UI redraws, preventing frame drops
@@ -145,6 +149,17 @@ class LineSpansGenerator(
 
 		tsExecutor.execute { runCatching { tree.close() } }
 		tsExecutor.shutdown()
+
+		// The shared TSQuery is freed on the main thread immediately after this returns
+		// (TSLanguageRegistry.destroy -> TsLanguageSpec.close), and captureRegion guards only the
+		// tree, not the query. Draining the executor first is what makes "no query is running" true
+		// rather than merely likely - a capture measures well under a millisecond, so the timeout is
+		// a safety valve, not a wait (ADFA-5401).
+		runCatching {
+			if (!tsExecutor.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+				Log.w(TAG, "Tree-sitter query executor did not drain within $SHUTDOWN_TIMEOUT_MS ms")
+			}
+		}.onFailure { Thread.currentThread().interrupt() }
 	}
 
 	fun captureRegion(

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
@@ -13,9 +13,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
- *
- * -----------------------------------------------------------------------------
- *
+ */
+
+/*******************************************************************************
  *    sora-editor - the awesome code editor for Android
  *    https://github.com/Rosemoe/sora-editor
  *    Copyright (C) 2020-2023  Rosemoe
@@ -37,7 +37,9 @@
  *
  *     Please contact Rosemoe by email 2073412493@qq.com if you need
  *     additional information or have any questions
- */
+ ******************************************************************************/
+
+@file:Suppress("ktlint:standard:kdoc", "ktlint:standard:no-consecutive-comments")
 
 package io.github.rosemoe.sora.editor.ts
 
@@ -71,7 +73,6 @@ import kotlinx.coroutines.launch
 import java.util.TreeMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -95,9 +96,6 @@ class LineSpansGenerator(
 	companion object {
 		const val CACHE_THRESHOLD = 100
 		const val TAG = "LineSpansGenerator"
-
-		/** Upper bound on waiting for an in-flight query when tearing the generator down. */
-		private const val SHUTDOWN_TIMEOUT_MS = 500L
 
 		/**
 		 * Delay in milliseconds to batch UI redraws, preventing frame drops
@@ -136,10 +134,10 @@ class LineSpansGenerator(
 		}
 	}
 
-/**
-* Queues the native tree destruction in the background
-* so it doesn't close while a query is running.
-*/
+	/**
+	 * Queues the native tree destruction in the background
+	 * so it doesn't close while a query is running.
+	 */
 	fun destroy() {
 		scope.cancel()
 		caches.evictAll()
@@ -149,17 +147,6 @@ class LineSpansGenerator(
 
 		tsExecutor.execute { runCatching { tree.close() } }
 		tsExecutor.shutdown()
-
-		// The shared TSQuery is freed on the main thread immediately after this returns
-		// (TSLanguageRegistry.destroy -> TsLanguageSpec.close), and captureRegion guards only the
-		// tree, not the query. Draining the executor first is what makes "no query is running" true
-		// rather than merely likely - a capture measures well under a millisecond, so the timeout is
-		// a safety valve, not a wait (ADFA-5401).
-		runCatching {
-			if (!tsExecutor.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-				Log.w(TAG, "Tree-sitter query executor did not drain within $SHUTDOWN_TIMEOUT_MS ms")
-			}
-		}.onFailure { Thread.currentThread().interrupt() }
 	}
 
 	fun captureRegion(

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
@@ -13,9 +13,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
- */
-
-/*******************************************************************************
+ *
+ * -----------------------------------------------------------------------------
+ *
  *    sora-editor - the awesome code editor for Android
  *    https://github.com/Rosemoe/sora-editor
  *    Copyright (C) 2020-2023  Rosemoe
@@ -37,7 +37,7 @@
  *
  *     Please contact Rosemoe by email 2073412493@qq.com if you need
  *     additional information or have any questions
- ******************************************************************************/
+ */
 
 package io.github.rosemoe.sora.editor.ts
 
@@ -45,6 +45,8 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.util.LruCache
+import com.itsaky.androidide.plugins.extensions.DecorationSpan
+import com.itsaky.androidide.syntax.decoration.EditorDecorationRegistry
 import com.itsaky.androidide.treesitter.TSInputEdit
 import com.itsaky.androidide.treesitter.TSQueryCapture
 import com.itsaky.androidide.treesitter.TSQueryCursor
@@ -61,14 +63,12 @@ import io.github.rosemoe.sora.lang.styling.span.SpanExtAttrs
 import io.github.rosemoe.sora.text.CharPosition
 import io.github.rosemoe.sora.text.Content
 import io.github.rosemoe.sora.widget.schemes.EditorColorScheme
-import com.itsaky.androidide.plugins.extensions.DecorationSpan
-import com.itsaky.androidide.syntax.decoration.EditorDecorationRegistry
-import java.util.TreeMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import java.util.TreeMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
@@ -81,380 +81,430 @@ import java.util.concurrent.atomic.AtomicInteger
  *
  * @author Rosemoe
  */
-class LineSpansGenerator(internal var tree: TSTree, internal var lineCount: Int,
-  private val content: Content, internal var theme: TsTheme,
-  private val languageSpec: TsLanguageSpec, var scopedVariables: TsScopedVariables,
-  private val spanFactory: TsSpanFactory, private val requestRedraw: () -> Unit) : Spans {
+class LineSpansGenerator(
+	internal var tree: TSTree,
+	internal var lineCount: Int,
+	private val content: Content,
+	internal var theme: TsTheme,
+	private val languageSpec: TsLanguageSpec,
+	var scopedVariables: TsScopedVariables,
+	private val spanFactory: TsSpanFactory,
+	private val requestRedraw: () -> Unit,
+) : Spans {
+	companion object {
+		const val CACHE_THRESHOLD = 100
+		const val TAG = "LineSpansGenerator"
 
-  companion object {
+		/**
+		 * Delay in milliseconds to batch UI redraws, preventing frame drops
+		 * when rapidly calculating multiple lines.
+		 */
+		const val REDRAW_DEBOUNCE_DELAY_MS = 32L
+	}
 
-    const val CACHE_THRESHOLD = 100
-    const val TAG = "LineSpansGenerator"
-    /**
-     * Delay in milliseconds to batch UI redraws, preventing frame drops
-     * when rapidly calculating multiple lines.
-     */
-    const val REDRAW_DEBOUNCE_DELAY_MS = 32L
-  }
+/**
+* Thread-safe cache for calculated line spans.
+* Automatically evicts the least recently used lines.
+*/
+	private val caches = LruCache<Int, MutableList<Span>>(CACHE_THRESHOLD)
+	private val calculatingLines = ConcurrentHashMap.newKeySet<Int>()
 
-  /**
-   * Thread-safe cache for calculated line spans.
-   * Automatically evicts the least recently used lines.
-   */
-  private val caches = LruCache<Int, MutableList<Span>>(CACHE_THRESHOLD)
-  private val calculatingLines = ConcurrentHashMap.newKeySet<Int>()
+	private val tsExecutor =
+		Executors.newSingleThreadExecutor { r ->
+			Thread(r, "TreeSitterWorker")
+		}
+	private val tsDispatcher = tsExecutor.asCoroutineDispatcher()
+	private val scope = CoroutineScope(SupervisorJob() + tsDispatcher)
 
-  private val tsExecutor = Executors.newSingleThreadExecutor { r ->
-    Thread(r, "TreeSitterWorker")
-  }
-  private val tsDispatcher = tsExecutor.asCoroutineDispatcher()
-  private val scope = CoroutineScope(SupervisorJob() + tsDispatcher)
+/**
+* Tracks content changes so the worker can instantly abort
+* outdated calculations when the user types.
+*/
+	private val contentVersion = AtomicInteger(0)
+	private val mainHandler = Handler(Looper.getMainLooper())
+	private var isRefreshScheduled = AtomicBoolean(false)
 
-  /**
-   * Tracks content changes so the worker can instantly abort
-   * outdated calculations when the user types.
-   */
-  private val contentVersion = AtomicInteger(0)
-  private val mainHandler = Handler(Looper.getMainLooper())
-  private var isRefreshScheduled = AtomicBoolean(false)
+	fun edit(edit: TSInputEdit) {
+		contentVersion.incrementAndGet()
+		scope.launch {
+			tree.edit(edit)
+			calculatingLines.clear()
+		}
+	}
 
-  fun edit(edit: TSInputEdit) {
-    contentVersion.incrementAndGet()
-    scope.launch {
-      tree.edit(edit)
-      calculatingLines.clear()
-    }
-  }
+/**
+* Queues the native tree destruction in the background
+* so it doesn't close while a query is running.
+*/
+	fun destroy() {
+		scope.cancel()
+		caches.evictAll()
+		calculatingLines.clear()
 
-  /**
-   * Queues the native tree destruction in the background
-   * so it doesn't close while a query is running.
-   */
-  fun destroy() {
-    scope.cancel()
-    caches.evictAll()
-    calculatingLines.clear()
+		mainHandler.removeCallbacksAndMessages(null)
 
-    mainHandler.removeCallbacksAndMessages(null)
+		tsExecutor.execute { runCatching { tree.close() } }
+		tsExecutor.shutdown()
+	}
 
-    tsExecutor.execute { runCatching { tree.close() } }
-    tsExecutor.shutdown()
-  }
+	fun captureRegion(
+		startIndex: Int,
+		endIndex: Int,
+	): MutableList<Span> {
+		val list = mutableListOf<Span>()
 
-  fun captureRegion(startIndex: Int, endIndex: Int): MutableList<Span> {
-    val list = mutableListOf<Span>()
+		if (!tree.canAccess() || tree.rootNode.hasChanges()) {
+			list.add(emptySpan(0))
+			return list
+		}
 
-    if (!tree.canAccess() || tree.rootNode.hasChanges()) {
-      list.add(emptySpan(0))
-      return list
-    }
+		val captures = mutableListOf<TSQueryCapture>()
 
-    val captures = mutableListOf<TSQueryCapture>()
+		TSQueryCursor.create().use { cursor ->
+			cursor.setByteRange(startIndex * 2, endIndex * 2)
 
-    TSQueryCursor.create().use { cursor ->
-      cursor.setByteRange(startIndex * 2, endIndex * 2)
-
-      cursor.safeExecQueryCursor(query = languageSpec.tsQuery, tree = tree,
-        recycleNodeAfterUse = true, debugLogging = false,
-        debugName = "LineSpansGenerator.captureRegion()") { match ->
-        if (languageSpec.queryPredicator.doPredicate(languageSpec.predicates, content, match)) {
-          captures.addAll(match.captures)
-        }
-      }
-
-      captures.sortBy { it.node.startByte }
-      var lastIndex = 0
-
-      for (capture in captures) {
-        val startByte = capture.node.startByte
-        val endByte = capture.node.endByte
-        val start = (startByte / 2 - startIndex).coerceAtLeast(0)
-        val pattern = capture.index
-        // Do not add span for overlapping regions and out-of-bounds regions
-        if (start >= lastIndex && endByte / 2 >= startIndex && startByte / 2 < endIndex && (pattern !in languageSpec.localsScopeIndices && pattern !in languageSpec.localsDefinitionIndices && pattern !in languageSpec.localsDefinitionValueIndices && pattern !in languageSpec.localsMembersScopeIndices)) {
-          if (start != lastIndex) {
-            list.addAll(createSpans(capture, lastIndex, start - 1, theme.normalTextStyle))
-          }
-          var style = 0L
-          if (capture.index in languageSpec.localsReferenceIndices) {
-            val def = scopedVariables.findDefinition(startByte / 2, endByte / 2,
-              content.substring(startByte / 2, endByte / 2))
-            if (def != null && def.matchedHighlightPattern != -1) {
-              style = theme.resolveStyleForPattern(def.matchedHighlightPattern)
-            }
-            // This reference can not be resolved to its definition
-            // but it can have its own fallback color by other captures
-            // so continue to next capture
-            if (style == 0L) {
-              continue
-            }
-          }
-          if (style == 0L) {
-            style = theme.resolveStyleForPattern(capture.index)
-          }
-          if (style == 0L) {
-            style = theme.normalTextStyle
-          }
-          val end = (endByte / 2 - startIndex).coerceAtMost(endIndex)
-          list.addAll(createSpans(capture, start, end, style))
-          lastIndex = end
-        }
-
-        (capture as? TreeSitterQueryCapture?)?.recycle()
-      }
-
-      if (lastIndex != endIndex) {
-        list.add(emptySpan(lastIndex))
-      }
-    }
-    if (list.isEmpty()) {
-      list.add(emptySpan(0))
-    }
-    return applyDecorations(list, startIndex, endIndex)
-  }
-
-  // ---------------------------------------------------------------------------
-  // Plugin editor decorations
-  //
-  // After the base (tree-sitter) spans for a region are built, every registered
-  // EditorDecorationProvider is given the region and returns additive, foreground-only color
-  // spans, which are merged in here. The IDE is feature-agnostic — it knows nothing about what a
-  // provider decorates (brackets, indent guides, markers, ...). Providers run on this analyze
-  // thread and receive the full document content so they can use context outside the region.
-  // ---------------------------------------------------------------------------
-
-  private fun applyDecorations(list: MutableList<Span>, startIndex: Int,
-    endIndex: Int): MutableList<Span> {
-    val providers = EditorDecorationRegistry.providers()
-    if (providers.isEmpty() || endIndex <= startIndex) return list
-
-    val isDark = EditorDecorationRegistry.isDark
-    var decorations: ArrayList<DecorationSpan>? = null
-    for (provider in providers) {
-      val spans = try {
-        provider.decorate(content, startIndex, endIndex, isDark)
-      } catch (t: Throwable) {
-        Log.e(TAG, "Editor decoration provider failed", t)
-        continue
-      }
-      if (spans.isEmpty()) continue
-      (decorations ?: ArrayList<DecorationSpan>().also { decorations = it }).addAll(spans)
-    }
-
-    val decos = decorations ?: return list
-    return mergeDecorations(list, startIndex, endIndex, decos)
-  }
-
-  /**
-   * Merges additive, foreground-only decoration spans into [list]: overrides only the foreground
-   * color of the covered characters while preserving every base style underneath, and keeps the
-   * strictly-ascending, non-overlapping span ordering the renderer requires. Decoration offsets are
-   * absolute; they are clipped to the region and converted to line-relative columns.
-   */
-  private fun mergeDecorations(list: MutableList<Span>, startIndex: Int, endIndex: Int,
-    decorations: List<DecorationSpan>): MutableList<Span> {
-    val lineLen = endIndex - startIndex
-
-    // Snapshot of the base styles, used to restore the original style after each decorated range.
-    val base = TreeMap<Int, Long>()
-    for (s in list) base.putIfAbsent(s.column, s.style)
-    val defaultStyle = TextStyle.makeStyle(EditorColorScheme.TEXT_NORMAL)
-    fun baseStyleAt(col: Int): Long = base.floorEntry(col)?.value ?: defaultStyle
-
-    val result = TreeMap<Int, Span>()
-    for (s in list) result.putIfAbsent(s.column, s)
-
-    for (d in decorations) {
-      val s = (d.start - startIndex).coerceAtLeast(0)
-      val e = (d.end - startIndex).coerceAtMost(lineLen)
-      if (e <= s) continue
-
-      // Override the foreground at the range start and at every span boundary inside it, so the
-      // color survives base-style changes within the range. Base style (bold/etc.) is preserved.
-      var coveredStart = false
-      for (col in result.subMap(s, true, e, false).keys.toList()) {
-        result[col] = coloredSpan(col, result[col]!!.style, d.argb)
-        if (col == s) coveredStart = true
-      }
-      if (!coveredStart) {
-        result[s] = coloredSpan(s, baseStyleAt(s), d.argb)
-      }
-      // Resume the underlying style right after the range, unless a span already begins there.
-      if (e < lineLen && !result.containsKey(e)) {
-        result[e] = SpanFactory.obtain(e, baseStyleAt(e))
-      }
-    }
-
-    return ArrayList(result.values)
-  }
-
-  private fun coloredSpan(column: Int, style: Long, argb: Int): Span {
-    val span = SpanFactory.obtain(column, style)
-    span.setSpanExt(SpanExtAttrs.EXT_COLOR_RESOLVER, SpanConstColorResolver(argb, 0))
-    return span
-  }
-
-  private fun createSpans(capture: TSQueryCapture, startColumn: Int, endColumn: Int,
-    style: Long): List<Span> {
-    val spans = spanFactory.createSpans(capture, startColumn, style)
-    if (spans.size > 1) {
-      var prevCol = spans[0].column
-      if (prevCol > endColumn) {
-        throw IndexOutOfBoundsException(
-          "Span's column is out of bounds! column=$prevCol, endColumn=$endColumn")
-      }
-      for (i in 1..spans.lastIndex) {
-        val col = spans[i].column
-        if (col <= prevCol) {
-          throw IllegalStateException("Spans must not overlap! prevCol=$prevCol, col=$col")
-        }
-        if (col > endColumn) {
-          throw IndexOutOfBoundsException(
-            "Span's column is out of bounds! column=$col, endColumn=$endColumn")
-        }
-        prevCol = col
-      }
-    }
-    return spans
-  }
-
-  private fun emptySpan(column: Int): Span {
-    return SpanFactory.obtain(column, TextStyle.makeStyle(EditorColorScheme.TEXT_NORMAL))
-  }
-
-  override fun adjustOnInsert(start: CharPosition, end: CharPosition) {
-    val lineDiff = end.line - start.line
-
-    if (lineDiff == 0) {
-      val colDiff = end.column - start.column
-      shiftSpansOnLine(start.line, start.column, colDiff)
-      return
-    }
-
-    rebuildCache { line, spans, cache ->
-      when {
-        line < start.line -> cache.put(line, spans)
-        line == start.line -> {
-          cache.put(line, spans)
-          cache.put(line + lineDiff, spans)
-        }
-        else -> cache.put(line + lineDiff, spans)
-      }
-    }
-  }
-
-  override fun adjustOnDelete(start: CharPosition, end: CharPosition) {
-    val lineDiff = end.line - start.line
-
-    if (lineDiff == 0) {
-      val colDiff = start.column - end.column
-      shiftSpansOnLine(start.line, end.column, colDiff)
-      return
-    }
-
-    rebuildCache { line, spans, cache ->
-      when {
-        line < start.line -> cache.put(line, spans)
-        line == start.line -> cache.put(line, spans)
-        line > end.line -> cache.put(line - lineDiff, spans)
-      }
-    }
-  }
-
-  /**
-   * Shifts span columns horizontally to prevent visual flickering during inline edits.
-   *
-   * @param line Line index of the modification.
-   * @param startColumn Column index where the shift begins.
-   * @param colDiff Number of columns to shift.
-   */
-  private fun shiftSpansOnLine(line: Int, startColumn: Int, colDiff: Int) {
-    caches.get(line)?.forEach { span ->
-      if (span.column >= startColumn) {
-        span.column += colDiff
-      }
-    }
-  }
-
-  /**
-   * Rebuilds the line cache for vertical text shifts (line additions or deletions).
-   *
-   * @param action Logic to determine how each cached line is re-inserted.
-   */
-  private inline fun rebuildCache(action: (line: Int, spans: MutableList<Span>, cache: LruCache<Int, MutableList<Span>>) -> Unit) {
-    val snapshot = caches.snapshot()
-    caches.evictAll()
-
-    for ((line, spans) in snapshot) {
-      action(line, spans, caches)
-    }
-  }
-
-  override fun read() = object : Spans.Reader {
-
-    private var spans = mutableListOf<Span>()
-
-    override fun moveToLine(line: Int) {
-      spans = getSpansForLine(line)
-    }
-
-    override fun getSpanCount() = spans.size
-
-    override fun getSpanAt(index: Int) = spans[index]
-    override fun getSpansOnLine(line: Int): MutableList<Span> = getSpansForLine(line)
-
-    private fun getSpansForLine(line: Int): MutableList<Span> {
-      if (line !in 0..<lineCount) return mutableListOf()
-
-      caches.get(line)?.let { return it }
-
-      if (!calculatingLines.add(line)) return mutableListOf(emptySpan(0))
-
-      val requestedVersion = contentVersion.get()
-
-      scope.launch {
-        try {
-          if (requestedVersion != contentVersion.get()) return@launch
-
-          val start = content.indexer.getCharPosition(line, 0).index
-          val end = start + content.getColumnCount(line)
-
-          val resultSpans = captureRegion(start, end)
-
-          if (requestedVersion == contentVersion.get()) {
-            caches.put(line, resultSpans)
-            scheduleRefresh()
-          }
-        } catch (e: Exception) {
-          Log.e(TAG, "Error processing spans for line $line", e)
-          e.printStackTrace()
-        } finally {
-          calculatingLines.remove(line)
-        }
+			cursor.safeExecQueryCursor(
+				query = languageSpec.tsQuery,
+				tree = tree,
+				recycleNodeAfterUse = true,
+				debugLogging = false,
+				debugName = "LineSpansGenerator.captureRegion()",
+			) { match ->
+				if (languageSpec.queryPredicator.doPredicate(languageSpec.predicates, content, match)) {
+					captures.addAll(match.captures)
+				}
 			}
-			return mutableListOf(emptySpan(0))
-    }
 
-  }
+			captures.sortBy { it.node.startByte }
+			var lastIndex = 0
 
-  /**
-   * Groups redraw requests together to avoid overloading the UI thread.
-   */
-  private fun scheduleRefresh() {
-    if (!isRefreshScheduled.compareAndSet(false, true)) return
+			for (capture in captures) {
+				val startByte = capture.node.startByte
+				val endByte = capture.node.endByte
+				val start = (startByte / 2 - startIndex).coerceAtLeast(0)
+				val pattern = capture.index
+				// Do not add span for overlapping regions and out-of-bounds regions
+				if (start >= lastIndex && endByte / 2 >= startIndex && startByte / 2 < endIndex &&
+					(
+						pattern !in languageSpec.localsScopeIndices && pattern !in languageSpec.localsDefinitionIndices &&
+							pattern !in languageSpec.localsDefinitionValueIndices &&
+							pattern !in languageSpec.localsMembersScopeIndices
+					)
+				) {
+					if (start != lastIndex) {
+						list.addAll(createSpans(capture, lastIndex, start - 1, theme.normalTextStyle))
+					}
+					var style = 0L
+					if (capture.index in languageSpec.localsReferenceIndices) {
+						val def =
+							scopedVariables.findDefinition(
+								startByte / 2,
+								endByte / 2,
+								content.substring(startByte / 2, endByte / 2),
+							)
+						if (def != null && def.matchedHighlightPattern != -1) {
+							style = theme.resolveStyleForPattern(def.matchedHighlightPattern)
+						}
+						// This reference can not be resolved to its definition
+						// but it can have its own fallback color by other captures
+						// so continue to next capture
+						if (style == 0L) {
+							continue
+						}
+					}
+					if (style == 0L) {
+						style = theme.resolveStyleForPattern(capture.index)
+					}
+					if (style == 0L) {
+						style = theme.normalTextStyle
+					}
+					val end = (endByte / 2 - startIndex).coerceAtMost(endIndex)
+					list.addAll(createSpans(capture, start, end, style))
+					lastIndex = end
+				}
 
-    mainHandler.postDelayed({
-      isRefreshScheduled.set(false)
-      requestRedraw()
-      Log.d(TAG, "Refreshing UI with newly processed lines")
-    }, REDRAW_DEBOUNCE_DELAY_MS)
-  }
+				(capture as? TreeSitterQueryCapture?)?.recycle()
+			}
 
-  override fun supportsModify() = false
+			if (lastIndex != endIndex) {
+				list.add(emptySpan(lastIndex))
+			}
+		}
+		if (list.isEmpty()) {
+			list.add(emptySpan(0))
+		}
+		return applyDecorations(list, startIndex, endIndex)
+	}
 
-  override fun modify(): Spans.Modifier {
-    throw UnsupportedOperationException()
-  }
+// ---------------------------------------------------------------------------
+// Plugin editor decorations
+//
+// After the base (tree-sitter) spans for a region are built, every registered
+// EditorDecorationProvider is given the region and returns additive, foreground-only color
+// spans, which are merged in here. The IDE is feature-agnostic — it knows nothing about what a
+// provider decorates (brackets, indent guides, markers, ...). Providers run on this analyze
+// thread and receive the full document content so they can use context outside the region.
+// ---------------------------------------------------------------------------
 
-  override fun getLineCount() = lineCount
+	private fun applyDecorations(
+		list: MutableList<Span>,
+		startIndex: Int,
+		endIndex: Int,
+	): MutableList<Span> {
+		val providers = EditorDecorationRegistry.providers()
+		if (providers.isEmpty() || endIndex <= startIndex) return list
+
+		val isDark = EditorDecorationRegistry.isDark
+		var decorations: ArrayList<DecorationSpan>? = null
+		for (provider in providers) {
+			val spans =
+				try {
+					provider.decorate(content, startIndex, endIndex, isDark)
+				} catch (t: Throwable) {
+					Log.e(TAG, "Editor decoration provider failed", t)
+					continue
+				}
+			if (spans.isEmpty()) continue
+			(decorations ?: ArrayList<DecorationSpan>().also { decorations = it }).addAll(spans)
+		}
+
+		val decos = decorations ?: return list
+		return mergeDecorations(list, startIndex, endIndex, decos)
+	}
+
+/**
+* Merges additive, foreground-only decoration spans into [list]: overrides only the foreground
+* color of the covered characters while preserving every base style underneath, and keeps the
+* strictly-ascending, non-overlapping span ordering the renderer requires. Decoration offsets are
+* absolute; they are clipped to the region and converted to line-relative columns.
+*/
+	private fun mergeDecorations(
+		list: MutableList<Span>,
+		startIndex: Int,
+		endIndex: Int,
+		decorations: List<DecorationSpan>,
+	): MutableList<Span> {
+		val lineLen = endIndex - startIndex
+
+		// Snapshot of the base styles, used to restore the original style after each decorated range.
+		val base = TreeMap<Int, Long>()
+		for (s in list) base.putIfAbsent(s.column, s.style)
+		val defaultStyle = TextStyle.makeStyle(EditorColorScheme.TEXT_NORMAL)
+
+		fun baseStyleAt(col: Int): Long = base.floorEntry(col)?.value ?: defaultStyle
+
+		val result = TreeMap<Int, Span>()
+		for (s in list) result.putIfAbsent(s.column, s)
+
+		for (d in decorations) {
+			val s = (d.start - startIndex).coerceAtLeast(0)
+			val e = (d.end - startIndex).coerceAtMost(lineLen)
+			if (e <= s) continue
+
+			// Override the foreground at the range start and at every span boundary inside it, so the
+			// color survives base-style changes within the range. Base style (bold/etc.) is preserved.
+			var coveredStart = false
+			for (col in result.subMap(s, true, e, false).keys.toList()) {
+				result[col] = coloredSpan(col, result[col]!!.style, d.argb)
+				if (col == s) coveredStart = true
+			}
+			if (!coveredStart) {
+				result[s] = coloredSpan(s, baseStyleAt(s), d.argb)
+			}
+			// Resume the underlying style right after the range, unless a span already begins there.
+			if (e < lineLen && !result.containsKey(e)) {
+				result[e] = SpanFactory.obtain(e, baseStyleAt(e))
+			}
+		}
+
+		return ArrayList(result.values)
+	}
+
+	private fun coloredSpan(
+		column: Int,
+		style: Long,
+		argb: Int,
+	): Span {
+		val span = SpanFactory.obtain(column, style)
+		span.setSpanExt(SpanExtAttrs.EXT_COLOR_RESOLVER, SpanConstColorResolver(argb, 0))
+		return span
+	}
+
+	private fun createSpans(
+		capture: TSQueryCapture,
+		startColumn: Int,
+		endColumn: Int,
+		style: Long,
+	): List<Span> {
+		val spans = spanFactory.createSpans(capture, startColumn, style)
+		if (spans.size > 1) {
+			var prevCol = spans[0].column
+			if (prevCol > endColumn) {
+				throw IndexOutOfBoundsException("Span's column is out of bounds! column=$prevCol, endColumn=$endColumn")
+			}
+			for (i in 1..spans.lastIndex) {
+				val col = spans[i].column
+				if (col <= prevCol) {
+					throw IllegalStateException("Spans must not overlap! prevCol=$prevCol, col=$col")
+				}
+				if (col > endColumn) {
+					throw IndexOutOfBoundsException("Span's column is out of bounds! column=$col, endColumn=$endColumn")
+				}
+				prevCol = col
+			}
+		}
+		return spans
+	}
+
+	private fun emptySpan(column: Int): Span = SpanFactory.obtain(column, TextStyle.makeStyle(EditorColorScheme.TEXT_NORMAL))
+
+	override fun adjustOnInsert(
+		start: CharPosition,
+		end: CharPosition,
+	) {
+		val lineDiff = end.line - start.line
+
+		if (lineDiff == 0) {
+			val colDiff = end.column - start.column
+			shiftSpansOnLine(start.line, start.column, colDiff)
+			return
+		}
+
+		rebuildCache { line, spans, cache ->
+			when {
+				line < start.line -> {
+					cache.put(line, spans)
+				}
+
+				line == start.line -> {
+					cache.put(line, spans)
+					cache.put(line + lineDiff, spans)
+				}
+
+				else -> {
+					cache.put(line + lineDiff, spans)
+				}
+			}
+		}
+	}
+
+	override fun adjustOnDelete(
+		start: CharPosition,
+		end: CharPosition,
+	) {
+		val lineDiff = end.line - start.line
+
+		if (lineDiff == 0) {
+			val colDiff = start.column - end.column
+			shiftSpansOnLine(start.line, end.column, colDiff)
+			return
+		}
+
+		rebuildCache { line, spans, cache ->
+			when {
+				line < start.line -> cache.put(line, spans)
+				line == start.line -> cache.put(line, spans)
+				line > end.line -> cache.put(line - lineDiff, spans)
+			}
+		}
+	}
+
+/**
+* Shifts span columns horizontally to prevent visual flickering during inline edits.
+*
+* @param line Line index of the modification.
+* @param startColumn Column index where the shift begins.
+* @param colDiff Number of columns to shift.
+*/
+	private fun shiftSpansOnLine(
+		line: Int,
+		startColumn: Int,
+		colDiff: Int,
+	) {
+		caches.get(line)?.forEach { span ->
+			if (span.column >= startColumn) {
+				span.column += colDiff
+			}
+		}
+	}
+
+/**
+* Rebuilds the line cache for vertical text shifts (line additions or deletions).
+*
+* @param action Logic to determine how each cached line is re-inserted.
+*/
+	private inline fun rebuildCache(action: (line: Int, spans: MutableList<Span>, cache: LruCache<Int, MutableList<Span>>) -> Unit) {
+		val snapshot = caches.snapshot()
+		caches.evictAll()
+
+		for ((line, spans) in snapshot) {
+			action(line, spans, caches)
+		}
+	}
+
+	override fun read() =
+		object : Spans.Reader {
+			private var spans = mutableListOf<Span>()
+
+			override fun moveToLine(line: Int) {
+				spans = getSpansForLine(line)
+			}
+
+			override fun getSpanCount() = spans.size
+
+			override fun getSpanAt(index: Int) = spans[index]
+
+			override fun getSpansOnLine(line: Int): MutableList<Span> = getSpansForLine(line)
+
+			private fun getSpansForLine(line: Int): MutableList<Span> {
+				if (line !in 0..<lineCount) return mutableListOf()
+
+				caches.get(line)?.let { return it }
+
+				if (!calculatingLines.add(line)) return mutableListOf(emptySpan(0))
+
+				val requestedVersion = contentVersion.get()
+
+				scope.launch {
+					try {
+						if (requestedVersion != contentVersion.get()) return@launch
+
+						val start = content.indexer.getCharPosition(line, 0).index
+						val end = start + content.getColumnCount(line)
+
+						val resultSpans = captureRegion(start, end)
+
+						if (requestedVersion == contentVersion.get()) {
+							caches.put(line, resultSpans)
+							scheduleRefresh()
+						}
+					} catch (e: Exception) {
+						Log.e(TAG, "Error processing spans for line $line", e)
+						e.printStackTrace()
+					} finally {
+						calculatingLines.remove(line)
+					}
+				}
+				return mutableListOf(emptySpan(0))
+			}
+		}
+
+/**
+* Groups redraw requests together to avoid overloading the UI thread.
+*/
+	private fun scheduleRefresh() {
+		if (!isRefreshScheduled.compareAndSet(false, true)) return
+
+		mainHandler.postDelayed({
+			isRefreshScheduled.set(false)
+			requestRedraw()
+			Log.d(TAG, "Refreshing UI with newly processed lines")
+		}, REDRAW_DEBOUNCE_DELAY_MS)
+	}
+
+	override fun supportsModify() = false
+
+	override fun modify(): Spans.Modifier = throw UnsupportedOperationException()
+
+	override fun getLineCount() = lineCount
 }

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/LineSpansGenerator.kt
@@ -15,7 +15,7 @@
  *   along with AndroidIDE.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*******************************************************************************
+/* *****************************************************************************
  *    sora-editor - the awesome code editor for Android
  *    https://github.com/Rosemoe/sora-editor
  *    Copyright (C) 2020-2023  Rosemoe
@@ -39,7 +39,9 @@
  *     additional information or have any questions
  ******************************************************************************/
 
-@file:Suppress("ktlint:standard:kdoc", "ktlint:standard:no-consecutive-comments")
+// Two licence grants: AndroidIDE's GPL-3 and, below it, sora-editor's LGPL-2.1. They stay
+// separate blocks so neither is framed as part of the other; that trips one ktlint rule.
+@file:Suppress("ktlint:standard:no-consecutive-comments")
 
 package io.github.rosemoe.sora.editor.ts
 
@@ -104,10 +106,10 @@ class LineSpansGenerator(
 		const val REDRAW_DEBOUNCE_DELAY_MS = 32L
 	}
 
-/**
-* Thread-safe cache for calculated line spans.
-* Automatically evicts the least recently used lines.
-*/
+	/**
+	 * Thread-safe cache for calculated line spans.
+	 * Automatically evicts the least recently used lines.
+	 */
 	private val caches = LruCache<Int, MutableList<Span>>(CACHE_THRESHOLD)
 	private val calculatingLines = ConcurrentHashMap.newKeySet<Int>()
 
@@ -118,10 +120,10 @@ class LineSpansGenerator(
 	private val tsDispatcher = tsExecutor.asCoroutineDispatcher()
 	private val scope = CoroutineScope(SupervisorJob() + tsDispatcher)
 
-/**
-* Tracks content changes so the worker can instantly abort
-* outdated calculations when the user types.
-*/
+	/**
+	 * Tracks content changes so the worker can instantly abort
+	 * outdated calculations when the user types.
+	 */
 	private val contentVersion = AtomicInteger(0)
 	private val mainHandler = Handler(Looper.getMainLooper())
 	private var isRefreshScheduled = AtomicBoolean(false)
@@ -238,16 +240,14 @@ class LineSpansGenerator(
 		return applyDecorations(list, startIndex, endIndex)
 	}
 
-// ---------------------------------------------------------------------------
-// Plugin editor decorations
-//
-// After the base (tree-sitter) spans for a region are built, every registered
-// EditorDecorationProvider is given the region and returns additive, foreground-only color
-// spans, which are merged in here. The IDE is feature-agnostic — it knows nothing about what a
-// provider decorates (brackets, indent guides, markers, ...). Providers run on this analyze
-// thread and receive the full document content so they can use context outside the region.
-// ---------------------------------------------------------------------------
-
+	/**
+	 * Merges plugin editor decorations into the base tree-sitter spans for a region.
+	 *
+	 * Every registered EditorDecorationProvider is given the region and returns additive,
+	 * foreground-only colour spans. The IDE is feature-agnostic - it knows nothing about what a
+	 * provider decorates (brackets, indent guides, markers, ...). Providers run on this analyze
+	 * thread and receive the full document content, so they can use context outside the region.
+	 */
 	private fun applyDecorations(
 		list: MutableList<Span>,
 		startIndex: Int,
@@ -274,12 +274,12 @@ class LineSpansGenerator(
 		return mergeDecorations(list, startIndex, endIndex, decos)
 	}
 
-/**
-* Merges additive, foreground-only decoration spans into [list]: overrides only the foreground
-* color of the covered characters while preserving every base style underneath, and keeps the
-* strictly-ascending, non-overlapping span ordering the renderer requires. Decoration offsets are
-* absolute; they are clipped to the region and converted to line-relative columns.
-*/
+	/**
+	 * Merges additive, foreground-only decoration spans into [list]: overrides only the foreground
+	 * color of the covered characters while preserving every base style underneath, and keeps the
+	 * strictly-ascending, non-overlapping span ordering the renderer requires. Decoration offsets are
+	 * absolute; they are clipped to the region and converted to line-relative columns.
+	 */
 	private fun mergeDecorations(
 		list: MutableList<Span>,
 		startIndex: Int,
@@ -411,13 +411,13 @@ class LineSpansGenerator(
 		}
 	}
 
-/**
-* Shifts span columns horizontally to prevent visual flickering during inline edits.
-*
-* @param line Line index of the modification.
-* @param startColumn Column index where the shift begins.
-* @param colDiff Number of columns to shift.
-*/
+	/**
+	 * Shifts span columns horizontally to prevent visual flickering during inline edits.
+	 *
+	 * @param line Line index of the modification.
+	 * @param startColumn Column index where the shift begins.
+	 * @param colDiff Number of columns to shift.
+	 */
 	private fun shiftSpansOnLine(
 		line: Int,
 		startColumn: Int,
@@ -430,11 +430,11 @@ class LineSpansGenerator(
 		}
 	}
 
-/**
-* Rebuilds the line cache for vertical text shifts (line additions or deletions).
-*
-* @param action Logic to determine how each cached line is re-inserted.
-*/
+	/**
+	 * Rebuilds the line cache for vertical text shifts (line additions or deletions).
+	 *
+	 * @param action Logic to determine how each cached line is re-inserted.
+	 */
 	private inline fun rebuildCache(action: (line: Int, spans: MutableList<Span>, cache: LruCache<Int, MutableList<Span>>) -> Unit) {
 		val snapshot = caches.snapshot()
 		caches.evictAll()
@@ -491,9 +491,9 @@ class LineSpansGenerator(
 			}
 		}
 
-/**
-* Groups redraw requests together to avoid overloading the UI thread.
-*/
+	/**
+	 * Groups redraw requests together to avoid overloading the UI thread.
+	 */
 	private fun scheduleRefresh() {
 		if (!isRefreshScheduled.compareAndSet(false, true)) return
 

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
@@ -43,6 +43,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
 import java.util.concurrent.CancellationException
 import java.util.concurrent.LinkedBlockingQueue
@@ -60,6 +62,9 @@ class TsAnalyzeWorker(
 ) {
 	companion object {
 		private val log = LoggerFactory.getLogger(TsAnalyzeWorker::class.java)
+
+		/** Upper bound on waiting for the analyzer loop to finish before freeing its document. */
+		private const val STOP_TIMEOUT_MS = 500L
 	}
 
 	var stylesReceiver: StyleReceiver? = null
@@ -106,11 +111,32 @@ class TsAnalyzeWorker(
 
 		document.requestCancellationAndWaitIfParsing()
 
-		analyzerContext.close()
 		messageChannel.clear()
 		analyzerJob?.cancel(CancellationException("Requested to be stopped"))
+
+		// Cancelling does not wake a thread parked in take(), and closing the dispatcher does not stop
+		// it either - kotlinx reroutes the rejected dispatch to Dispatchers.IO. Hand the loop a message
+		// so it can see isDestroyed and return.
+		messageChannel.offer(Stop)
+
+		// The document's native objects are freed just below, and the shared TSQuery right after this
+		// returns, so the loop must be *finished*, not merely cancelled. Anything still in doMod would
+		// be reading memory that is about to go away (ADFA-5401).
+		val stopped =
+			runBlocking {
+				withTimeoutOrNull(STOP_TIMEOUT_MS) {
+					analyzerJob?.join()
+					true
+				}
+			} != null
+
+		if (!stopped) {
+			log.warn("Analyzer did not stop within {} ms; freeing its document anyway", STOP_TIMEOUT_MS)
+		}
+
 		analyzerScope.cancel(CancellationException("Requested to be stopped"))
 		document.close()
+		analyzerContext.close()
 	}
 
 	fun start() {
@@ -205,7 +231,7 @@ class TsAnalyzeWorker(
 
 	private fun processNextMessage() {
 		val message = messageChannel.take()
-		if (isDestroyed) {
+		if (isDestroyed || message is Stop) {
 			return
 		}
 
@@ -394,6 +420,15 @@ internal data class Init(
 internal data class Mod(
 	override val data: TextMod,
 ) : Message<TextMod>
+
+/**
+ * Wakes the worker's blocking [java.util.concurrent.LinkedBlockingQueue.take] so it can observe
+ * that it has been destroyed. Cancelling the job cannot do this: take() is a blocking call, not a
+ * suspension point (ADFA-5401).
+ */
+internal data object Stop : Message<Unit> {
+	override val data = Unit
+}
 
 internal data class TextInit(
 	val text: String,

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
@@ -51,340 +51,359 @@ import java.util.concurrent.LinkedBlockingQueue
  * @author Akash Yadav
  */
 class TsAnalyzeWorker(
-  private val analyzer: TsAnalyzeManager,
-  private val languageSpec: TsLanguageSpec,
-  private val theme: TsTheme,
-  private val styles: Styles,
-  private val reference: ContentReference,
-  private val spanFactory: TsSpanFactory
+	private val analyzer: TsAnalyzeManager,
+	private val languageSpec: TsLanguageSpec,
+	private val theme: TsTheme,
+	private val styles: Styles,
+	private val reference: ContentReference,
+	private val spanFactory: TsSpanFactory,
 ) {
+	companion object {
+		private val log = LoggerFactory.getLogger(TsAnalyzeWorker::class.java)
+	}
 
-  companion object {
+	var stylesReceiver: StyleReceiver? = null
 
-    private val log = LoggerFactory.getLogger(TsAnalyzeWorker::class.java)
-  }
+	@OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+	private val analyzerContext = newSingleThreadContext("TsAnalyzeWorkerContext")
 
-  var stylesReceiver: StyleReceiver? = null
+	private val analyzerScope = CoroutineScope(analyzerContext)
+	private val messageChannel = LinkedBlockingQueue<Message<*>>()
+	private var analyzerJob: Job? = null
 
-  @OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
-  private val analyzerContext = newSingleThreadContext("TsAnalyzeWorkerContext")
+	private var isInitialized = false
+	private var isDestroyed = false
 
-  private val analyzerScope = CoroutineScope(analyzerContext)
-  private val messageChannel = LinkedBlockingQueue<Message<*>>()
-  private var analyzerJob: Job? = null
+	val document = TsTextDocument(languageSpec.language)
 
-  private var isInitialized = false
-  private var isDestroyed = false
+	internal val tree: TSTree?
+		get() = document.tree
 
-  val document = TsTextDocument(languageSpec.language)
+	internal val text: UTF16String
+		get() = document.text
 
-  internal val tree: TSTree?
-    get() = document.tree
+	internal fun init(init: Init) {
+		if (isDestroyed) {
+			log.warn("Received Init after TsAnalyzeWorker has been destroyed. Ignoring...")
+			return
+		}
 
-  internal val text: UTF16String
-    get() = document.text
+		messageChannel.offer(init)
+	}
 
-  internal fun init(init: Init) {
-    if (isDestroyed) {
-      log.warn("Received Init after TsAnalyzeWorker has been destroyed. Ignoring...")
-      return
-    }
+	internal fun onMod(mod: Mod) {
+		if (isDestroyed) {
+			log.warn("Received Mod after TsAnalyzeWorker has been destroyed. Ignoring...")
+			return
+		}
 
-    messageChannel.offer(init)
-  }
+		messageChannel.offer(mod)
+	}
 
-  internal fun onMod(mod: Mod) {
-    if (isDestroyed) {
-      log.warn("Received Mod after TsAnalyzeWorker has been destroyed. Ignoring...")
-      return
-    }
+	fun stop() {
+		log.debug("Stopping TsAnalyzeWorker...")
+		isDestroyed = true
 
-    messageChannel.offer(mod)
-  }
+		document.requestCancellationAndWaitIfParsing()
 
-  fun stop() {
-    log.debug("Stopping TsAnalyzeWorker...")
-    isDestroyed = true
+		analyzerContext.close()
+		messageChannel.clear()
+		analyzerJob?.cancel(CancellationException("Requested to be stopped"))
+		analyzerScope.cancel(CancellationException("Requested to be stopped"))
+		document.close()
+	}
 
-    document.requestCancellationAndWaitIfParsing()
+	fun start() {
+		check(!isDestroyed) { "TsAnalyeWorker has already been destroyed" }
 
-    analyzerContext.close()
-    messageChannel.clear()
-    analyzerJob?.cancel(CancellationException("Requested to be stopped"))
-    analyzerScope.cancel(CancellationException("Requested to be stopped"))
-    document.close()
-  }
+		analyzerJob =
+			analyzerScope
+				.launch {
+					while (!isDestroyed && isActive) {
+						processNextMessage()
+					}
+				}.also { job ->
+					job.invokeOnCompletion { error ->
+						if (error != null && error !is CancellationException) {
+							log.error("Analyzer job failed", error)
+						} else {
+							log.info("Analyzer job completed")
+						}
+					}
+				}
+	}
 
-  fun start() {
-    check(!isDestroyed) { "TsAnalyeWorker has already been destroyed" }
+	fun addBreakpoint(line: Int) = toggleBreakpoint(line = line, addOnly = true)
 
-    analyzerJob = analyzerScope.launch {
-      while (!isDestroyed && isActive) {
-        processNextMessage()
-      }
-    }.also { job ->
-      job.invokeOnCompletion { error ->
-        if (error != null && error !is CancellationException) {
-          log.error("Analyzer job failed", error)
-        } else {
-          log.info("Analyzer job completed")
-        }
-      }
-    }
-  }
+	fun removeBreakpoint(line: Int) = toggleBreakpoint(line = line, removeOnly = true)
 
-  fun addBreakpoint(line: Int) = toggleBreakpoint(line = line, addOnly = true)
-  fun removeBreakpoint(line: Int) = toggleBreakpoint(line = line, removeOnly = true)
-  fun removeAllBreakpoints() {
-      styles.lineStyles?.forEach { style ->
-          style.eraseStyle(LineGutterBackground::class.java)
-      }
-      refreshLineStyles()
-  }
+	fun removeAllBreakpoints() {
+		styles.lineStyles?.forEach { style ->
+			style.eraseStyle(LineGutterBackground::class.java)
+		}
+		refreshLineStyles()
+	}
 
-  fun toggleBreakpoint(line: Int, addOnly: Boolean = false, removeOnly: Boolean = false) {
-    require(!(addOnly && removeOnly)) {
-        "set either addOnly or removeOnly, not both"
-    }
+	fun toggleBreakpoint(
+		line: Int,
+		addOnly: Boolean = false,
+		removeOnly: Boolean = false,
+	) {
+		require(!(addOnly && removeOnly)) {
+			"set either addOnly or removeOnly, not both"
+		}
 
-    val lineStyle = styles.lineStyles?.firstOrNull { it.line == line }
-    val gutterBg = lineStyle?.findOne(LineGutterBackground::class.java)
-    var notify = true
+		val lineStyle = styles.lineStyles?.firstOrNull { it.line == line }
+		val gutterBg = lineStyle?.findOne(LineGutterBackground::class.java)
+		var notify = true
 
-    if (gutterBg == null && !removeOnly) {
-      styles.addLineStyle(LineGutterBackground(line) { scheme ->
-        scheme.getColor(SchemeAndroidIDE.BREAKPOINT_LINE_INDICATOR)
-      })
-    } else if (!addOnly) {
-      styles.eraseLineStyle(line, LineGutterBackground::class.java)
-    } else {
-        notify = false
-    }
+		if (gutterBg == null && !removeOnly) {
+			styles.addLineStyle(
+				LineGutterBackground(line) { scheme ->
+					scheme.getColor(SchemeAndroidIDE.BREAKPOINT_LINE_INDICATOR)
+				},
+			)
+		} else if (!addOnly) {
+			styles.eraseLineStyle(line, LineGutterBackground::class.java)
+		} else {
+			notify = false
+		}
 
-    if (notify) {
-      refreshLineStyles()
-    }
-  }
+		if (notify) {
+			refreshLineStyles()
+		}
+	}
 
-  fun highlightLine(line: Int) {
-    val lineStyle = styles.lineStyles?.firstOrNull { it.line == line }
-    val lineBg = lineStyle?.findOne(LineBackground::class.java)
-    if (lineBg == null) {
-      styles.addLineStyle(LineBackground(line) { scheme ->
-        scheme.getColor(SchemeAndroidIDE.BREAKPOINT_LINE_BG)
-      })
-      refreshLineStyles()
-    }
-  }
+	fun highlightLine(line: Int) {
+		val lineStyle = styles.lineStyles?.firstOrNull { it.line == line }
+		val lineBg = lineStyle?.findOne(LineBackground::class.java)
+		if (lineBg == null) {
+			styles.addLineStyle(
+				LineBackground(line) { scheme ->
+					scheme.getColor(SchemeAndroidIDE.BREAKPOINT_LINE_BG)
+				},
+			)
+			refreshLineStyles()
+		}
+	}
 
-  fun unhighlightLines() {
-    styles.lineStyles?.forEach { style ->
-      style.eraseStyle(LineBackground::class.java)
-    }
-    refreshLineStyles()
-  }
+	fun unhighlightLines() {
+		styles.lineStyles?.forEach { style ->
+			style.eraseStyle(LineBackground::class.java)
+		}
+		refreshLineStyles()
+	}
 
-  private fun refreshLineStyles() {
-    // We can call styles.finishBuilding() instead of sorting lineStyles manually
-    // but finishBuilding() performs some unnecessary tasks like iterating over and sorting
-    // blockLines as well, which we don't need to do here
-    // As a result, we manually sort the line styles to avoid that unnecessary processing
-    styles.lineStyles?.sort()
-    stylesReceiver?.setStyles(analyzer, styles)
-  }
+	private fun refreshLineStyles() {
+		// We can call styles.finishBuilding() instead of sorting lineStyles manually
+		// but finishBuilding() performs some unnecessary tasks like iterating over and sorting
+		// blockLines as well, which we don't need to do here
+		// As a result, we manually sort the line styles to avoid that unnecessary processing
+		styles.lineStyles?.sort()
+		stylesReceiver?.setStyles(analyzer, styles)
+	}
 
-  private fun processNextMessage() {
-    val message = messageChannel.take()
-    if (isDestroyed) {
-      return
-    }
+	private fun processNextMessage() {
+		val message = messageChannel.take()
+		if (isDestroyed) {
+			return
+		}
 
-    try {
-      when (message) {
-        is Init -> doInit(message)
-        is Mod -> doMod(message)
-      }
-    } catch (err: Throwable) {
-      val langName = languageSpec.language.name
-      val msgType = message.javaClass.simpleName
-      val msgTypeSuffix = if (message is Mod) {
-        "[start=${message.data.start}, end=${message.data.end}, type=${if (message.data.changedText == null) "delete" else "insert"}]"
-      } else ""
-      val pendingMsgs = messageChannel.size
-      log.error(
-        "AnalyzeWorker[lang={}, message={}{}], pendingMsgs={}] crashed",
-        langName,
-        msgType,
-        msgTypeSuffix,
-        pendingMsgs,
-        err)
-    }
-  }
+		try {
+			when (message) {
+				is Init -> doInit(message)
+				is Mod -> doMod(message)
+			}
+		} catch (err: Throwable) {
+			val langName = languageSpec.language.name
+			val msgType = message.javaClass.simpleName
+			val msgTypeSuffix =
+				if (message is Mod) {
+					"[start=${message.data.start}, end=${message.data.end}, type=${if (message.data.changedText == null) "delete" else "insert"}]"
+				} else {
+					""
+				}
+			val pendingMsgs = messageChannel.size
+			log.error(
+				"AnalyzeWorker[lang={}, message={}{}], pendingMsgs={}] crashed",
+				langName,
+				msgType,
+				msgTypeSuffix,
+				pendingMsgs,
+				err,
+			)
+		}
+	}
 
-  private fun doInit(init: Init) {
-    document.requestCancellationAndWaitIfParsing()
+	private fun doInit(init: Init) {
+		document.requestCancellationAndWaitIfParsing()
 
-    check(!isInitialized) {
-      "'Init' must be the first message to TsAnalyzeWorker"
-    }
+		check(!isInitialized) {
+			"'Init' must be the first message to TsAnalyzeWorker"
+		}
 
-    document.doInit(init.data)
-    document.reparse()
-    updateStyles()
+		document.doInit(init.data)
+		document.reparse()
+		updateStyles()
 
-    isInitialized = true
-  }
+		isInitialized = true
+	}
 
-  private fun doMod(mod: Mod) {
+	private fun doMod(mod: Mod) {
+		check(isInitialized) {
+			"'Init' must be the first message to TsAnalyzeWorker"
+		}
 
-    check(isInitialized) {
-      "'Init' must be the first message to TsAnalyzeWorker"
-    }
+		val textMod = mod.data
+		val edit = textMod.edit
 
-    val textMod = mod.data
-    val edit = textMod.edit
+		val oldTree = tree!!
+		oldTree.edit(edit)
 
-    val oldTree = tree!!
-    oldTree.edit(edit)
+		document.doMod(textMod)
 
-    document.doMod(textMod)
+		(edit as? TreeSitterInputEdit?)?.recycle()
 
-    (edit as? TreeSitterInputEdit?)?.recycle()
+		document.requestCancellationAndWaitIfParsing()
 
-    document.requestCancellationAndWaitIfParsing()
+		if (isDestroyed) {
+			return
+		}
 
-    if (isDestroyed) {
-      return
-    }
+		document.reparse(oldTree)
 
-    document.reparse(oldTree)
+		oldTree.close()
+		updateStyles()
+	}
 
-    oldTree.close()
-    updateStyles()
-  }
+	private fun updateStyles() {
+		if (isDestroyed || messageChannel.isNotEmpty() || tree?.canAccess() != true) {
+			// analyzer stopped or
+			// more message need to be processed
+			return
+		}
 
-  private fun updateStyles() {
-    if (isDestroyed || messageChannel.isNotEmpty() || tree?.canAccess() != true) {
-      // analyzer stopped or
-      // more message need to be processed
-      return
-    }
+		val tree = tree!!
+		val scopedVariables = TsScopedVariables(tree, text, languageSpec)
+		val oldSpans = (styles.spans as? LineSpansGenerator?)
+		val oldBrackets = analyzer.currentBracketPairs
 
-    val tree = tree!!
-    val scopedVariables = TsScopedVariables(tree, text, languageSpec)
-    val oldSpans = (styles.spans as? LineSpansGenerator?)
-    val oldBrackets = analyzer.currentBracketPairs
+		oldSpans?.destroy()
 
-    oldSpans?.destroy()
+		// Use separate tree copies for the background worker and the UI thread
+		// to prevent concurrent access crashes.
+		styles.spans =
+			LineSpansGenerator(
+				tree.copy(),
+				reference.lineCount,
+				reference.reference,
+				theme,
+				languageSpec,
+				scopedVariables,
+				spanFactory,
+				requestRedraw = { stylesReceiver?.setStyles(analyzer, styles) },
+			)
 
-    // Use separate tree copies for the background worker and the UI thread
-    // to prevent concurrent access crashes.
-    styles.spans = LineSpansGenerator(
-      tree.copy(),
-      reference.lineCount,
-      reference.reference,
-      theme,
-      languageSpec,
-      scopedVariables,
-      spanFactory,
-      requestRedraw = { stylesReceiver?.setStyles(analyzer, styles) }
-    )
+		val newBrackets = TsBracketPairs(tree.copy(), languageSpec)
+		analyzer.currentBracketPairs = newBrackets
 
-    val newBrackets = TsBracketPairs(tree.copy(), languageSpec)
-    analyzer.currentBracketPairs = newBrackets
+		val oldBlocks = styles.blocks
+		updateCodeBlocks()
+		oldBlocks?.also { ObjectAllocator.recycleBlockLines(it) }
 
-    val oldBlocks = styles.blocks
-    updateCodeBlocks()
-    oldBlocks?.also { ObjectAllocator.recycleBlockLines(it) }
+		stylesReceiver?.setStyles(analyzer, styles)
+		stylesReceiver?.updateBracketProvider(analyzer, newBrackets)
 
-    stylesReceiver?.setStyles(analyzer, styles)
-    stylesReceiver?.updateBracketProvider(analyzer, newBrackets)
+		oldBrackets?.let { Handler(Looper.getMainLooper()).post { it.close() } }
+	}
 
-    oldBrackets?.let { Handler(Looper.getMainLooper()).post { it.close() } }
-  }
+	private fun updateCodeBlocks() {
+		if (languageSpec.blocksQuery.patternCount == 0 ||
+			!languageSpec.blocksQuery.canAccess() ||
+			tree?.canAccess() != true
+		) {
+			return
+		}
 
-  private fun updateCodeBlocks() {
-    if (languageSpec.blocksQuery.patternCount == 0
-      || !languageSpec.blocksQuery.canAccess()
-      || tree?.canAccess() != true
-    ) {
-      return
-    }
+		val blocks = mutableListOf<CodeBlock>()
+		TSQueryCursor.create().use { cursor ->
 
-    val blocks = mutableListOf<CodeBlock>()
-    TSQueryCursor.create().use { cursor ->
+			cursor.safeExecQueryCursor(
+				query = languageSpec.blocksQuery,
+				tree = tree,
+				recycleNodeAfterUse = true,
+				matchCondition = { !isDestroyed },
+				onClosedOrEdited = { blocks.clear() },
+				debugName = "TsAnalyzeManager.updateCodeBlocks()",
+			) { match ->
+				if (!languageSpec.blocksPredicator.doPredicate(
+						languageSpec.predicates,
+						text,
+						match,
+					)
+				) {
+					return@safeExecQueryCursor
+				}
 
-      cursor.safeExecQueryCursor(
-        query = languageSpec.blocksQuery,
-        tree = tree,
-        recycleNodeAfterUse = true,
-        matchCondition = { !isDestroyed },
-        onClosedOrEdited = { blocks.clear() },
-        debugName = "TsAnalyzeManager.updateCodeBlocks()"
-      ) { match ->
-        if (!languageSpec.blocksPredicator.doPredicate(
-            languageSpec.predicates,
-            text,
-            match
-          )
-        ) {
-          return@safeExecQueryCursor
-        }
+				match.captures.forEach { capture ->
+					val block = ObjectAllocator.obtainBlockLine()
+					var node = capture.node
+					val start = node.startPoint
 
-        match.captures.forEach { capture ->
-          val block = ObjectAllocator.obtainBlockLine()
-          var node = capture.node
-          val start = node.startPoint
+					block.startLine = start.row
+					block.startColumn = start.column / 2
 
-          block.startLine = start.row
-          block.startColumn = start.column / 2
+					val end =
+						if (languageSpec.blocksQuery
+								.getCaptureNameForId(capture.index)
+								.endsWith(".marked")
+						) {
+							// Goto last terminal element
+							while (node.childCount > 0) {
+								node = node.getChild(node.childCount - 1)
+							}
+							node.startPoint
+						} else {
+							node.endPoint
+						}
+					block.endLine = end.row
+					block.endColumn = end.column / 2
+					if (block.endLine - block.startLine > 1) {
+						blocks.add(block)
+					}
 
-          val end = if (languageSpec.blocksQuery.getCaptureNameForId(capture.index)
-              .endsWith(".marked")
-          ) {
-            // Goto last terminal element
-            while (node.childCount > 0) {
-              node = node.getChild(node.childCount - 1)
-            }
-            node.startPoint
-          } else {
-            node.endPoint
-          }
-          block.endLine = end.row
-          block.endColumn = end.column / 2
-          if (block.endLine - block.startLine > 1) {
-            blocks.add(block)
-          }
+					(capture as? TreeSitterQueryCapture?)?.recycle()
+				}
+			}
+		}
 
-          (capture as? TreeSitterQueryCapture?)?.recycle()
-        }
-      }
-    }
-
-    val distinct = blocks.asSequence().distinct().toMutableList()
-    styles.blocks = distinct
-    styles.finishBuilding()
-  }
+		val distinct = blocks.asSequence().distinct().toMutableList()
+		styles.blocks = distinct
+		styles.finishBuilding()
+	}
 }
 
 internal interface Message<T> {
-
-  val data: T
+	val data: T
 }
 
-internal data class Init(override val data: TextInit) : Message<TextInit>
+internal data class Init(
+	override val data: TextInit,
+) : Message<TextInit>
 
-internal data class Mod(override val data: TextMod) : Message<TextMod>
+internal data class Mod(
+	override val data: TextMod,
+) : Message<TextMod>
 
 internal data class TextInit(
-  val text: String,
-  val contentVersion: Long
+	val text: String,
+	val contentVersion: Long,
 )
 
 internal data class TextMod(
-  val start: Int,
-  val end: Int,
-  val edit: TSInputEdit,
-  val changedText: String?,
-  val contentVersion: Long
+	val start: Int,
+	val end: Int,
+	val edit: TSInputEdit,
+	val changedText: String?,
+	val contentVersion: Long,
 )

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
@@ -113,17 +113,48 @@ class TsAnalyzeWorker(
 
 		document.requestCancellationAndWaitIfParsing()
 
-		messageChannel.clear()
-		analyzerJob?.cancel(CancellationException("Requested to be stopped"))
+		drainPendingMessages()
+
+		val job = analyzerJob
+		job?.cancel(CancellationException("Requested to be stopped"))
 
 		// Cancelling does not wake a thread parked in take(), and closing the dispatcher does not stop
 		// it either - kotlinx reroutes the rejected dispatch to Dispatchers.IO. Hand the loop a message
-		// so it can see isDestroyed and return.
+		// so it can see isDestroyed and return; it frees the natives on its way out.
 		messageChannel.offer(Stop)
 
 		analyzerScope.cancel(CancellationException("Requested to be stopped"))
-		document.close()
-		analyzerContext.close()
+
+		if (job == null) {
+			// start() was never called, so there is no loop to do it.
+			closeNatives()
+		}
+	}
+
+	/**
+	 * Releases the document and the dispatcher. Runs on the analyzer thread once its loop has
+	 * finished, so nothing can still be reading what it frees.
+	 */
+	private fun closeNatives() {
+		try {
+			document.close()
+		} finally {
+			analyzerContext.close()
+		}
+	}
+
+	/**
+	 * Empties the queue, recycling each message's pooled natives. [LinkedBlockingQueue.clear] would
+	 * drop them without recycling, and stop() runs on every reset - so that churn would be
+	 * per-interaction, not per-close.
+	 */
+	private fun drainPendingMessages() {
+		while (true) {
+			when (val pending = messageChannel.poll() ?: return) {
+				is Mod -> (pending.data.edit as? TreeSitterInputEdit?)?.recycle()
+				else -> Unit
+			}
+		}
 	}
 
 	fun start() {
@@ -132,8 +163,17 @@ class TsAnalyzeWorker(
 		analyzerJob =
 			analyzerScope
 				.launch {
-					while (!isDestroyed && isActive) {
-						processNextMessage()
+					try {
+						while (!isDestroyed && isActive) {
+							processNextMessage()
+						}
+					} finally {
+						// Freed here, by the thread that uses them, rather than by whoever calls
+						// stop(): the loop can be mid doMod()/updateStyles() when stop() runs, and a
+						// caller-side close would pull the text and tree out from under it. Same idiom
+						// as LineSpansGenerator, which posts its own tree.close() onto its executor.
+						// stop() cannot wait for this instead - it is on the setText/reset hot path.
+						closeNatives()
 					}
 				}.also { job ->
 					job.invokeOnCompletion { error ->

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
@@ -60,9 +60,6 @@ class TsAnalyzeWorker(
 ) {
 	companion object {
 		private val log = LoggerFactory.getLogger(TsAnalyzeWorker::class.java)
-
-		/** Upper bound on waiting for the analyzer loop to finish before freeing its document. */
-		private const val STOP_TIMEOUT_MS = 500L
 	}
 
 	var stylesReceiver: StyleReceiver? = null
@@ -113,48 +110,17 @@ class TsAnalyzeWorker(
 
 		document.requestCancellationAndWaitIfParsing()
 
-		drainPendingMessages()
-
-		val job = analyzerJob
-		job?.cancel(CancellationException("Requested to be stopped"))
+		messageChannel.clear()
+		analyzerJob?.cancel(CancellationException("Requested to be stopped"))
 
 		// Cancelling does not wake a thread parked in take(), and closing the dispatcher does not stop
 		// it either - kotlinx reroutes the rejected dispatch to Dispatchers.IO. Hand the loop a message
-		// so it can see isDestroyed and return; it frees the natives on its way out.
+		// so it can see isDestroyed and return.
 		messageChannel.offer(Stop)
 
 		analyzerScope.cancel(CancellationException("Requested to be stopped"))
-
-		if (job == null) {
-			// start() was never called, so there is no loop to do it.
-			closeNatives()
-		}
-	}
-
-	/**
-	 * Releases the document and the dispatcher. Runs on the analyzer thread once its loop has
-	 * finished, so nothing can still be reading what it frees.
-	 */
-	private fun closeNatives() {
-		try {
-			document.close()
-		} finally {
-			analyzerContext.close()
-		}
-	}
-
-	/**
-	 * Empties the queue, recycling each message's pooled natives. [LinkedBlockingQueue.clear] would
-	 * drop them without recycling, and stop() runs on every reset - so that churn would be
-	 * per-interaction, not per-close.
-	 */
-	private fun drainPendingMessages() {
-		while (true) {
-			when (val pending = messageChannel.poll() ?: return) {
-				is Mod -> (pending.data.edit as? TreeSitterInputEdit?)?.recycle()
-				else -> Unit
-			}
-		}
+		document.close()
+		analyzerContext.close()
 	}
 
 	fun start() {
@@ -163,17 +129,8 @@ class TsAnalyzeWorker(
 		analyzerJob =
 			analyzerScope
 				.launch {
-					try {
-						while (!isDestroyed && isActive) {
-							processNextMessage()
-						}
-					} finally {
-						// Freed here, by the thread that uses them, rather than by whoever calls
-						// stop(): the loop can be mid doMod()/updateStyles() when stop() runs, and a
-						// caller-side close would pull the text and tree out from under it. Same idiom
-						// as LineSpansGenerator, which posts its own tree.close() onto its executor.
-						// stop() cannot wait for this instead - it is on the setText/reset hot path.
-						closeNatives()
+					while (!isDestroyed && isActive) {
+						processNextMessage()
 					}
 				}.also { job ->
 					job.invokeOnCompletion { error ->

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
@@ -43,8 +43,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
 import java.util.concurrent.CancellationException
 import java.util.concurrent.LinkedBlockingQueue
@@ -77,6 +75,10 @@ class TsAnalyzeWorker(
 	private var analyzerJob: Job? = null
 
 	private var isInitialized = false
+
+	// Written by whoever calls stop(), read by the analyzer loop and by the query guards it
+	// passes as matchCondition; the only happens-before edge otherwise is the Stop message.
+	@Volatile
 	private var isDestroyed = false
 
 	val document = TsTextDocument(languageSpec.language)
@@ -118,21 +120,6 @@ class TsAnalyzeWorker(
 		// it either - kotlinx reroutes the rejected dispatch to Dispatchers.IO. Hand the loop a message
 		// so it can see isDestroyed and return.
 		messageChannel.offer(Stop)
-
-		// The document's native objects are freed just below, and the shared TSQuery right after this
-		// returns, so the loop must be *finished*, not merely cancelled. Anything still in doMod would
-		// be reading memory that is about to go away (ADFA-5401).
-		val stopped =
-			runBlocking {
-				withTimeoutOrNull(STOP_TIMEOUT_MS) {
-					analyzerJob?.join()
-					true
-				}
-			} != null
-
-		if (!stopped) {
-			log.warn("Analyzer did not stop within {} ms; freeing its document anyway", STOP_TIMEOUT_MS)
-		}
 
 		analyzerScope.cancel(CancellationException("Requested to be stopped"))
 		document.close()

--- a/editor/src/main/java/com/itsaky/androidide/editor/language/treesitter/TreeSitterIndentProvider.kt
+++ b/editor/src/main/java/com/itsaky/androidide/editor/language/treesitter/TreeSitterIndentProvider.kt
@@ -50,128 +50,132 @@ import kotlin.math.min
  * @author Akash Yadav
  */
 class TreeSitterIndentProvider(
-  private val languageSpec: TreeSitterLanguageSpec,
-  private val analyzer: TsAnalyzeWorker,
-  private val indentSize: Int
+	private val languageSpec: TreeSitterLanguageSpec,
+	private val analyzer: TsAnalyzeWorker,
+	private val indentSize: Int,
 ) {
+	companion object {
+		private const val IDENT_AUTO = "indent.auto"
+		private const val IDENT_BEGIN = "indent.begin"
+		private const val IDENT_END = "indent.end"
+		private const val IDENT_DEDENT = "indent.dedent"
+		private const val IDENT_BRANCH = "indent.branch"
+		private const val IDENT_IGNORE = "indent.ignore"
+		private const val IDENT_ALIGN = "indent.align"
+		private const val IDENT_ZERO = "indent.zero"
 
-  companion object {
+		private const val IDENT_TYP_COUNT = 8 // increment this when adding a new indent type above
 
-    private const val IDENT_AUTO = "indent.auto"
-    private const val IDENT_BEGIN = "indent.begin"
-    private const val IDENT_END = "indent.end"
-    private const val IDENT_DEDENT = "indent.dedent"
-    private const val IDENT_BRANCH = "indent.branch"
-    private const val IDENT_IGNORE = "indent.ignore"
-    private const val IDENT_ALIGN = "indent.align"
-    private const val IDENT_ZERO = "indent.zero"
+		private val log = LoggerFactory.getLogger(TreeSitterIndentProvider::class.java)
+		internal const val INDENTATION_ERR = Int.MIN_VALUE
+		internal const val INDENT_ALIGN_ZERO = Int.MIN_VALUE
+		internal const val INDENT_AUTO = Int.MAX_VALUE
 
-    private const val IDENT_TYP_COUNT = 8 // increment this when adding a new indent type above
+		private val DELIMITER_REGEX = Regex("""[\-.+\[\]()$^\\?*]""")
+		private const val CONTEXT_LINES_LIMIT = 5
+	}
 
-    private val log = LoggerFactory.getLogger(TreeSitterIndentProvider::class.java)
-    internal const val INDENTATION_ERR = Int.MIN_VALUE
-    internal const val INDENT_ALIGN_ZERO = Int.MIN_VALUE
-    internal const val INDENT_AUTO = Int.MAX_VALUE
+	fun getIndentsForLines(
+		content: Content,
+		positions: LongArray,
+		default: Int = INDENTATION_ERR,
+	): IntArray {
+		log.debug(
+			"getIndentsForLine(Content({}),{})",
+			content.length,
+			positions.joinToString(",") { "${IntPair.getFirst(it)}:${IntPair.getSecond(it)}" },
+		)
+		val defaultIndents = IntArray(positions.size) { default }
 
-    private val DELIMITER_REGEX = Regex("""[\-.+\[\]()$^\\?*]""")
-    private const val CONTEXT_LINES_LIMIT = 5
-  }
+		// not really needed, but just in case
+		if (content.isEmpty() || positions.isEmpty()) {
+			return defaultIndents
+		}
 
-  fun getIndentsForLines(
-    content: Content,
-    positions: LongArray,
-    default: Int = INDENTATION_ERR
-  ): IntArray {
-    log.debug("getIndentsForLine(Content({}),{})", content.length,
-      positions.joinToString(",") { "${IntPair.getFirst(it)}:${IntPair.getSecond(it)}" })
-    val defaultIndents = IntArray(positions.size) { default }
+		val document = analyzer.document
+		TSParser.create().use { parser ->
+			parser.language = document.parser.language
 
-    // not really needed, but just in case
-    if (content.isEmpty() || positions.isEmpty()) {
-      return defaultIndents
-    }
+			var closeTree = true
+			val tree =
+				if (content.documentVersion == document.version) {
+					// avoid converting the content to string if not really needed
+					log.info("Re-using cached tree from document version {}", document.version)
+					closeTree = false
+					document.tree
+				} else {
+					log.info(
+						"Re-parsing content for indentation as document version {} does not match version {}",
+						document.version,
+						content.documentVersion,
+					)
 
-    val document = analyzer.document
-    TSParser.create().use { parser ->
-      parser.language = document.parser.language
+					(document.tree?.copy() ?: return defaultIndents).use { copiedTree ->
+						parser.parseString(copiedTree, content.toString())
+					}
+				}
 
-      var closeTree = true
-      val tree = if (content.documentVersion == document.version) {
-        // avoid converting the content to string if not really needed
-        log.info("Re-using cached tree from document version {}", document.version)
-        closeTree = false
-        document.tree
-      } else {
-        log.info(
-          "Re-parsing content for indentation as document version {} does not match version {}",
-          document.version,
-          content.documentVersion
-        )
+			if (tree == null) {
+				log.info("Parsed tree is null, returning default indent: {}", default)
+				return defaultIndents
+			}
 
-        (document.tree?.copy() ?: return defaultIndents).use { copiedTree ->
-          parser.parseString(copiedTree, content.toString())
-        }
-      }
+			try {
+				return computeIndents(tree, content, positions, defaultIndents)
+					.also { indents ->
+						log.debug("Computed indents: {}", indents.joinToString(","))
+					}
+			} finally {
+				if (closeTree) {
+					tree.close()
+				}
+			}
+		}
+	}
 
-      if (tree == null) {
-        log.info("Parsed tree is null, returning default indent: {}", default)
-        return defaultIndents
-      }
+	private fun computeIndents(
+		tree: TSTree,
+		content: Content,
+		positions: LongArray,
+		defaultIndents: IntArray,
+	): IntArray {
+		val indentsQuery =
+			languageSpec.indentsQuery ?: run {
+				log.info("Cannot compute indents. Indents query is null.")
+				return defaultIndents
+			}
 
-      try {
-        return computeIndents(tree, content, positions, defaultIndents)
-          .also { indents ->
-            log.debug("Computed indents: {}", indents.joinToString(","))
-          }
-      } finally {
-        if (closeTree) {
-          tree.close()
-        }
-      }
-    }
-  }
+		if (indentsQuery == TSQuery.EMPTY) {
+			log.info("Cannot compute indents. Indents query is empty.")
+			return defaultIndents
+		}
 
-  private fun computeIndents(
-    tree: TSTree,
-    content: Content,
-    positions: LongArray,
-    defaultIndents: IntArray
-  ): IntArray {
-    val indentsQuery = languageSpec.indentsQuery ?: run {
-      log.info("Cannot compute indents. Indents query is null.")
-      return defaultIndents
-    }
+		val rootNode =
+			tree.rootNode ?: run {
+				log.info("Cannot compute indents. Root node is null.")
+				return defaultIndents
+			}
 
-    if (indentsQuery == TSQuery.EMPTY) {
-      log.info("Cannot compute indents. Indents query is empty.")
-      return defaultIndents
-    }
-
-    val rootNode = tree.rootNode ?: run {
-      log.info("Cannot compute indents. Root node is null.")
-      return defaultIndents
-    }
-
-    return TSQueryCursor.create().use { cursor ->
-      cursor.addPredicateHandler(SetDirectiveHandler())
+		return TSQueryCursor.create().use { cursor ->
+			cursor.addPredicateHandler(SetDirectiveHandler())
 
 			optimizeCursorRange(positions, content, cursor)
 
-      cursor.exec(indentsQuery, tree.rootNode)
+			cursor.exec(indentsQuery, tree.rootNode)
 
-      val indents = getIndents(languageSpec.indentsQuery, cursor)
-      return@use IntArray(positions.size) { index ->
-        val line = IntPair.getFirst(positions[index])
-        val column = IntPair.getSecond(positions[index])
-        computeIndentForLine(content, line, column, defaultIndents[index], rootNode, indents)
-      }
-    }
-  }
+			val indents = getIndents(languageSpec.indentsQuery, cursor)
+			return@use IntArray(positions.size) { index ->
+				val line = IntPair.getFirst(positions[index])
+				val column = IntPair.getSecond(positions[index])
+				computeIndentForLine(content, line, column, defaultIndents[index], rootNode, indents)
+			}
+		}
+	}
 
 	private fun optimizeCursorRange(
 		positions: LongArray,
 		content: Content,
-		cursor: TSQueryCursor?
+		cursor: TSQueryCursor?,
 	) {
 		if (!positions.isNotEmpty()) return
 
@@ -185,363 +189,414 @@ class TreeSitterIndentProvider(
 		cursor?.setByteRange(startByte, endByte)
 	}
 
-  private fun computeIndentForLine(
-    content: Content,
-    line: Int,
-    column: Int,
-    default: Int,
-    rootNode: TSNode,
-    indents: IndentsContainer
-  ): Int {
-    val isEmptyLine = content.getLine(line).trimmedLength() == 0
-    var node: TSNode?
+	private fun computeIndentForLine(
+		content: Content,
+		line: Int,
+		column: Int,
+		default: Int,
+		rootNode: TSNode,
+		indents: IndentsContainer,
+	): Int {
+		val isEmptyLine = content.getLine(line).trimmedLength() == 0
+		var node: TSNode?
 
-    if (isEmptyLine) {
-      val prevlnum = content.previousNonBlankLine(line)
-      if (prevlnum == -1) {
-        log.error("Cannot compute indents. Unable to get previous non-blank line.")
-        return default
-      } else {
-        log.debug("Previous non-blank line: {}", prevlnum)
-      }
+		if (isEmptyLine) {
+			val prevlnum = content.previousNonBlankLine(line)
+			if (prevlnum == -1) {
+				log.error("Cannot compute indents. Unable to get previous non-blank line.")
+				return default
+			} else {
+				log.debug("Previous non-blank line: {}", prevlnum)
+			}
 
-      var prevline: CharSequence = content.getLine(prevlnum)
-      val indentBytes = TextUtils.countLeadingSpaceCount(prevline, indentSize) shl 1
-      prevline = prevline.trim()
+			var prevline: CharSequence = content.getLine(prevlnum)
+			val indentBytes = TextUtils.countLeadingSpaceCount(prevline, indentSize) shl 1
+			prevline = prevline.trim()
 
-      // The final position can be trailing spaces, which should not affect indentation
-      node = content.getLastNodeAtLine(rootNode, prevlnum,
-        (indentBytes + prevline.length shl 1) - 2
-      ) ?: run {
-        log.error("Unable to get last node at line: {}", prevlnum)
-        return default
-      }
+			// The final position can be trailing spaces, which should not affect indentation
+			node = content.getLastNodeAtLine(
+				rootNode,
+				prevlnum,
+				(indentBytes + prevline.length shl 1) - 2,
+			) ?: run {
+				log.error("Unable to get last node at line: {}", prevlnum)
+				return default
+			}
 
-      // TODO(itsaky): Make this an API
-      //    Language defs must be able to specify captures which represent a comment
-      if (node.type == "comment") {
-        // The final node we capture of the previous line can be a comment node, which should also be ignored
-        // Unless the last line is an entire line of comment, ignore the comment range and find the last node again
-        val firstNode = content.getFirstNodeAtLine(rootNode, prevlnum, indentBytes)
-        val scol = node.startPoint.column
-        if (firstNode?.nodeId != node.nodeId) {
-          // In case the last captured node is a trailing comment node, re-trim the string
-          prevline = prevline.subSequence(0, (scol shr 1) - (indentBytes shr 1)).trim()
-          val col = indentBytes + ((prevline.length - 1) shl 1)
+			// TODO(itsaky): Make this an API
+			//    Language defs must be able to specify captures which represent a comment
+			if (node.type == "comment") {
+				// The final node we capture of the previous line can be a comment node, which should also be ignored
+				// Unless the last line is an entire line of comment, ignore the comment range and find the last node again
+				val firstNode = content.getFirstNodeAtLine(rootNode, prevlnum, indentBytes)
+				val scol = node.startPoint.column
+				if (firstNode?.nodeId != node.nodeId) {
+					// In case the last captured node is a trailing comment node, re-trim the string
+					prevline = prevline.subSequence(0, (scol shr 1) - (indentBytes shr 1)).trim()
+					val col = indentBytes + ((prevline.length - 1) shl 1)
 
-          node = content.getLastNodeAtLine(rootNode, prevlnum, col)
-        }
-      }
+					node = content.getLastNodeAtLine(rootNode, prevlnum, col)
+				}
+			}
 
-      if (indents[IDENT_END]!![node?.nodeId ?: 0] != null) {
-        node = content.getFirstNodeAtLine(rootNode, line)
-      }
-    } else {
-      node = content.getFirstNodeAtLine(rootNode, line, column shl 1)
-    }
+			if (indents[IDENT_END]!![node?.nodeId ?: 0] != null) {
+				node = content.getFirstNodeAtLine(rootNode, line)
+			}
+		} else {
+			node = content.getFirstNodeAtLine(rootNode, line, column shl 1)
+		}
 
-    if (node == null || !node.canAccess()) {
-      log.error(
-        "Cannot compute indents. Unable to get node at line: {}. node={} node.canAccess={}", line,
-        node, node?.canAccess())
-      return default
-    }
+		if (node == null || !node.canAccess()) {
+			log.error(
+				"Cannot compute indents. Unable to get node at line: {}. node={} node.canAccess={}",
+				line,
+				node,
+				node?.canAccess(),
+			)
+			return default
+		}
 
-    var indent = 0
+		var indent = 0
 
-    if (indents[IDENT_ZERO]?.containsKey(node.nodeId) == true) {
-      // indent.zero: align the node to the start of the line
-      log.debug("Zero indent for node: {}", node)
-      return INDENT_ALIGN_ZERO
-    }
+		if (indents[IDENT_ZERO]?.containsKey(node.nodeId) == true) {
+			// indent.zero: align the node to the start of the line
+			log.debug("Zero indent for node: {}", node)
+			return INDENT_ALIGN_ZERO
+		}
 
-    // map to store whether a given line is already processed
-    // this is to ensure that we do not accidentally apply multiple indent levels to the same line
-    val processedLines = mutableIntObjectMapOf<Boolean>()
+		// map to store whether a given line is already processed
+		// this is to ensure that we do not accidentally apply multiple indent levels to the same line
+		val processedLines = mutableIntObjectMapOf<Boolean>()
 
-    while (node != null && node.canAccess()) {
+		while (node != null && node.canAccess()) {
+			val srow = node.startPoint.line
+			val erow = node.endPoint.line
 
-      val srow = node.startPoint.line
-      val erow = node.endPoint.line
+			// do 'auto indent' if not marked as '@indent'
+			if (!indents.hasNode(IDENT_BEGIN, node) &&
+				!indents.hasNode(IDENT_ALIGN, node) &&
+				indents.hasNode(IDENT_AUTO, node) &&
+				srow < line &&
+				line <= erow
+			) {
+				log.debug("Auto indent for node: {}", node)
+				return INDENT_AUTO
+			}
 
-      // do 'auto indent' if not marked as '@indent'
-      if (!indents.hasNode(IDENT_BEGIN, node)
-        && !indents.hasNode(IDENT_ALIGN, node)
-        && indents.hasNode(IDENT_AUTO, node)
-        && srow < line
-        && line <= erow
-      ) {
-        log.debug("Auto indent for node: {}", node)
-        return INDENT_AUTO
-      }
+			// Do not indent if we are inside an @ignore block.
+			// If a node spans from L1,C1 to L2,C2, we know that lines where L1 < line <= L2 would
+			// have their indentations contained by the node.
+			if (!indents.hasNode(IDENT_BEGIN, node) &&
+				indents.hasNode(IDENT_IGNORE, node) &&
+				srow < line &&
+				line <= erow
+			) {
+				log.debug("Ignore indent for node: {}", node)
+				return default
+			}
 
-      // Do not indent if we are inside an @ignore block.
-      // If a node spans from L1,C1 to L2,C2, we know that lines where L1 < line <= L2 would
-      // have their indentations contained by the node.
-      if (!indents.hasNode(IDENT_BEGIN, node)
-        && indents.hasNode(IDENT_IGNORE, node)
-        && srow < line
-        && line <= erow
-      ) {
-        log.debug("Ignore indent for node: {}", node)
-        return default
-      }
+			var isProcessed = false
 
-      var isProcessed = false
+			if (!processedLines.containsKey(srow) &&
+				(
+					(indents.hasNode(IDENT_BRANCH, node) && srow == line) ||
+						(indents.hasNode(IDENT_DEDENT, node) && srow != line)
+				)
+			) {
+				indent -= indentSize
+				isProcessed = true
+			}
 
-      if (!processedLines.containsKey(srow)
-        && ((indents.hasNode(IDENT_BRANCH, node) && srow == line)
-            || (indents.hasNode(IDENT_DEDENT, node) && srow != line))
-      ) {
-        indent -= indentSize
-        isProcessed = true
-      }
+			// do not indent for nodes that starts-and-ends on same line and starts on target line (lnum)
+			val shouldProcess = !processedLines.containsKey(srow)
+			var isInError = false
+			if (shouldProcess) {
+				isInError = node.parent?.let { it.canAccess() && it.hasErrors() } == true
+			}
 
-      // do not indent for nodes that starts-and-ends on same line and starts on target line (lnum)
-      val shouldProcess = !processedLines.containsKey(srow)
-      var isInError = false
-      if (shouldProcess) {
-        isInError = node.parent?.let { it.canAccess() && it.hasErrors() } == true
-      }
+			if (shouldProcess &&
+				(
+					indents.hasNode(IDENT_BEGIN, node) &&
+						(
+							srow != erow || isInError ||
+								indents.hasMeta(
+									IDENT_BEGIN,
+									node,
+									"indent.immediate",
+								)
+						) &&
+						(srow != line || indents.hasMeta(IDENT_BEGIN, node, "indent.start_at_same_line"))
+				)
+			) {
+				indent += indentSize
+				isProcessed = true
+			}
 
-      if (shouldProcess &&
-        (indents.hasNode(IDENT_BEGIN, node)
-            && (srow != erow || isInError || indents.hasMeta(IDENT_BEGIN, node,
-          "indent.immediate"))
-            && (srow != line || indents.hasMeta(IDENT_BEGIN, node, "indent.start_at_same_line")))
-      ) {
-        indent += indentSize
-        isProcessed = true
-      }
+			if (isInError && !indents.hasNode(IDENT_ALIGN, node)) {
+				// only when the node is in error, promote the
+				// first child's aligned indent to the error node
+				// to work around ((ERROR "X" . (_)) @aligned_indent (#set! "delimiter" "AB"))
+				// matching for all X, instead set do
+				// (ERROR "X" @aligned_indent (#set! "delimiter" "AB") . (_))
+				// and we will fish it out here.
 
-      if (isInError && !indents.hasNode(IDENT_ALIGN, node)) {
-        // only when the node is in error, promote the
-        // first child's aligned indent to the error node
-        // to work around ((ERROR "X" . (_)) @aligned_indent (#set! "delimiter" "AB"))
-        // matching for all X, instead set do
-        // (ERROR "X" @aligned_indent (#set! "delimiter" "AB") . (_))
-        // and we will fish it out here.
+				for (i in 0 until node.childCount) {
+					val child = node.getChild(i)
+					if (indents.hasNode(IDENT_ALIGN, child)) {
+						indents[IDENT_ALIGN]!![node.nodeId] = indents[IDENT_ALIGN]!![child.nodeId]!!
+						break
+					}
+				}
+			}
 
-        for (i in 0 until node.childCount) {
-          val child = node.getChild(i)
-          if (indents.hasNode(IDENT_ALIGN, child)) {
-            indents[IDENT_ALIGN]!![node.nodeId] = indents[IDENT_ALIGN]!![child.nodeId]!!
-            break
-          }
-        }
-      }
+			// do not indent for nodes that starts-and-ends on same line and starts on target line (lnum)
+			if (shouldProcess &&
+				indents.hasNode(IDENT_ALIGN, node) &&
+				(srow != erow || isInError) &&
+				(srow != line)
+			) {
+				val meta = indents.getMeta(IDENT_ALIGN, node)!!
+				var oDelimNode: TSNode?
+				var oIsLastInLine = false
+				var cDelimNode: TSNode?
+				var cIsLastInLine = false
+				var indentIsAbsolute = false
 
-      // do not indent for nodes that starts-and-ends on same line and starts on target line (lnum)
-      if (shouldProcess
-        && indents.hasNode(IDENT_ALIGN, node)
-        && (srow != erow || isInError)
-        && (srow != line)
-      ) {
-        val meta = indents.getMeta(IDENT_ALIGN, node)!!
-        var oDelimNode: TSNode?
-        var oIsLastInLine = false
-        var cDelimNode: TSNode?
-        var cIsLastInLine = false
-        var indentIsAbsolute = false
+				if (meta.containsKey("indent.open_delimiter")) {
+					val r = findDelimiter(content, node, meta["indent.open_delimiter"]!!)
+					oDelimNode = r.first
+					oIsLastInLine = r.second
+				} else {
+					oDelimNode = node
+				}
 
-        if (meta.containsKey("indent.open_delimiter")) {
-          val r = findDelimiter(content, node, meta["indent.open_delimiter"]!!)
-          oDelimNode = r.first
-          oIsLastInLine = r.second
-        } else {
-          oDelimNode = node
-        }
+				if (meta.containsKey("indent.close_delimiter")) {
+					val r = findDelimiter(content, node, meta["indent.close_delimiter"]!!)
+					cDelimNode = r.first
+					cIsLastInLine = r.second
+				} else {
+					cDelimNode = node
+				}
 
-        if (meta.containsKey("indent.close_delimiter")) {
-          val r = findDelimiter(content, node, meta["indent.close_delimiter"]!!)
-          cDelimNode = r.first
-          cIsLastInLine = r.second
-        } else {
-          cDelimNode = node
-        }
+				if (oDelimNode != null) {
+					val osrow = oDelimNode.startPoint.row
+					val oscol = oDelimNode.startPoint.column
+					var csrow: Int? = null
+					if (cDelimNode != null) {
+						csrow = cDelimNode.startPoint.row
+					}
 
-        if (oDelimNode != null) {
-          val osrow = oDelimNode.startPoint.row
-          val oscol = oDelimNode.startPoint.column
-          var csrow: Int? = null
-          if (cDelimNode != null) {
-            csrow = cDelimNode.startPoint.row
-          }
+					if (oIsLastInLine) {
+						// hanging indent (previous line ended with starting delimiter)
+						// should be processed like indent
+						if (shouldProcess) {
+							indent += indentSize
+							if (cIsLastInLine) {
+								// If current line is outside the range of a node marked with `@aligned_indent`
+								// Then its indent level shouldn't be affected by `@aligned_indent` node
+								if (csrow != null && csrow < line) {
+									indent = max(indent - indentSize, 0)
+								}
+							}
+						}
+					} else {
+						// aligned indent
+						if (cIsLastInLine && csrow != null && osrow != csrow && csrow < line) {
+							// If current line is outside the range of a node marked with `@aligned_indent`
+							// Then its indent level shouldn't be affected by `@aligned_indent` node
+							indent = max(indent - indentSize, 0)
+						} else {
+							indent = oscol + (meta.getInt("indent.increment") ?: 1)
+							indentIsAbsolute = true
+						}
+					}
 
-          if (oIsLastInLine) {
-            // hanging indent (previous line ended with starting delimiter)
-            // should be processed like indent
-            if (shouldProcess) {
-              indent += indentSize
-              if (cIsLastInLine) {
-                // If current line is outside the range of a node marked with `@aligned_indent`
-                // Then its indent level shouldn't be affected by `@aligned_indent` node
-                if (csrow != null && csrow < line) {
-                  indent = max(indent - indentSize, 0)
-                }
-              }
-            }
-          } else {
-            // aligned indent
-            if (cIsLastInLine && csrow != null && osrow != csrow && csrow < line) {
-              // If current line is outside the range of a node marked with `@aligned_indent`
-              // Then its indent level shouldn't be affected by `@aligned_indent` node
-              indent = max(indent - indentSize, 0)
-            } else {
-              indent = oscol + (meta.getInt("indent.increment") ?: 1)
-              indentIsAbsolute = true
-            }
-          }
+					// deal with final line
+					var avoidLastMatchingNext = false
+					if (csrow != null && csrow != osrow && csrow == line) {
+						// delims end on current line, and are not open and closed same line.
+						// then this last line may need additional indent to avoid clashes
+						// with the next. `indent.avoid_last_matching_next` controls this behavior,
+						// for example this is needed for function parameters.
 
-          // deal with final line
-          var avoidLastMatchingNext = false
-          if (csrow != null && csrow != osrow && csrow == line) {
-            // delims end on current line, and are not open and closed same line.
-            // then this last line may need additional indent to avoid clashes
-            // with the next. `indent.avoid_last_matching_next` controls this behavior,
-            // for example this is needed for function parameters.
+						avoidLastMatchingNext = meta.getBolean("indent.avoid_last_matching_next")
+							?: false
+					}
 
-            avoidLastMatchingNext = meta.getBolean("indent.avoid_last_matching_next")
-              ?: false
-          }
+					if (avoidLastMatchingNext) {
+						// last line must be indented more in cases where
+						// it would be same indent as next line (we determine this as one
+						// width more than the open indent to avoid confusing with any
+						// hanging indents)
+						val osrowIndent = TextUtils.countLeadingSpaceCount(content.getLine(osrow), indentSize)
+						if (indent <= osrowIndent + indentSize) {
+							indent += indentSize
+						}
+					}
 
-          if (avoidLastMatchingNext) {
-            // last line must be indented more in cases where
-            // it would be same indent as next line (we determine this as one
-            // width more than the open indent to avoid confusing with any
-            // hanging indents)
-            val osrowIndent = TextUtils.countLeadingSpaceCount(content.getLine(osrow), indentSize)
-            if (indent <= osrowIndent + indentSize) {
-              indent += indentSize
-            }
-          }
+					isProcessed = true
+					if (indentIsAbsolute) {
+						// don't allow further indenting by parent nodes, this is an absolute position
+						return indent
+					}
+				}
+			}
 
-          isProcessed = true
-          if (indentIsAbsolute) {
-            // don't allow further indenting by parent nodes, this is an absolute position
-            return indent
-          }
-        }
-      }
+			processedLines[srow] = processedLines.getOrDefault(srow, isProcessed)
 
-      processedLines[srow] = processedLines.getOrDefault(srow, isProcessed)
+			node = node.parent
+		}
 
-      node = node.parent
-    }
+		return indent
+	}
 
-    return indent
-  }
+	private fun findDelimiter(
+		content: Content,
+		node: TSNode,
+		delimiter: String,
+	): Pair<TSNode?, Boolean> {
+		for (i in 0 until node.childCount) {
+			val child = node.getChild(i)
+			if (child.type != delimiter) {
+				continue
+			}
 
-  private fun findDelimiter(content: Content, node: TSNode,
-    delimiter: String): Pair<TSNode?, Boolean> {
-    for (i in 0 until node.childCount) {
-      val child = node.getChild(i)
-      if (child.type != delimiter) {
-        continue
-      }
+			val start = node.startPoint
+			val end = node.endPoint
+			val line = content.getLine(start.line)
+			val escapedDelim = delimiter.replace(DELIMITER_REGEX, "\\\\$0")
+			val trimmedAfterDelim =
+				line
+					.substring((end.column shr 1) + 1)
+					.replace(Regex("""[\s$escapedDelim]*"""), "")
+			return child to trimmedAfterDelim.isEmpty()
+		}
 
-      val start = node.startPoint
-      val end = node.endPoint
-      val line = content.getLine(start.line)
-      val escapedDelim = delimiter.replace(DELIMITER_REGEX, "\\\\$0")
-      val trimmedAfterDelim = line.substring((end.column shr 1) + 1)
-        .replace(Regex("""[\s$escapedDelim]*"""), "")
-      return child to trimmedAfterDelim.isEmpty()
-    }
+		return null to false
+	}
 
-    return null to false
-  }
+	/**
+	 * Get the indents from the query.
+	 *
+	 * @return The indent captures from the query. The returned map has the following structure :
+	 * ```
+	 * map[indentType][node_id] = capture
+	 * ```
+	 * where `indentType` is one of the indent types defined in [TreeSitterIndentProvider.Companion]`.IDENT_XXX`
+	 * and `node_id` is same as [TSNode.getNodeId].
+	 */
+	private fun getIndents(
+		query: TSQuery,
+		cursor: TSQueryCursor,
+	): IndentsContainer {
+		val indents = IndentsContainer()
 
-  /**
-   * Get the indents from the query.
-   *
-   * @return The indent captures from the query. The returned map has the following structure :
-   * ```
-   * map[indentType][node_id] = capture
-   * ```
-   * where `indentType` is one of the indent types defined in [TreeSitterIndentProvider.Companion]`.IDENT_XXX`
-   * and `node_id` is same as [TSNode.getNodeId].
-   */
-  private fun getIndents(
-    query: TSQuery,
-    cursor: TSQueryCursor
-  ): IndentsContainer {
-    val indents = IndentsContainer()
+		var match: TSQueryMatch? = cursor.nextMatch()
+		while (match != null) {
+			for (capture in match.captures) {
+				val captureName = query.getCaptureNameForId(capture.index)
+				if (!indents.containsKey(captureName)) {
+					log.warn("Unknown capture name in indents query: {}", captureName)
+					continue
+				}
 
-    var match: TSQueryMatch? = cursor.nextMatch()
-    while (match != null) {
-      for (capture in match.captures) {
-        val captureName = query.getCaptureNameForId(capture.index)
-        if (!indents.containsKey(captureName)) {
-          log.warn("Unknown capture name in indents query: {}", captureName)
-          continue
-        }
+				indents[captureName]!![capture.node.nodeId] = capture to match.metadata
+			}
+			match = cursor.nextMatch()
+		}
 
-        indents[captureName]!![capture.node.nodeId] = capture to match.metadata
-      }
-      match = cursor.nextMatch()
-    }
+		return indents
+	}
 
-    return indents
-  }
+	private inner class IndentsContainer {
+		private val data =
+			HashMap<String, MutableLongObjectMap<Pair<TSQueryCapture, TSQueryMatch.Metadata>>>(IDENT_TYP_COUNT)
 
-  private inner class IndentsContainer {
+		init {
+			// pre-fill the indents type so we could report any unknown indent types later
+			data[IDENT_AUTO] = mutableLongObjectMapOf()
+			data[IDENT_BEGIN] = mutableLongObjectMapOf()
+			data[IDENT_END] = mutableLongObjectMapOf()
+			data[IDENT_DEDENT] = mutableLongObjectMapOf()
+			data[IDENT_BRANCH] = mutableLongObjectMapOf()
+			data[IDENT_IGNORE] = mutableLongObjectMapOf()
+			data[IDENT_ALIGN] = mutableLongObjectMapOf()
+			data[IDENT_ZERO] = mutableLongObjectMapOf()
+		}
 
-    private val data = HashMap<String, MutableLongObjectMap<Pair<TSQueryCapture, TSQueryMatch.Metadata>>>(
-      IDENT_TYP_COUNT)
+		fun containsKey(key: String): Boolean = data.containsKey(key)
 
-    init {
-      // pre-fill the indents type so we could report any unknown indent types later
-      data[IDENT_AUTO] = mutableLongObjectMapOf()
-      data[IDENT_BEGIN] = mutableLongObjectMapOf()
-      data[IDENT_END] = mutableLongObjectMapOf()
-      data[IDENT_DEDENT] = mutableLongObjectMapOf()
-      data[IDENT_BRANCH] = mutableLongObjectMapOf()
-      data[IDENT_IGNORE] = mutableLongObjectMapOf()
-      data[IDENT_ALIGN] = mutableLongObjectMapOf()
-      data[IDENT_ZERO] = mutableLongObjectMapOf()
-    }
+		fun get(
+			type: String,
+			node: TSNode,
+		) = get(type, node.nodeId)
 
-    fun containsKey(key: String): Boolean {
-      return data.containsKey(key)
-    }
+		fun get(
+			type: String,
+			nodeId: Long,
+		) = data[type]?.get(nodeId)
 
-    fun get(type: String, node: TSNode) = get(type, node.nodeId)
-    fun get(type: String, nodeId: Long) = data[type]?.get(nodeId)
+		fun hasNode(
+			type: String,
+			node: TSNode,
+		) = hasNode(type, node.nodeId)
 
-    fun hasNode(type: String, node: TSNode) = hasNode(type, node.nodeId)
-    fun hasNode(type: String, nodeId: Long) = data[type]?.get(nodeId) != null
+		fun hasNode(
+			type: String,
+			nodeId: Long,
+		) = data[type]?.get(nodeId) != null
 
-    fun hasMeta(type: String, node: TSNode, metaKey: String) = hasMeta(type, node.nodeId, metaKey)
-    fun hasMeta(type: String, nodeId: Long, metaKey: String) =
-      data[type]?.get(nodeId)?.second?.get<Any>(metaKey) != null
+		fun hasMeta(
+			type: String,
+			node: TSNode,
+			metaKey: String,
+		) = hasMeta(type, node.nodeId, metaKey)
 
-    fun getMeta(type: String, node: TSNode) = getMeta(type, node.nodeId)
-    fun getMeta(type: String, nodeId: Long) = data[type]?.get(nodeId)?.second
+		fun hasMeta(
+			type: String,
+			nodeId: Long,
+			metaKey: String,
+		) = data[type]?.get(nodeId)?.second?.get<Any>(metaKey) != null
 
-    fun <T : Any?> getMetaValue(type: String, node: TSNode, metaKey: String) =
-      getMetaValue<T>(type, node.nodeId, metaKey)
+		fun getMeta(
+			type: String,
+			node: TSNode,
+		) = getMeta(type, node.nodeId)
 
-    fun <T : Any?> getMetaValue(type: String, nodeId: Long, metaKey: String) =
-      data[type]?.get(nodeId)?.second?.get<T>(metaKey)
+		fun getMeta(
+			type: String,
+			nodeId: Long,
+		) = data[type]?.get(nodeId)?.second
 
-    operator fun get(
-      key: String): MutableLongObjectMap<Pair<TSQueryCapture, TSQueryMatch.Metadata>>? {
-      return data[key]
-    }
+		fun <T : Any?> getMetaValue(
+			type: String,
+			node: TSNode,
+			metaKey: String,
+		) = getMetaValue<T>(type, node.nodeId, metaKey)
 
-    operator fun set(key: String,
-      value: MutableLongObjectMap<Pair<TSQueryCapture, TSQueryMatch.Metadata>>) {
-      data[key] = value
-    }
-  }
+		fun <T : Any?> getMetaValue(
+			type: String,
+			nodeId: Long,
+			metaKey: String,
+		) = data[type]?.get(nodeId)?.second?.get<T>(metaKey)
+
+		operator fun get(key: String): MutableLongObjectMap<Pair<TSQueryCapture, TSQueryMatch.Metadata>>? = data[key]
+
+		operator fun set(
+			key: String,
+			value: MutableLongObjectMap<Pair<TSQueryCapture, TSQueryMatch.Metadata>>,
+		) {
+			data[key] = value
+		}
+	}
 }
 
 /**
  * Alias for [TSPoint.row].
  */
 private val TSPoint.line: Int
-  get() = this.row
+	get() = this.row
 
 private fun TSQueryMatch.Metadata.getInt(key: String) = getString(key).toIntOrNull()
+
 private fun TSQueryMatch.Metadata.getBolean(key: String) = getString(key).toBooleanStrictOrNull()

--- a/editor/src/main/java/com/itsaky/androidide/editor/language/treesitter/TreeSitterIndentProvider.kt
+++ b/editor/src/main/java/com/itsaky/androidide/editor/language/treesitter/TreeSitterIndentProvider.kt
@@ -161,9 +161,11 @@ class TreeSitterIndentProvider(
 
 			optimizeCursorRange(positions, content, cursor)
 
-			if (!indentsQuery.canAccess() || !cursor.canAccess()) {
+			if (!indentsQuery.canAccess()) {
 				// The spec that owns indentsQuery is closed from the editor's teardown, on another
-				// thread; running a cursor over a freed query is a native crash (ADFA-5401).
+				// thread; running a cursor over a freed query is a native crash. Falling back to the
+				// defaults is the whole answer here - a partially built IndentsContainer would give
+				// silently wrong indentation instead (ADFA-5401).
 				log.info("Cannot compute indents. The indents query is no longer accessible.")
 				return@use defaultIndents
 			}
@@ -499,11 +501,7 @@ class TreeSitterIndentProvider(
 		val indents = IndentsContainer()
 
 		var match: TSQueryMatch? = cursor.nextMatch()
-
-		// Re-checked every iteration, not just before the loop: the query is shared and whoever
-		// frees it does so on another thread, so a free landing mid-traversal would make the next
-		// nextMatch() dereference a dangling TSQuery (ADFA-5401).
-		while (match != null && query.canAccess() && cursor.canAccess()) {
+		while (match != null) {
 			for (capture in match.captures) {
 				val captureName = query.getCaptureNameForId(capture.index)
 				if (!indents.containsKey(captureName)) {

--- a/editor/src/main/java/com/itsaky/androidide/editor/language/treesitter/TreeSitterIndentProvider.kt
+++ b/editor/src/main/java/com/itsaky/androidide/editor/language/treesitter/TreeSitterIndentProvider.kt
@@ -161,6 +161,13 @@ class TreeSitterIndentProvider(
 
 			optimizeCursorRange(positions, content, cursor)
 
+			if (!indentsQuery.canAccess() || !cursor.canAccess()) {
+				// The spec that owns indentsQuery is closed from the editor's teardown, on another
+				// thread; running a cursor over a freed query is a native crash (ADFA-5401).
+				log.info("Cannot compute indents. The indents query is no longer accessible.")
+				return@use defaultIndents
+			}
+
 			cursor.exec(indentsQuery, tree.rootNode)
 
 			val indents = getIndents(languageSpec.indentsQuery, cursor)
@@ -492,7 +499,11 @@ class TreeSitterIndentProvider(
 		val indents = IndentsContainer()
 
 		var match: TSQueryMatch? = cursor.nextMatch()
-		while (match != null) {
+
+		// Re-checked every iteration, not just before the loop: the query is shared and whoever
+		// frees it does so on another thread, so a free landing mid-traversal would make the next
+		// nextMatch() dereference a dangling TSQuery (ADFA-5401).
+		while (match != null && query.canAccess() && cursor.canAccess()) {
 			for (capture in match.captures) {
 				val captureName = query.getCaptureNameForId(capture.index)
 				if (!indents.containsKey(captureName)) {


### PR DESCRIPTION
## ADFA-5401: Guard the shared tree-sitter query

Closing a project could kill the process with a SIGSEGV in `ts_query_cursor_next_match`: a native tree-sitter object was freed while another thread was still using it.

### Finding the object

The crash trace named the call site but not the dead pointer, so I instrumented a debug build and reproduced project close on device:

```
14:06:31.578  TreeSitterWorker  CAPTURE enter/exit  spec=177439654 query=189780455
14:06:31.978  main              GEN.destroy  gen=91225799
14:06:31.978  main              SPEC.close ENTER    spec=177439654 query=189780455
```

It is the **shared `TSQuery`**. `LineSpansGenerator.captureRegion` runs on the generator's own executor; `TsLanguageSpec.close()` — reached from `CodeEditor.release()` → `TreeSitterLanguage.destroy()` → `languageSpec.close()` — frees the query on the **main thread**, and nothing serialises the two.

### What this PR does

`doSafeExecQueryCursor` checked `query.canAccess()` **once before the loop**, but its per-iteration guard covered only the cursor and node — never the query. So a query freed mid-loop made the next `nextMatch()` dereference a dangling pointer. Adding `query.canAccess()` to that condition is the fix.

Everything else here is small and additive:

| Change | Why |
| --- | --- |
| `indentsQuery.canAccess()` before `exec()` in `TreeSitterIndentProvider`, falling back to the default indents | That file never routes through `safeExecQueryCursor` and had no guard at all, on the same free chain |
| `Stop` sentinel in `stop()` | The loop parks in `LinkedBlockingQueue.take()`, a blocking call rather than a suspension point, so cancelling cannot wake it |
| `analyzerContext.close()` after `document.close()` rather than before | The dispatcher should outlive what runs on it |
| `isDestroyed` is `@Volatile` | Written by whoever calls `stop()`, read by the analyzer loop and the query guards |

### What this PR deliberately does *not* do

Three review rounds established that **every change I made to lifecycle or ordering in this module introduced a race I had not foreseen**, while the additive guards held up. Two earlier approaches were tried and reverted:

- **Bounded waits** (`runBlocking` join in `stop()`, `awaitTermination` in `destroy()`). Reverted: `TsAnalyzeManager.reset()` → `rerun()` → `stop()` and `CodeEditor.setText()` calls `reset()`, so `stop()` is on the hot path — every log-filter change, build-output filter change and tab open. A 500ms main-thread wait there is not affordable. On timeout it also freed the document anyway.
- **Moving teardown into the analyzer loop's `finally`.** Reverted: `stop()` cancels the job before offering `Stop`, so a coroutine cancelled before its body was dispatched never runs the `finally` at all — leaking the native document and the dispatcher thread; and `stop()` still called `requestCancellationAndWaitIfParsing()` on the caller thread while the analyzer could be closing that same parser.
- **Drain-and-recycle of queued edits.** Reverted: `TsAnalyzeManager.insert()` hands the same `TSInputEdit` to `LineSpansGenerator.edit()`, which applies it asynchronously, so recycling from `stop()` can corrupt a pending apply. `clear()` is wasteful and safe.

Filed rather than fixed here:

- **ADFA-5413** — the shared `TSQuery` has no ownership, so `canAccess()` stays check-then-use. This PR narrows the window; it does not close it.
- **ADFA-5414** — `doSafeExecQueryCursor`'s top-of-loop exit skips `onClosedOrEdited()` and the match recycle. Pre-existing, but the new guard makes it reachable more often.
- **ADFA-5415** — `stop()` can still free the document while the analyzer reads it. **Correction:** an earlier revision of this description said that path produces a *caught* `IllegalStateException` rather than a SIGSEGV. That is true of the instance I observed (`UTF16String` is access-checked) but not of the path in general: `processNextMessage` checks `isDestroyed` once and then calls `doInit`/`doMod` with no re-check, so `document.close()` -> `parser.close()` can race `parser.parseString()`, and `ts_parser_delete` concurrent with `ts_parser_parse` is a native crash. I used the weaker characterisation to justify deferring this, and it was wrong. The ticket carries the correction and records why both obvious fixes were reverted.
- **ADFA-5407 / ADFA-5408** — `LineSpansGenerator.destroy()` publishing after teardown, and not being idempotent.

**No unit test.** `editor-treesitter` has no test source set, and adding one would mean new test dependencies in vendored sora-editor code. The argument is the mechanism, not the absence of a crash in a handful of cycles.

### Testing

- **On device** (Pixel 6 Pro, Android 17, arm64): four open/close cycles with the log panel open — the shape that produced the original crash. Same pid throughout, no SIGSEGV, no `Cannot access native object`, no `Analyzer job failed`.
- `spotlessApply` clean; `:editor-api:`, `:editor-treesitter:` and `:editor:` compile.

### Review by commit

| Commit | What |
| --- | --- |
| `99255a0`, `eeb5636`, `ae196e3` | style only — the four touched files enter the Spotless ratchet (vendored sora-editor code, 2-space → tabs) |
| `66f3742`, `98c2acb`, `61fa2ab`, `3a98482` | the three superseded attempts, kept for the trail |
| `059f691` | the shrink — reverts the mechanism, keeps the guards. **Read this one against `origin/stage`** |

`LineSpansGenerator.kt`'s licence header is two separate blocks: merging AndroidIDE's GPL-3 notice and Rosemoe's LGPL-2.1 into one would frame two distinct grants on vendored code as one. The one ktlint rule that trips (`no-consecutive-comments`) is suppressed at file level.

Found while verifying ADFA-5375 on device; not caused by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Crj29d6Q2DGjioWPxtuSR
