### PR TITLE
ADFA-5607: Nudge the documentation team on user-facing text changes

### DIFF
--- a/.githooks/pre-push/0003-strings-review-nudge
+++ b/.githooks/pre-push/0003-strings-review-nudge
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Non-blocking nudge: when a push changes user-facing text, remind the author to
+# ask the documentation team (#documentation-request) before the PR goes out.
+#
+# Two triggers, because they need two mechanisms. English strings.xml files are
+# path-matchable, so CODEOWNERS already auto-requests @appdevforall/documentation
+# at PR time -- this hook just moves that signal earlier. Inline literals are NOT
+# path-matchable (you cannot own "Kotlin files that happen to contain UI text"),
+# so a content scan of the diff is the only way to catch them.
+#
+# This is a REMINDER, not a gate -- it always exits 0 and never blocks a push.
+
+set -u
+
+cyan=$(tput setaf 6 2>/dev/null || true)
+yellow=$(tput setaf 3 2>/dev/null || true)
+reset=$(tput sgr0 2>/dev/null || true)
+
+# Determine the commits being pushed. Prefer the tracked upstream; fall back to
+# the integration branch (feature branches are based on stage). If neither is
+# resolvable, stay quiet rather than nag.
+if git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1; then
+	range="@{upstream}..HEAD"
+elif git rev-parse --verify -q origin/stage >/dev/null 2>&1; then
+	range="origin/stage..HEAD"
+else
+	exit 0
+fi
+
+# The English source strings owned by the documentation team. Kept in step with
+# CODEOWNERS on purpose: the hook and the PR-time reviewer request must agree.
+strings=$(git diff --name-only "$range" -- \
+	'app/src/main/res/values/strings.xml' \
+	'resources/src/main/res/values/strings.xml' \
+	'logsender/src/main/res/values/strings.xml' 2>/dev/null) || exit 0
+
+# Calls that put a literal in front of the user. The trailing [^"] rejects the
+# empty literal, so clearing a field (editor?.setText("")) does not nag.
+ui_text='android:(text|hint|contentDescription|title|summary|label)="[^@?"]'
+ui_text+='|(setText|setContentText|setContentTitle|setTitle|setMessage|setSummary)\("[^"]'
+ui_text+='|makeText\(.*, *"[^"]'
+ui_text+='|(^|[^A-Za-z])Text\( *(text *= *)?"[^"]'
+
+# Added lines only ("^+", minus the "+++" file header), so pre-existing hardcoded
+# text does not re-nag on every push. git-core is excluded because JGit's
+# CommitCommand.setMessage writes a commit message, not UI text.
+inline=$(git diff --unified=0 "$range" -- \
+	'*.kt' '*.java' '*/res/layout/*.xml' \
+	':!git-core/' ':!*/src/test/*' ':!*/src/androidTest/*' 2>/dev/null \
+	| grep -E '^\+' \
+	| grep -vE '^\+\+\+' \
+	| grep -E "$ui_text" \
+	|| true)
+
+[ -n "$strings" ] || [ -n "$inline" ] || exit 0
+
+echo ""
+echo "${cyan}[documentation nudge]${reset} this push changes user-facing text."
+
+if [ -n "$strings" ]; then
+	echo "${yellow}  English strings.xml:${reset}"
+	printf '%s\n' "$strings" | sed 's/^/    /'
+fi
+
+if [ -n "$inline" ]; then
+	echo "${yellow}  Text written inline instead of in strings.xml:${reset}"
+	printf '%s\n' "$inline" | sed 's/^+[[:space:]]*/    /'
+fi
+
+echo "${yellow}  Post in ${cyan}#documentation-request${yellow} before opening the PR${reset}${yellow} -- the"
+echo "  documentation team would rather see wording now than after QA.${reset}"
+echo "${yellow}  (Reminder only -- your push continues.)${reset}"
+echo ""
+
+exit 0

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,23 +1,9 @@
-./logsender/src/main/res/values/strings.xml @appdevforall/documentation
-./app/src/main/res/values/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-es-rES/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-zh-rCN/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-bn-rIN/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-de-rDE/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-ru-rRU/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-hi-rIN/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-pt-rBR/strings.xml @appdevforall/documentation
-./resources/src/main/res/values/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-tr-rTR/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-ro-rRO/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-in-rID/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-ar-rSA/strings.xml @appdevforall/documentation
-./resources/src/main/res/values-fr-rFR/strings.xml @appdevforall/documentation
-./LayoutEditor/app/src/main/res/values-ru/strings.xml @appdevforall/documentation
-./LayoutEditor/app/src/main/res/values-zh-rTW/strings.xml @appdevforall/documentation
-./LayoutEditor/app/src/main/res/values-zh-rCN/strings.xml @appdevforall/documentation
-./LayoutEditor/app/src/main/res/values-in/strings.xml @appdevforall/documentation
-./LayoutEditor/app/src/main/res/values-pt-rBR/strings.xml @appdevforall/documentation
-./LayoutEditor/app/src/main/res/values/strings.xml @appdevforall/documentation
-./LayoutEditor/app/src/main/res/values-tr/strings.xml @appdevforall/documentation
-./LayoutEditor/app/src/main/assets/strings.xml @appdevforall/documentation
+# GitHub reads these as gitignore-style patterns. A leading "./" matches
+# nothing, which is why every rule in this file was inert from 2025-04 until
+# ADFA-5607: no strings.xml change ever auto-requested the documentation team.
+#
+# English source strings only. Translated values-XX/strings.xml files are a
+# different review (wording is already settled by the time it is translated).
+app/src/main/res/values/strings.xml        @appdevforall/documentation
+resources/src/main/res/values/strings.xml  @appdevforall/documentation
+logsender/src/main/res/values/strings.xml  @appdevforall/documentation


