### PR TITLE
ADFA-5414 + ADFA-5416: cleanup and guard-order fixes in the tree-sitter query path

### DIFF
--- a/editor-api/src/main/java/com/itsaky/androidide/treesitter/api/tsUtils.kt
+++ b/editor-api/src/main/java/com/itsaky/androidide/treesitter/api/tsUtils.kt
@@ -152,22 +152,33 @@ if (!node.canAccess() || node.hasChanges()) {
 }
 
 exec(query, node)
+
+// Both ways out of this loop have to clean up the same way. The condition is re-checked at the
+// top as well as after the action, because the query, cursor and node are shared and can be
+// closed or edited by another thread at any point; whichever check trips, the caller's
+// onClosedOrEdited must run so it can discard whatever it had half-built, and the match it was
+// holding has to go back to the pool (ADFA-5414).
 var match = nextMatch()
-while (matchCondition(match) && whileTrue(match)) {
+while (match != null) {
+	if (!matchCondition(match)) {
+	logCannotProceed(query, node, debugName, debugLogging)
+	onClosedOrEdited()
+	(match as? TreeSitterQueryMatch?)?.recycle()
+	break
+	}
+
+	if (!whileTrue(match)) {
+	// The caller asked to stop; nothing is wrong, so no onClosedOrEdited.
+	(match as? TreeSitterQueryMatch?)?.recycle()
+	break
+	}
 
 	val result = action(match)
 
 	if (!matchCondition(match)) {
-	if (debugLogging) {
-		log.debug(
-		"$debugName: Cannot proceed with query operation.",
-		"cursor.canAccess=${canAccess()}",
-		"query.canAccess=${query.canAccess()}",
-		"node.canAccess=${node.canAccess()}",
-		"node.hasChanges=${node.canAccess() && node.hasErrors()}"
-		)
-	}
+	logCannotProceed(query, node, debugName, debugLogging)
 	onClosedOrEdited()
+	(match as? TreeSitterQueryMatch?)?.recycle()
 	break
 	}
 
@@ -187,4 +198,27 @@ if (recycleNodeAfterUse && node is TreeSitterNode && !node.isRecycled) {
 }
 
 return null
+}
+
+/**
+ * Diagnostic for the two places [doSafeExecQueryCursor] gives up on a traversal.
+ */
+@PublishedApi
+internal fun TSQueryCursor.logCannotProceed(
+	query: TSQuery,
+	node: TSNode,
+	debugName: String,
+	debugLogging: Boolean,
+) {
+	if (!debugLogging) {
+		return
+	}
+
+	log.debug(
+		"$debugName: Cannot proceed with query operation.",
+		"cursor.canAccess=${canAccess()}",
+		"query.canAccess=${query.canAccess()}",
+		"node.canAccess=${node.canAccess()}",
+		"node.hasChanges=${node.canAccess() && node.hasChanges()}",
+	)
 }

--- a/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
+++ b/editor-treesitter/src/main/java/io/github/rosemoe/sora/editor/ts/TsAnalyzeWorker.kt
@@ -328,8 +328,11 @@ class TsAnalyzeWorker(
 	}
 
 	private fun updateCodeBlocks() {
-		if (languageSpec.blocksQuery.patternCount == 0 ||
-			!languageSpec.blocksQuery.canAccess() ||
+		// canAccess() first: getPatternCount() calls checkAccess() internally, so on a closed query
+		// reading patternCount throws before the guard beside it can return (ADFA-5416). The sibling
+		// site in TsBracketPairs already has the operands this way round.
+		if (!languageSpec.blocksQuery.canAccess() ||
+			languageSpec.blocksQuery.patternCount == 0 ||
 			tree?.canAccess() != true
 		) {
 			return


### PR DESCRIPTION
## ADFA-5414 + ADFA-5416: cleanup and guard-order fixes in the tree-sitter query path

> **Stacked on #1776.** Base is `task/ADFA-5401-treesitter-close-race`, not `stage`, because both files are reformatted by that PR's ratchet commits — basing on `stage` would duplicate those reformats and conflict. Merge #1776 first, or retarget this to `stage` once it lands.

Two independent fixes found while reviewing #1776. Both are small; they share a branch because they are in the same two files and the same review context.

### ADFA-5414 — clean up on both exits from the query cursor loop (`68ed840`)

`doSafeExecQueryCursor` had two ways out and only one cleaned up. The check after `action(match)` called `onClosedOrEdited()` and recycled the match; the **loop condition** could also become false, and that path exited straight out — the caller's compensating action never ran, and the match it was holding never went back to the pool.

That matters because `onClosedOrEdited` is how a caller discards a partial result:

| Caller | `onClosedOrEdited` | Consequence of the silent exit |
| --- | --- | --- |
| `updateCodeBlocks` | `{ blocks.clear() }` | commits a half-built list — the editor draws a truncated set of fold/indent guides instead of none |
| `TsScopedVariables.init` | `{ captures.clear() }` | commits a torn scope tree, mis-resolving local-variable highlighting |

The loop is now driven by `match != null` — normal exhaustion, which must **not** trigger `onClosedOrEdited` — with the condition re-checked at the top as well as after the action. Both failure exits run `onClosedOrEdited()` and recycle; the `whileTrue` exit recycles without it, since a caller stopping on purpose is not an error.

Pre-existing, but #1776 widened it: adding `query.canAccess()` to `matchCondition` means a freed query now reaches this exit too, not just an edited node.

Also corrects the diagnostic beside it, which printed `node.hasErrors()` under a `node.hasChanges` label — `matchCondition` tests `hasChanges`, so the log pointed at the wrong thing precisely when someone would be reading it.

**Not addressed:** the early `return result` path still skips the `node.recycle()` below the loop. Separate leak, and a separate decision about whether a returned result may reference the node.

### ADFA-5416 — check `canAccess()` before reading `patternCount` (`aa973a8`)

`updateCodeBlocks()` guarded on `blocksQuery.patternCount == 0 || !blocksQuery.canAccess() || …`, but `getPatternCount()` calls `checkAccess()` internally — so on a closed query the *first* operand throws before the guard beside it can return. The exception left `updateStyles()` and was swallowed as "AnalyzeWorker crashed", dropping the whole style update rather than skipping just the code-blocks step. Swapped, matching `TsBracketPairs`, which already had the operands this way round.

### Testing

- **On device** (Pixel 6 Pro, Android 17): syntax highlighting renders and updates normally — this loop is what feeds it — with no `AnalyzeWorker crashed`, no `Cannot access native object`, no SIGSEGV.
- `:editor-api:`, `:editor-treesitter:` and `:editor:` compile; `spotlessApply` clean.
- No unit test: `editor-api` has no test source set for this helper, and the behaviour is a teardown race. The argument is the control flow, which is small enough to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Crj29d6Q2DGjioWPxtuSR