### PR TITLE
ADFA-5493: Authorize PR approvers by push access, not author_association

### DIFF
--- a/.github/workflows/jira-advance-to-qa.yml
+++ b/.github/workflows/jira-advance-to-qa.yml
@@ -11,23 +11,46 @@ jobs:
     name: Move linked Jira ticket to QA
     runs-on: ubuntu-latest
     # Public repo: anyone can approve, and a fork branch can be named after
-    # anyone's ticket. Only our own branches, and only an approval from an org
-    # member or a repo collaborator. That is a proxy for write access, not proof
-    # of it -- proving it needs a token this workflow deliberately does not hold.
+    # anyone's ticket, so only our own branches qualify. Whether the approver
+    # may push is settled inside the job, not here.
     if: >-
       github.event.review.state == 'approved' &&
       github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Move the ticket to QA
         timeout-minutes: 5
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
+          APPROVER: ${{ github.event.review.user.login }}
+          GH_TOKEN: ${{ github.token }}
           AUTH: ${{ secrets.JIRA_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}
         run: |
-          [[ "$BRANCH" =~ ADFA-[0-9]+ ]] || { echo "No ADFA key in $BRANCH"; exit 0; }
+          [[ "$BRANCH" =~ ADFA-[0-9]+ ]] || { echo "::warning::No ADFA key in $BRANCH"; exit 0; }
           KEY="${BASH_REMATCH[0]}"
+
+          # github.event.review.author_association is computed for an anonymous
+          # viewer. This org publishes no memberships, so a member reads as
+          # CONTRIBUTOR however much write access they hold, and only the direct
+          # collaborators read as COLLABORATOR. Ask the repository who may push
+          # instead. This endpoint answers "write" for maintain and "read" for
+          # triage, so the two names below cover every role that may push.
+          #
+          # The question is asked here rather than in if: because a skipped job
+          # runs no steps, so it cannot say why it declined. Every decline below
+          # exits 0: this is a convenience, and it never reddens a PR.
+          #
+          # This read needs no scope. Run 33932341806 asked the same endpoint
+          # from a job holding permissions: {} and got "write" for both a
+          # team-derived member and a direct collaborator, so the workflow
+          # keeps granting GITHUB_TOKEN nothing.
+          PERM=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$APPROVER/permission" --jq .permission) \
+            || { echo "::warning::$KEY: cannot read repository access for $APPROVER, ticket untouched"; exit 0; }
+          case "$PERM" in
+            admin | write) ;;
+            *) echo "::warning::$KEY: $APPROVER has $PERM access, not write; ticket untouched"; exit 0 ;;
+          esac
+
           API="https://appdevforall.atlassian.net/rest/api/3/issue/$KEY/transitions"
           jira() { curl -sS -f --max-time 30 -u "$AUTH" "$@"; }
 
@@ -46,5 +69,5 @@ jobs:
             jira -X POST -H 'Content-Type: application/json' \
               -d "{\"transition\":{\"id\":\"$ID\"}}" "$API" \
               || { echo "::warning::$KEY: transition \"$STEP\" failed"; exit 0; }
-            echo "$KEY: $STEP"
+            echo "::notice::$KEY: $STEP"
           done

--- a/.github/workflows/jira-advance-to-qa.yml
+++ b/.github/workflows/jira-advance-to-qa.yml
@@ -29,21 +29,10 @@ jobs:
           [[ "$BRANCH" =~ ADFA-[0-9]+ ]] || { echo "::warning::No ADFA key in $BRANCH"; exit 0; }
           KEY="${BASH_REMATCH[0]}"
 
