### PR TITLE
ADFA-5398: Release the debug client when the adapter closes

### DIFF
--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/JavaDebugAdapter.kt
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/JavaDebugAdapter.kt
@@ -238,7 +238,15 @@ internal class JavaDebugAdapter :
 		threadState.initThreads()
 
 		this.vms.add(vmConnection)
-		this._listenerState!!.client.onAttach(client)
+
+		val state = this._listenerState
+		if (state == null) {
+			// close() ran while this connection was being established.
+			logger.warn("Connected to a VM after the debug adapter was closed; not attaching")
+			return
+		}
+
+		state.client.onAttach(client)
 	}
 
 	override suspend fun connectedRemoteClients(): Set<RemoteClient> = vms.map(VmConnection::client).toSet()
@@ -598,6 +606,13 @@ internal class JavaDebugAdapter :
 			listenerThread?.interrupt()
 		} catch (err: Throwable) {
 			logger.error("Unable to stop VM connection listener", err)
+		} finally {
+			// ListenerState holds the IDebugClient, which holds the DebuggerViewModel and its whole
+			// thread/frame/variable state. This adapter lives on JavaLanguageServer in the global
+			// registry, so without dropping the reference here that graph stays reachable from a
+			// native GC root until the next connectDebugClient (ADFA-5398).
+			_listenerState = null
+			listenerThread = null
 		}
 
 		adapterScope.launch(Dispatchers.IO) {

--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/JavaDebugAdapter.kt
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/JavaDebugAdapter.kt
@@ -146,7 +146,7 @@ internal class JavaDebugAdapter :
 
 		_listenerState?.invalidate()
 		listenerThread?.interrupt()
-		
+
 		_listenerState =
 			ListenerState(
 				client = client,
@@ -154,19 +154,20 @@ internal class JavaDebugAdapter :
 				args = args,
 			)
 
-		val failure = withContext(Dispatchers.IO) {
-			try {
-				logger.debug("startListening")
-				listenerState.startListening()
-				null
-			} catch (e: Throwable) {
-				if (e is CancellationException) {
-					throw e
+		val failure =
+			withContext(Dispatchers.IO) {
+				try {
+					logger.debug("startListening")
+					listenerState.startListening()
+					null
+				} catch (e: Throwable) {
+					if (e is CancellationException) {
+						throw e
+					}
+					logger.error("Failed to listen for incoming JDWP connections", e)
+					return@withContext DebugClientConnectionResult.Failure(cause = e)
 				}
-				logger.error("Failed to listen for incoming JDWP connections", e)
-				return@withContext DebugClientConnectionResult.Failure(cause = e)
 			}
-		}
 
 		if (failure != null) {
 			return failure
@@ -354,7 +355,7 @@ internal class JavaDebugAdapter :
 
 					val spec =
 						when (breakpoint) {
-							is PositionalBreakpoint ->
+							is PositionalBreakpoint -> {
 								specList.createBreakpoint(
 									source = breakpoint.source,
 									// +1 because we receive 0-indexed line numbers from the IDE
@@ -363,8 +364,9 @@ internal class JavaDebugAdapter :
 									qualifiedName = qualifiedName,
 									suspendPolicy = breakpoint.suspendPolicy.asJdiInt(),
 								)
+							}
 
-							is MethodBreakpoint ->
+							is MethodBreakpoint -> {
 								specList.createBreakpoint(
 									source = breakpoint.source,
 									methodId = breakpoint.methodId,
@@ -372,8 +374,11 @@ internal class JavaDebugAdapter :
 									qualifiedName = qualifiedName,
 									suspendPolicy = breakpoint.suspendPolicy.asJdiInt(),
 								)
+							}
 
-							else -> throw IllegalArgumentException("Unsupported breakpoint type: $breakpoint")
+							else -> {
+								throw IllegalArgumentException("Unsupported breakpoint type: $breakpoint")
+							}
 						}
 
 					val result =
@@ -385,19 +390,23 @@ internal class JavaDebugAdapter :
 					val resolveSuccess = result.getOrDefault(false)
 
 					when {
-						resolveSuccess && spec.isResolved ->
+						resolveSuccess && spec.isResolved -> {
 							BreakpointResult.Success(
 								breakpoint,
 								false,
 							)
+						}
 
-						resolveSuccess && !spec.isResolved ->
+						resolveSuccess && !spec.isResolved -> {
 							BreakpointResult.Success(
 								breakpoint,
 								true,
 							)
+						}
 
-						else -> BreakpointResult.Failure(breakpoint, failure)
+						else -> {
+							BreakpointResult.Failure(breakpoint, failure)
+						}
 					}
 				},
 			)
@@ -631,8 +640,10 @@ internal class JDWPListenerThread(
 	override fun run() {
 		logger.debug("run::start")
 		if (!listenerState.isListening && !listenerState.isInvalidated) {
-			logger.warn("Listener should've been listening at this point, but it's not. " +
-					"Trying to start listening...")
+			logger.warn(
+				"Listener should've been listening at this point, but it's not. " +
+					"Trying to start listening...",
+			)
 			listenerState.startListening()
 		}
 

--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/JavaDebugAdapter.kt
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/debug/JavaDebugAdapter.kt
@@ -147,12 +147,15 @@ internal class JavaDebugAdapter :
 		_listenerState?.invalidate()
 		listenerThread?.interrupt()
 
-		_listenerState =
+		// Held locally as well as in the field: close() may null the field from another thread, and
+		// re-reading it with !! below would then throw (ADFA-5398).
+		val state =
 			ListenerState(
 				client = client,
 				connector = connector,
 				args = args,
 			)
+		_listenerState = state
 
 		val failure =
 			withContext(Dispatchers.IO) {
@@ -175,7 +178,7 @@ internal class JavaDebugAdapter :
 
 		listenerThread =
 			JDWPListenerThread(
-				_listenerState!!,
+				state,
 				this::onConnectedToVm,
 			).also { thread -> thread.start() }
 		return DebugClientConnectionResult.Success
@@ -239,14 +242,19 @@ internal class JavaDebugAdapter :
 
 		this.vms.add(vmConnection)
 
-		val state = this._listenerState
-		if (state == null) {
-			// close() ran while this connection was being established.
-			logger.warn("Connected to a VM after the debug adapter was closed; not attaching")
+		val listener = this._listenerState
+		if (listener == null) {
+			// close() ran while this connection was being established. Returning here without
+			// undoing the two lines above would leave a live VM connection, and its event handler,
+			// attached to an adapter that is gone.
+			logger.warn("Connected to a VM after the debug adapter was closed; dropping it")
+			vms.remove(vmConnection)
+			runCatching { vmConnection.close() }
+				.onFailure { err -> logger.error("Failed to close a VM connected after close()", err) }
 			return
 		}
 
-		state.client.onAttach(client)
+		listener.client.onAttach(client)
 	}
 
 	override suspend fun connectedRemoteClients(): Set<RemoteClient> = vms.map(VmConnection::client).toSet()
@@ -601,8 +609,12 @@ internal class JavaDebugAdapter :
 
 	override fun close() {
 		logger.debug("close")
+		// Separate catches: the listener thread holds its own ListenerState reference, so if
+		// invalidate() throws and skips the interrupt, clearing the fields below releases nothing.
+		runCatching { _listenerState?.invalidate() }
+			.onFailure { err -> logger.error("Unable to invalidate the VM connection listener", err) }
+
 		try {
-			_listenerState?.invalidate()
 			listenerThread?.interrupt()
 		} catch (err: Throwable) {
 			logger.error("Unable to stop VM connection listener", err)


### PR DESCRIPTION
## ADFA-5398: Release the debug client when the adapter closes

`JavaDebugAdapter.close()` invalidated its `ListenerState` and interrupted the listener thread, but never dropped the reference. So this chain stayed reachable:

```
JDWPListenerThread -> ListenerState -> IDebugClient
  -> DebuggerViewModel -> threads, frames, variablesTree
```

The adapter lives on `JavaLanguageServer` in the process-global registry, so nothing collected that graph until the next `connectDebugClient` happened to replace the state.

`close()` now clears `_listenerState` and `listenerThread` in a `finally`, so the graph is released even if `invalidate()` or `interrupt()` throws. I checked that this actually runs per session rather than only at process exit: `ProjectHandlerActivity` calls `destroyLanguageServers()` on editor destroy, which reaches `JavaLanguageServer.shutdown()` and this `close()`.

`onConnectedToVm` read `_listenerState!!`, so a late callback from the listener thread would now NPE on the cleared field. It takes the state into a local and logs-and-returns if the adapter was closed underneath it.

Unlike the thread leak in ADFA-5375, this is a plain retained-object leak — the kind LeakCanary does report.

### Review by commit

| Commit | What |
| --- | --- |
| `ea3b496` | style only — the file enters the Spotless ratchet, mostly brace-wrapping `when` branches |
| `b1b1d23` | the fix — 16 insertions, 1 deletion |

### Testing

`:lsp:java:` compiles; `spotlessApply` clean.

**Not verified on device.** Exercising this needs a live JDWP attach, which on this hardware means interactive wireless-debugging pairing plus a full on-device Gradle build. The fix is a reference drop on a path I traced by reading — `destroyLanguageServers` → `shutdown()` → `close()` — and I would rather say that than imply a heap dump I did not take. A LeakCanary before/after on a real debug session is the check this deserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Crj29d6Q2DGjioWPxtuSR