### PR DESCRIPTION
Engineers ship user-facing strings through code review and QA without ever asking the documentation team. Two gaps caused it, and they need two mechanisms, because one trigger is path-matchable and the other is not.

## 1. CODEOWNERS was inert

Every pattern carried a leading `./`, which gitignore syntax does not match. The documentation team was never auto-requested on a `strings.xml` change from April 2025 until now. GitHub's `codeowners/errors` API reports `{"errors":[]}` for this, so nothing ever surfaced it.

Confirmed against history rather than assumed — PRs #1456, #1780 and #1781 each changed an owned `strings.xml`, and `@appdevforall/documentation` appears in none of their `review_requested` timeline events, while other teams and individuals do:

| Pattern | `git check-ignore` vs `app/src/main/res/values/strings.xml` |
|---------|------------------------------------------------------------|
| `./app/src/main/res/values/strings.xml` | **no match** |
| `app/src/main/res/values/strings.xml` | matches |

Also removed: 8 rules for `LayoutEditor/**` paths that no longer exist in the repo, and 15 translated `values-XX` rules. Translation is a separate review — wording is settled before it is translated.

Scope is now the three English sources:

| Owned file | Strings | Commits touching it in the last 150 |
|-----------|---------|--------------------------------------|
| `resources/src/main/res/values/strings.xml` | 1387 | 32 |
| `app/src/main/res/values/strings.xml` | 7 | 0 |
| `logsender/src/main/res/values/strings.xml` | 5 | 0 |

`resources/` carries effectively all user-facing text. The other two stay owned as cheap insurance.

**Left unowned on purpose:** the vendored `appintro` subtree, the `gradle-plugin` and `testing` resource fixtures, `logsender-sample`, `apk-viewer-plugin`, `markdown-preview-plugin`, and `docs/docdb/*.sql` tooltip text.

## 2. New pre-push hook for inline strings

CODEOWNERS matches paths, so it structurally cannot cover a literal inside a `.kt` file — you cannot own "Kotlin files that happen to contain UI text". `.githooks/pre-push/0003-strings-review-nudge` scans added lines in the push range instead and points the author at `#documentation-request`.

It follows the existing `0002-architecture-review-nudge`: non-blocking, always exits 0, silent unless it matches. Its `strings.xml` list is identical to CODEOWNERS on purpose, so the early nudge and the PR-time reviewer request cannot drift apart.

Over the last 150 commits on `stage`, 4 commits contained inline literals: two were real user-facing text, two were false positives — an empty `setText("")` and JGit's `CommitCommand.setMessage` under `git-core/`. Both filters are in the hook.

## Verification

| Check | Result |
|-------|--------|
| gitignore semantics of both pattern forms | Proved directly with `git check-ignore -v` in a scratch repo |
| Regex regression vs the 4 historical commits | 4/4 pass — both true positives caught, both false positives filtered |
| Filters are load-bearing | Removing either makes its commit produce 1 spurious hit; with them, 0 |
| Hook silent when nothing matches | Ran on this branch, and again live during this push — no output, exit 0 |
| Hook fires on `strings.xml` | Temp commit, fired, reverted |
| Hook fires on an inline literal | Temp commit with `setTitle("Delete this project?")`, fired, reverted |
| Spotless | `spotlessShellCheck` passed on push |

**Not verified, and it cannot be from this PR:** CODEOWNERS only takes effect once merged, because the base branch's copy governs. The end-to-end proof is the next `strings.xml` PR after this merges.

No UI change, so no font-scale check applies.

## Separate defect found, not fixed here

`CONTRIBUTING.md:29`/`:34` and `CLAUDE.md:79` tell people to run `scripts/install-git-hooks.sh`, deleted in ADFA-902. Hooks are now installed by `flox activate -d flox/local` instead, which is why hook reach is actually fine. Worth its own ticket.

https://claude.ai/code/session_0112h3Murjs6kBZLwrYYoXPr