-          # github.event.review.author_association is computed for an anonymous
-          # viewer. This org publishes no memberships, so a member reads as
-          # CONTRIBUTOR however much write access they hold, and only the direct
-          # collaborators read as COLLABORATOR. Ask the repository who may push
-          # instead. This endpoint answers "write" for maintain and "read" for
-          # triage, so the two names below cover every role that may push.
-          #
-          # The question is asked here rather than in if: because a skipped job
-          # runs no steps, so it cannot say why it declined. Every decline below
-          # exits 0: this is a convenience, and it never reddens a PR.
-          #
-          # This read needs no scope. Run 33932341806 asked the same endpoint
-          # from a job holding permissions: {} and got "write" for both a
-          # team-derived member and a direct collaborator, so the workflow
-          # keeps granting GITHUB_TOKEN nothing.
+          # author_association is an anonymous-viewer value: private org members
+          # read as CONTRIBUTOR, so it cannot say who may push. maintain reports
+          # here as write, triage as read. Asked in the step, not in if:, because
+          # a skipped job cannot warn.
           PERM=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$APPROVER/permission" --jq .permission) \
             || { echo "::warning::$KEY: cannot read repository access for $APPROVER, ticket untouched"; exit 0; }
           case "$PERM" in


### PR DESCRIPTION
Fixes ADFA-5493.

## The defect

`github.event.review.author_association` is computed for an anonymous viewer. This org publishes no memberships, so every member reads as `CONTRIBUTOR` however much write access they hold, and only the seven *direct* collaborators read as `COLLABORATOR`. The `OWNER`/`MEMBER`/`COLLABORATOR` gate therefore rejected approvals from anyone whose write access arrives through a team.

The workflow has never advanced a ticket. Of its 150 runs, 149 were comment or change-request reviews, which the state test correctly drops. The single approval to reach it since it merged to `stage` -- itsaky-adfa on #1721, run `33880565001` -- was skipped, though that account holds `write`.

Evidence: the same review read from the REST API returns `author_association=MEMBER` authenticated and `CONTRIBUTOR` anonymously; `orgs/appdevforall/public_members` is empty; `collaborators/itsaky-adfa/permission` returns `write`.

## The change

Ask the repository who may push instead of inferring it from the payload. The endpoint reports `maintain` as `write` and `triage` as `read`, so `admin|write` covers every role that may push and excludes the ones that may not.

The check also moves out of the job-level `if:` into the job. A skipped job runs no steps, so it cannot say why it declined -- which is how this stayed invisible across 150 runs. The `if:` keeps only the cheap filters (approved, not draft, our own branch), so comment reviews still skip silently, and every decline inside the job now warns with the ticket key and the reason. Declines still exit 0: this is a convenience, and it never reddens a PR.

## Verification

A throwaway probe (run `33932341806`, since deleted) asked the endpoint from two jobs differing only in their `permissions` block. Both answered, both reported `write` for a team-derived member *and* a direct collaborator:

```
PROBE none/itsaky-adfa: ok -> write        PROBE contents-read/itsaky-adfa: ok -> write
PROBE none/jatezzz:     ok -> write        PROBE contents-read/jatezzz:     ok -> write
```

That disproved the assumption this branch started with, that the job would need `contents: read`. It does not: `permissions: {}` stands, and the job grants `GITHUB_TOKEN` nothing.

`actionlint` and `shellcheck` pass. Both untrusted values (`head.ref`, `review.user.login`) stay in `env:` and are only ever used quoted.

**This PR is its own end-to-end test.** `pull_request_review` runs the head branch's copy of the workflow, so approving this PR should move ADFA-5493 forward where run `33880565001` stood still. An approval from a reviewer whose access comes through a team is the interesting case; a direct collaborator's approval must keep working.

## Siblings checked, deliberately left alone

Two other workflows read the same field. Neither is a security hole and neither is touched here:

- `debug.yml:437` reads `author_association` from the merged PR through an authenticated API call, not a webhook payload, so it may or may not see the same value -- I did not determine what an installation token reports. Its worst case is a skipped fix-version update on an internal merge that carries no ADFA key anywhere, which branch-name linting already makes rare.
- `lint-branch-name.yml:23` gates on the same three names, but its job already restricts itself to fork PRs. Worst case is nagging an insider who opened a PR from a personal fork about the `community/` prefix. Cosmetic.

Happy to file a follow-up for either.