### PR TITLE
ADFA-5595: Remove the Sentry MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,5 @@
 {
   "mcpServers": {
-    "sentry": {
-      "type": "http",
-      "url": "https://mcp.sentry.dev/mcp"
-    },
     "sonarqube": {
       "command": "sonar",
       "args": [


### PR DESCRIPTION
## What

Removes the `sentry` MCP server from `.mcp.json`. `sonarqube` is now the only configured server.

## Why

[ADFA-5595](https://appdevforall.atlassian.net/browse/ADFA-5595) — the hosted `https://mcp.sentry.dev/mcp` server is no longer wanted in the repo's Claude Code config.

## Scope check

`.mcp.json` is the only place the Sentry MCP appeared. Deliberately left alone:

- `gradle/libs.versions.toml` `sentry-*` aliases and the `io.sentry.android.gradle` plugin — that is the Sentry SDK used as our GlitchTip client, unrelated to the MCP server.
- `.github/workflows/analyze.yml` and `REVIEW.md` — reference the SDK, not the MCP.
- `CLAUDE.md` documents the SonarQube MCP only, so no doc drift.

## Test

Config-only change; no code paths touched. `python3 -m json.tool .mcp.json` parses clean.

https://claude.ai/code/session_01H74p2We7nSkpAX8hq1swEo


[ADFA-5595]: https://appdevforall.atlassian.net/browse/ADFA-5595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