### PR TITLE
ADFA-2602: Build the per-ABI asset zips from any branch, with content gates

### DIFF
--- a/.github/workflows/generate_assets.yml
+++ b/.github/workflows/generate_assets.yml
@@ -19,7 +19,12 @@ on:
         type: choice
         options:
           - site
+          - candidate
           - release
+      candidate_path:
+        description: 'GreenGeeks candidate staging path (asset_source: candidate), e.g. tmp/assets/candidates/42'
+        required: false
+        default: ''
       asset_release_tag:
         description: 'Release tag holding the debug ingredients (asset_source: release)'
         required: false
@@ -77,7 +82,7 @@ jobs:
           access_token_scopes: 'https://www.googleapis.com/auth/drive'
 
       - name: Set up SSH key
-        if: inputs.asset_source == 'site'
+        if: inputs.asset_source == 'site' || inputs.asset_source == 'candidate'
         env:
           GREENGEEKS_HOST: ${{ vars.GREENGEEKS_SSH_HOST }}
           GREENGEEKS_KEY: ${{ secrets.GREENGEEKS_SSH_PRIVATE_KEY }}
@@ -140,6 +145,23 @@ jobs:
             -Dandroid.aapt2.daemonHeapSize=4096M \
             -Dorg.gradle.workers.max=1 \
             -Dorg.gradle.parallel=false
+
+      - name: Download debug assets from the candidate staging area
+        if: inputs.asset_source == 'candidate'
+        env:
+          GREENGEEKS_HOST: ${{ vars.GREENGEEKS_SSH_HOST }}
+          CANDIDATE_PATH: ${{ inputs.candidate_path }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CANDIDATE_PATH" ]; then
+            echo "ERROR: asset_source is 'candidate' but candidate_path is empty."
+            echo "       Take the path from the dev-assets asset-set run summary."
+            exit 1
+          fi
+          mkdir -p assets
+          scp "$GREENGEEKS_HOST:$CANDIDATE_PATH/debug/*" assets/
+          rm -f assets/*.md5
+          ls -la assets/
 
       - name: Download debug assets from a release
         if: inputs.asset_source == 'release'
@@ -232,7 +254,7 @@ jobs:
           echo "google-services.json cleaned up successfully"
 
       - name: Cleanup ssh
-        if: always() && inputs.asset_source == 'site'
+        if: always() && (inputs.asset_source == 'site' || inputs.asset_source == 'candidate')
         run: |
           # Remove SSH key
           rm -f ~/.ssh/id_rsa

--- a/.github/workflows/generate_assets.yml
+++ b/.github/workflows/generate_assets.yml
@@ -327,6 +327,16 @@ jobs:
             -Dorg.gradle.workers.max=1 \
             -Dorg.gradle.parallel=false
 
+      - name: Read the toolchain version
+        id: toolchain
+        run: |
+          set -euo pipefail
+          CONSTANTS=composite-builds/build-deps-common/constants/src/main/java/org/adfa/constants/constants.kt
+          ver=$(grep 'GRADLE_DISTRIBUTION_VERSION' "$CONSTANTS" | grep -o '"[0-9.]*"' | tr -d '"')
+          [ -n "$ver" ] || { echo "ERROR: could not read GRADLE_DISTRIBUTION_VERSION"; exit 1; }
+          echo "GRADLE_VERSION=$ver" >> $GITHUB_OUTPUT
+          echo "toolchain: gradle $ver"
+
       - name: Verify assets zip
         id: assets_zip
         run: |
@@ -354,10 +364,10 @@ jobs:
           CLOUDFLARE_KEY_ID: ${{ vars.CLOUDFLARE_KEY_ID }}
           CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
           R2_BUCKET: ${{ vars.R2_ASSETS_BUCKET || 'apk-repo' }}
-          R2_KEY_PREFIX: assets/
+          R2_KEY_PREFIX: assets/${{ steps.toolchain.outputs.GRADLE_VERSION }}/
         run: |
           uv run --with boto3 scripts/cloudflare-r2-upload.py "${{ steps.assets_zip.outputs.ASSETS_PATH }}"
-          echo "DOWNLOAD_URL=https://download.appdevforall.org/assets/assets-${{ matrix.arch }}.zip" >> $GITHUB_OUTPUT
+          echo "DOWNLOAD_URL=https://download.appdevforall.org/assets/${{ steps.toolchain.outputs.GRADLE_VERSION }}/assets-${{ matrix.arch }}.zip" >> $GITHUB_OUTPUT
 
       - name: Send Slack notification
         env:
@@ -365,11 +375,13 @@ jobs:
           ASSET_LABEL: ${{ matrix.label }}
           DOWNLOAD_URL: ${{ steps.r2.outputs.DOWNLOAD_URL }}
           BUILD_REF: ${{ inputs.ref }}
+          GRADLE_VERSION: ${{ steps.toolchain.outputs.GRADLE_VERSION }}
         run: |
           jq -n \
             --arg label "$ASSET_LABEL" \
             --arg url "$DOWNLOAD_URL" \
             --arg ref "$BUILD_REF" \
+            --arg gradle "$GRADLE_VERSION" \
             '{
               blocks: [
                 {
@@ -392,7 +404,7 @@ jobs:
                   elements: [
                     {
                       type: "mrkdwn",
-                      text: "Built from `\($ref)`. Push to `/sdcard/Download/` on the device, then `adb shell touch` it."
+                      text: "Gradle \($gradle), built from `\($ref)`. Push to `/sdcard/Download/` on the device, then `adb shell touch` it."
                     }
                   ]
                 }

--- a/.github/workflows/generate_assets.yml
+++ b/.github/workflows/generate_assets.yml
@@ -35,6 +35,10 @@ on:
         required: false
         default: adfa-2602-rc
 
+concurrency:
+  group: generate-assets
+  cancel-in-progress: false
+
 env:
   SCP_HOST: ${{ vars.GREENGEEKS_SSH_HOST }}
 
@@ -244,11 +248,37 @@ jobs:
             || { echo "ERROR: documentation.db predates the templateId column; docs requests will 500"; exit 1; }
           echo "All ingredients staged"
 
-      - name: Upload staged assets
+      - name: Upload staged assets (ABI-independent)
         uses: actions/upload-artifact@v4
         with:
-          name: debug-assets
-          path: assets/
+          name: debug-assets-common
+          path: |
+            assets/
+            !assets/android-sdk-*.zip
+            !assets/bootstrap-*.zip
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload staged assets (v8)
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-assets-v8
+          path: |
+            assets/android-sdk-arm64-v8a.zip
+            assets/bootstrap-arm64-v8a.zip
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload staged assets (v7)
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-assets-v7
+          path: |
+            assets/android-sdk-armeabi-v7a.zip
+            assets/bootstrap-armeabi-v7a.zip
+          compression-level: 0
           retention-days: 1
           if-no-files-found: error
 
@@ -317,10 +347,16 @@ jobs:
         run: |
           echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
 
-      - name: Download staged assets
+      - name: Download staged assets (ABI-independent)
         uses: actions/download-artifact@v4
         with:
-          name: debug-assets
+          name: debug-assets-common
+          path: assets
+
+      - name: Download staged assets (this ABI)
+        uses: actions/download-artifact@v4
+        with:
+          name: debug-assets-${{ matrix.abi }}
           path: assets
 
       - name: Assemble assets zip
@@ -344,6 +380,8 @@ jobs:
 
       - name: Verify assets zip
         id: assets_zip
+        env:
+          GRADLE_VERSION: ${{ steps.toolchain.outputs.GRADLE_VERSION }}
         run: |
           zip_path="app/build/outputs/assets/assets-${{ matrix.arch }}.zip"
           if [ ! -s "$zip_path" ]; then
@@ -352,7 +390,8 @@ jobs:
           fi
           unzip -tq "$zip_path"
           for entry in android-sdk.zip bootstrap.zip localMvnRepository.zip documentation.db \
-                       core.cgt plugin-artifacts.zip plugin-maven-repo.zip; do
+                       core.cgt plugin-artifacts.zip plugin-maven-repo.zip \
+                       "gradle-$GRADLE_VERSION-bin.zip" "gradle-api-$GRADLE_VERSION.jar.zip"; do
             unzip -l "$zip_path" | grep -qE "[[:space:]]$entry$" \
               || { echo "ERROR: $zip_path is missing entry $entry"; exit 1; }
           done

--- a/.github/workflows/generate_assets.yml
+++ b/.github/workflows/generate_assets.yml
@@ -312,9 +312,11 @@ jobs:
           - abi: v8
             arch: arm64-v8a
             label: 64-bit ARM
+            drive_file_id_secret: ASSETS_V8_FILE_ID
           - abi: v7
             arch: armeabi-v7a
             label: 32-bit ARM
+            drive_file_id_secret: ASSETS_V7_FILE_ID
 
     steps:
       - name: Checkout repository
@@ -346,6 +348,15 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
           echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+
+      - name: Authenticate to Google Cloud for Drive access
+        id: auth_drive
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.IDENTITY_EMAIL }}
+          token_format: 'access_token'
+          access_token_scopes: 'https://www.googleapis.com/auth/drive'
 
       - name: Download staged assets (ABI-independent)
         uses: actions/download-artifact@v4
@@ -398,33 +409,39 @@ jobs:
           echo "ASSETS_PATH=$zip_path" >> $GITHUB_OUTPUT
           echo "$(du -h "$zip_path" | cut -f1) $zip_path"
 
-      - name: Checkout this workflow's tooling
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-          path: .workflow-tools
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Upload assets zip to Cloudflare R2
-        id: r2
+      - name: Upload assets zip to Google Drive
+        id: drive
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_KEY_ID: ${{ vars.CLOUDFLARE_KEY_ID }}
-          CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
-          R2_BUCKET: ${{ vars.R2_ASSETS_BUCKET || 'apk-repo' }}
-          R2_KEY_PREFIX: assets/${{ steps.toolchain.outputs.GRADLE_VERSION }}/
+          ACCESS_TOKEN: ${{ steps.auth_drive.outputs.access_token }}
+          DRIVE_FILE_ID: ${{ secrets[matrix.drive_file_id_secret] }}
+          ASSETS_PATH: ${{ steps.assets_zip.outputs.ASSETS_PATH }}
         run: |
-          uv run --with boto3 .workflow-tools/scripts/cloudflare-r2-upload.py "${{ steps.assets_zip.outputs.ASSETS_PATH }}"
-          echo "DOWNLOAD_URL=https://download.appdevforall.org/assets/${{ steps.toolchain.outputs.GRADLE_VERSION }}/assets-${{ matrix.arch }}.zip" >> $GITHUB_OUTPUT
+          if [ -z "$DRIVE_FILE_ID" ]; then
+            echo "ERROR: ${{ matrix.drive_file_id_secret }} is not set"
+            exit 1
+          fi
+
+          echo "Uploading $ASSETS_PATH to Drive file $DRIVE_FILE_ID..."
+          response=$(curl -s -o /dev/null -w "%{http_code}" --fail -X PATCH \
+            -H "Authorization: Bearer $ACCESS_TOKEN" \
+            -H "Content-Type: application/zip" \
+            --upload-file "$ASSETS_PATH" \
+            "https://www.googleapis.com/upload/drive/v3/files/${DRIVE_FILE_ID}?uploadType=media")
+
+          if [[ "$response" -ne 200 ]]; then
+            echo "Upload of $ASSETS_PATH failed with HTTP status $response"
+            exit 1
+          fi
+
+          echo "Upload complete."
+          echo "DOWNLOAD_URL=https://drive.google.com/file/d/${DRIVE_FILE_ID}/view" >> $GITHUB_OUTPUT
 
       - name: Send Slack notification
         if: inputs.notify_slack
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           ASSET_LABEL: ${{ matrix.label }}
-          DOWNLOAD_URL: ${{ steps.r2.outputs.DOWNLOAD_URL }}
+          DOWNLOAD_URL: ${{ steps.drive.outputs.DOWNLOAD_URL }}
           BUILD_REF: ${{ inputs.ref }}
           GRADLE_VERSION: ${{ steps.toolchain.outputs.GRADLE_VERSION }}
         run: |
@@ -447,7 +464,7 @@ jobs:
                   type: "section",
                   text: {
                     type: "mrkdwn",
-                    text: "*\($label):* <\($url)|Download assets zip>"
+                    text: "*Assets \($label) Link:* <\($url)|Download Assets Zip \($label)>"
                   }
                 },
                 {

--- a/.github/workflows/generate_assets.yml
+++ b/.github/workflows/generate_assets.yml
@@ -21,6 +21,11 @@ on:
           - site
           - candidate
           - release
+      notify_slack:
+        description: Post the download links to Slack
+        required: false
+        type: boolean
+        default: false
       candidate_path:
         description: 'GreenGeeks candidate staging path (asset_source: candidate), e.g. tmp/assets/candidates/42'
         required: false
@@ -354,6 +359,12 @@ jobs:
           echo "ASSETS_PATH=$zip_path" >> $GITHUB_OUTPUT
           echo "$(du -h "$zip_path" | cut -f1) $zip_path"
 
+      - name: Checkout this workflow's tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          path: .workflow-tools
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
@@ -366,10 +377,11 @@ jobs:
           R2_BUCKET: ${{ vars.R2_ASSETS_BUCKET || 'apk-repo' }}
           R2_KEY_PREFIX: assets/${{ steps.toolchain.outputs.GRADLE_VERSION }}/
         run: |
-          uv run --with boto3 scripts/cloudflare-r2-upload.py "${{ steps.assets_zip.outputs.ASSETS_PATH }}"
+          uv run --with boto3 .workflow-tools/scripts/cloudflare-r2-upload.py "${{ steps.assets_zip.outputs.ASSETS_PATH }}"
           echo "DOWNLOAD_URL=https://download.appdevforall.org/assets/${{ steps.toolchain.outputs.GRADLE_VERSION }}/assets-${{ matrix.arch }}.zip" >> $GITHUB_OUTPUT
 
       - name: Send Slack notification
+        if: inputs.notify_slack
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           ASSET_LABEL: ${{ matrix.label }}

--- a/.github/workflows/generate_assets.yml
+++ b/.github/workflows/generate_assets.yml
@@ -1,4 +1,4 @@
-name: Generate Assets Zips and Upload to Google Drive
+name: Generate Assets Zips
 
 permissions:
   id-token: write
@@ -7,13 +7,30 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch or tag to build the asset zips from
+        required: false
+        default: stage
+      asset_source:
+        description: Where the debug asset ingredients come from
+        required: false
+        default: site
+        type: choice
+        options:
+          - site
+          - release
+      asset_release_tag:
+        description: 'Release tag holding the debug ingredients (asset_source: release)'
+        required: false
+        default: adfa-2602-rc
 
 env:
   SCP_HOST: ${{ vars.GREENGEEKS_SSH_HOST }}
 
 jobs:
-  generate_assets:
-    name: Generate Assets Zips
+  prepare:
+    name: Stage debug assets
     runs-on: self-hosted
     timeout-minutes: 90
 
@@ -21,7 +38,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: stage
+          ref: ${{ inputs.ref }}
+
+      - name: Remove stale staged assets
+        run: |
+          rm -f assets/*.zip assets/documentation.db assets/core.cgt
+          ls -la assets/ 2>/dev/null || true
 
       - name: Check if Nix is installed
         id: check_nix
@@ -55,6 +77,7 @@ jobs:
           access_token_scopes: 'https://www.googleapis.com/auth/drive'
 
       - name: Set up SSH key
+        if: inputs.asset_source == 'site'
         env:
           GREENGEEKS_HOST: ${{ vars.GREENGEEKS_SSH_HOST }}
           GREENGEEKS_KEY: ${{ secrets.GREENGEEKS_SSH_PRIVATE_KEY }}
@@ -109,7 +132,8 @@ jobs:
           rm -f ~/.ssh/id_ed25519 ~/.ssh/id_ecdsa ~/.ssh/id_dsa ~/.ssh/id_rsa.pub 2>/dev/null
           ssh-keyscan -H "$GREENGEEKS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
-      - name: Download debug assets
+      - name: Download debug assets from the site
+        if: inputs.asset_source == 'site'
         run: |
           flox activate -d flox/base -- ./gradlew :app:assetsDownloadDebug --no-daemon \
             -Dorg.gradle.jvmargs="-Xmx10g -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED" \
@@ -117,12 +141,28 @@ jobs:
             -Dorg.gradle.workers.max=1 \
             -Dorg.gradle.parallel=false
 
+      - name: Download debug assets from a release
+        if: inputs.asset_source == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ASSET_TAG: ${{ inputs.asset_release_tag }}
+        run: |
+          mkdir -p assets
+          gh release download "$ASSET_TAG" --dir assets --clobber \
+            --pattern 'android-sdk-*.zip' \
+            --pattern 'bootstrap-*.zip' \
+            --pattern 'gradle-*-bin.zip' \
+            --pattern 'gradle-api-*.jar.zip' \
+            --pattern 'localMvnRepository.zip' \
+            --pattern 'core.cgt'
+          ls -la assets/
+
       - name: Download latest documentation.db from Google Drive
         run: |
           DB_FILE_ID="${{ secrets.DOCUMENTATION_DB_FILE_ID }}"
           ACCESS_TOKEN="${{ steps.auth_drive.outputs.access_token }}"
 
-          if [ -z "DB_FILE_ID" ]; then
+          if [ -z "$DB_FILE_ID" ]; then
             echo "ERROR: DOCUMENTATION_DB_FILE_ID secret not set"
             echo "Please set the DOCUMENTATION_DB_FILE_ID secret in repository settings"
             exit 1
@@ -151,107 +191,40 @@ jobs:
 
           echo "Successfully downloaded documentation.db ($FILE_SIZE_HUMAN)"
 
-      - name: Assemble Assets
+      - name: Verify staged ingredients
         run: |
-          flox activate -d flox/base -- ./gradlew :app:assembleAssets --no-daemon \
-            -Dorg.gradle.jvmargs="-Xmx10g -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED" \
-            -Dandroid.aapt2.daemonHeapSize=4096M \
-            -Dorg.gradle.workers.max=1 \
-            -Dorg.gradle.parallel=false
-
-      - name: V8 Assets Path
-        id: assets_v8
-        run: |
-          assets_path="app/build/outputs/assets/assets-arm64-v8a.zip"
-          echo "ASSETS_PATH=$assets_path" >> $GITHUB_OUTPUT
-
-      - name: V7 Assets Path
-        id: assets_v7
-        run: |
-          assets_path="app/build/outputs/assets/assets-armeabi-v7a.zip"
-          echo "ASSETS_PATH=$assets_path" >> $GITHUB_OUTPUT
-
-      - name: Upload asset zips to Google Drive
-        run: |
-          echo "Uploading assets v8 and v7 to Google Drive..."
-
-          ACCESS_TOKEN="${{ steps.auth_drive.outputs.access_token }}"
-          V8_FILE_ID="${{ secrets.ASSETS_V8_FILE_ID }}"
-          V7_FILE_ID="${{ secrets.ASSETS_V7_FILE_ID }}"
-          
-          V8_PATH="${{ steps.assets_v8.outputs.ASSETS_PATH }}"
-          V7_PATH="${{ steps.assets_v7.outputs.ASSETS_PATH }}"         
-          
-          # Upload v8          
-          response=$(curl -s -o /dev/null -w "%{http_code}" --fail -X PATCH \
-            -H "Authorization: Bearer $ACCESS_TOKEN" \
-            -H "Content-Type: application/zip" \
-            --upload-file "${V8_PATH}" \
-            "https://www.googleapis.com/upload/drive/v3/files/${V8_FILE_ID}?uploadType=media")
-
-          if [[ "$response" -ne 200 ]]; then
-            echo "Upload of ${V8_PATH} failed with HTTP status $response"
-            exit 1
+          missing=0
+          for f in localMvnRepository.zip documentation.db core.cgt \
+                   android-sdk-arm64-v8a.zip android-sdk-armeabi-v7a.zip \
+                   bootstrap-arm64-v8a.zip bootstrap-armeabi-v7a.zip; do
+            if [ ! -s "assets/$f" ]; then
+              echo "ERROR: missing or empty assets/$f"
+              missing=1
+            fi
+          done
+          if ! ls assets/gradle-*-bin.zip >/dev/null 2>&1; then
+            echo "ERROR: no assets/gradle-*-bin.zip staged"
+            missing=1
           fi
-
-          # Upload v7          
-          response=$(curl -s -o /dev/null -w "%{http_code}" --fail -X PATCH \
-            -H "Authorization: Bearer $ACCESS_TOKEN" \
-            -H "Content-Type: application/zip" \
-            --upload-file "${V7_PATH}" \
-            "https://www.googleapis.com/upload/drive/v3/files/${V7_FILE_ID}?uploadType=media")
-
-          if [[ "$response" -ne 200 ]]; then
-            echo "Upload of ${V7_PATH} failed with HTTP status $response"
-            exit 1
+          if ! ls assets/gradle-api-*.jar.zip >/dev/null 2>&1; then
+            echo "ERROR: no assets/gradle-api-*.jar.zip staged"
+            missing=1
           fi
+          [ "$missing" -eq 0 ] || exit 1
+          command -v sqlite3 >/dev/null || { sudo apt-get update -qq && sudo apt-get install -y -qq sqlite3; }
+          sqlite3 assets/documentation.db \
+            "SELECT 1 FROM pragma_table_info('Content') WHERE name='templateId';" | grep -q 1 \
+            || { echo "ERROR: documentation.db predates the templateId column; docs requests will 500"; exit 1; }
+          echo "All ingredients staged"
 
-          echo "Upload complete."
+      - name: Upload staged assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-assets
+          path: assets/
+          retention-days: 1
+          if-no-files-found: error
 
-      - name: Send Rich Slack Notification
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: |
-          
-          V8_FILE_ID="${{ secrets.ASSETS_V8_FILE_ID }}"
-          V7_FILE_ID="${{ secrets.ASSETS_V7_FILE_ID }}"         
-          
-          GDRIVE_V8_LINK="<https://drive.google.com/file/d/${V8_FILE_ID}/view|Download Assets Zip 64-bit ARM>"
-          GDRIVE_V7_LINK="<https://drive.google.com/file/d/${V7_FILE_ID}/view|Download Assets Zip 32-bit ARM>"         
-          
-          jq -n \
-            --arg v8_link "$GDRIVE_V8_LINK" \
-            --arg v7_link "$GDRIVE_V7_LINK" \
-            '{
-              blocks: [
-                {
-                  type: "header",
-                  text: {
-                    type: "plain_text",
-                    text: ":rocket: [Updated] New Assets Zips Available",
-                    emoji: true
-                  }
-                },
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: "*Assets 64-bit ARM Link:* \($v8_link)"
-                  }
-                },
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: "*Assets 32-bit ARM Link:* \($v7_link)"
-                  }
-                }    
-              ]
-            }' > payload.json
-          
-          curl -X POST -H "Content-type: application/json" --data @payload.json "$SLACK_WEBHOOK"
-
-          rm -f payload.json
       - name: Cleanup google-services.json
         if: always()
         run: |
@@ -259,7 +232,7 @@ jobs:
           echo "google-services.json cleaned up successfully"
 
       - name: Cleanup ssh
-        if: always()
+        if: always() && inputs.asset_source == 'site'
         run: |
           # Remove SSH key
           rm -f ~/.ssh/id_rsa
@@ -269,3 +242,147 @@ jobs:
           fi
           # Remove entire .ssh directory if empty
           rmdir ~/.ssh 2>/dev/null || true
+
+  zip:
+    name: Zip assets
+    runs-on: self-hosted
+    timeout-minutes: 60
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - abi: v8
+            arch: arm64-v8a
+            label: 64-bit ARM
+          - abi: v7
+            arch: armeabi-v7a
+            label: 32-bit ARM
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Remove stale staged assets
+        run: |
+          rm -f assets/*.zip assets/documentation.db assets/core.cgt
+
+      - name: Check if Nix is installed
+        id: check_nix
+        run: |
+          if command -v nix >/dev/null 2>&1; then
+            echo "nix is installed"
+            echo "nix_installed=true" >> $GITHUB_ENV
+          else
+            echo "nix is not installed"
+            echo "nix_installed=false" >> $GITHUB_ENV
+          fi
+
+      - name: Install Flox
+        if: env.nix_installed == 'false'
+        uses: flox/install-flox-action@v2
+
+      - name: Create google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+
+      - name: Download staged assets
+        uses: actions/download-artifact@v4
+        with:
+          name: debug-assets
+          path: assets
+
+      - name: Assemble assets zip
+        run: |
+          variant_upper=$(echo "${{ matrix.abi }}" | tr '[:lower:]' '[:upper:]')
+          flox activate -d flox/base -- ./gradlew :app:assemble${variant_upper}Assets --no-daemon \
+            -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED" \
+            -Dandroid.aapt2.daemonHeapSize=4096M \
+            -Dorg.gradle.workers.max=1 \
+            -Dorg.gradle.parallel=false
+
+      - name: Verify assets zip
+        id: assets_zip
+        run: |
+          zip_path="app/build/outputs/assets/assets-${{ matrix.arch }}.zip"
+          if [ ! -s "$zip_path" ]; then
+            echo "ERROR: $zip_path was not produced"
+            exit 1
+          fi
+          unzip -tq "$zip_path"
+          for entry in android-sdk.zip bootstrap.zip localMvnRepository.zip documentation.db \
+                       core.cgt plugin-artifacts.zip plugin-maven-repo.zip; do
+            unzip -l "$zip_path" | grep -qE "[[:space:]]$entry$" \
+              || { echo "ERROR: $zip_path is missing entry $entry"; exit 1; }
+          done
+          echo "ASSETS_PATH=$zip_path" >> $GITHUB_OUTPUT
+          echo "$(du -h "$zip_path" | cut -f1) $zip_path"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Upload assets zip to Cloudflare R2
+        id: r2
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_KEY_ID: ${{ vars.CLOUDFLARE_KEY_ID }}
+          CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ vars.R2_ASSETS_BUCKET || 'apk-repo' }}
+          R2_KEY_PREFIX: assets/
+        run: |
+          uv run --with boto3 scripts/cloudflare-r2-upload.py "${{ steps.assets_zip.outputs.ASSETS_PATH }}"
+          echo "DOWNLOAD_URL=https://download.appdevforall.org/assets/assets-${{ matrix.arch }}.zip" >> $GITHUB_OUTPUT
+
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          ASSET_LABEL: ${{ matrix.label }}
+          DOWNLOAD_URL: ${{ steps.r2.outputs.DOWNLOAD_URL }}
+          BUILD_REF: ${{ inputs.ref }}
+        run: |
+          jq -n \
+            --arg label "$ASSET_LABEL" \
+            --arg url "$DOWNLOAD_URL" \
+            --arg ref "$BUILD_REF" \
+            '{
+              blocks: [
+                {
+                  type: "header",
+                  text: {
+                    type: "plain_text",
+                    text: ":rocket: [Updated] New Assets Zip Available",
+                    emoji: true
+                  }
+                },
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: "*\($label):* <\($url)|Download assets zip>"
+                  }
+                },
+                {
+                  type: "context",
+                  elements: [
+                    {
+                      type: "mrkdwn",
+                      text: "Built from `\($ref)`. Push to `/sdcard/Download/` on the device, then `adb shell touch` it."
+                    }
+                  ]
+                }
+              ]
+            }' > payload.json
+
+          curl -X POST -H "Content-type: application/json" --data @payload.json "$SLACK_WEBHOOK"
+
+          rm -f payload.json
+
+      - name: Clean up outputs
+        if: always()
+        run: |
+          rm -f app/google-services.json
+          rm -rf app/build/outputs/assets/

--- a/scripts/cloudflare-r2-upload.py
+++ b/scripts/cloudflare-r2-upload.py
@@ -6,15 +6,15 @@ import boto3
 from botocore.config import Config
 
 REQUIRED_ENV = (
-    "CLOUDFLARE_ACCOUNT_ID",
-    "CLOUDFLARE_KEY_ID",
-    "CLOUDFLARE_SECRET_ACCESS_KEY",
+	"CLOUDFLARE_ACCOUNT_ID",
+	"CLOUDFLARE_KEY_ID",
+	"CLOUDFLARE_SECRET_ACCESS_KEY",
 )
 
 for name in REQUIRED_ENV:
-    if not os.environ.get(name):
-        print(f"ERROR: {name} environment variable is not set.", file=sys.stderr)
-        sys.exit(1)
+	if not os.environ.get(name):
+		print(f"ERROR: {name} environment variable is not set.", file=sys.stderr)
+		sys.exit(1)
 
 CLOUDFLARE_ACCOUNT_ID = os.environ["CLOUDFLARE_ACCOUNT_ID"]
 CLOUDFLARE_KEY_ID = os.environ["CLOUDFLARE_KEY_ID"]
@@ -25,23 +25,23 @@ KEY_PREFIX = os.environ.get("R2_KEY_PREFIX", "")
 R2_ENDPOINT_URL = f"https://{CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
 
 config = Config(
-    read_timeout=300,
-    connect_timeout=60,
-    retries={"max_attempts": 10},
+	read_timeout=300,
+	connect_timeout=60,
+	retries={"max_attempts": 10},
 )
 
 s3 = boto3.client(
-    service_name="s3",
-    endpoint_url=R2_ENDPOINT_URL,
-    aws_access_key_id=CLOUDFLARE_KEY_ID,
-    aws_secret_access_key=CLOUDFLARE_SECRET_ACCESS_KEY,
-    region_name="auto",
-    config=config,
+	service_name="s3",
+	endpoint_url=R2_ENDPOINT_URL,
+	aws_access_key_id=CLOUDFLARE_KEY_ID,
+	aws_secret_access_key=CLOUDFLARE_SECRET_ACCESS_KEY,
+	region_name="auto",
+	config=config,
 )
 
 if len(sys.argv) < 2:
-    print("Usage: cloudflare-r2-upload.py <file_path>", file=sys.stderr)
-    sys.exit(1)
+	print("Usage: cloudflare-r2-upload.py <file_path>", file=sys.stderr)
+	sys.exit(1)
 
 file_path = sys.argv[1]
 file_size = os.path.getsize(file_path)
@@ -49,27 +49,27 @@ file_name = os.path.basename(file_path)
 
 extra_args = {}
 if file_name.lower().endswith(".apk"):
-    extra_args["ContentType"] = "application/vnd.android.package-archive"
+	extra_args["ContentType"] = "application/vnd.android.package-archive"
 
 # Progress callback: print new lines at 10% intervals for CI-friendly logs (bytes_amount is incremental per call)
 _seen_so_far = [0]
 _last_printed_pct = [-1]
 
 def progress_callback(bytes_amount):
-    _seen_so_far[0] += bytes_amount
-    if file_size <= 0:
-        return
-    pct = int(100 * _seen_so_far[0] / file_size)
-    if pct >= _last_printed_pct[0] + 10 or pct == 100:
-        _last_printed_pct[0] = pct
-        mb = _seen_so_far[0] / (1024 * 1024)
-        total_mb = file_size / (1024 * 1024)
-        print(f"Upload progress: {pct}% ({mb:.1f} MB / {total_mb:.1f} MB)", flush=True)
+	_seen_so_far[0] += bytes_amount
+	if file_size <= 0:
+		return
+	pct = int(100 * _seen_so_far[0] / file_size)
+	if pct >= _last_printed_pct[0] + 10 or pct == 100:
+		_last_printed_pct[0] = pct
+		mb = _seen_so_far[0] / (1024 * 1024)
+		total_mb = file_size / (1024 * 1024)
+		print(f"Upload progress: {pct}% ({mb:.1f} MB / {total_mb:.1f} MB)", flush=True)
 
 
 upload_kwargs = {"Callback": progress_callback}
 if extra_args:
-    upload_kwargs["ExtraArgs"] = extra_args
+	upload_kwargs["ExtraArgs"] = extra_args
 
 object_key = f"{KEY_PREFIX}{file_name}"
 

--- a/scripts/cloudflare-r2-upload.py
+++ b/scripts/cloudflare-r2-upload.py
@@ -6,42 +6,41 @@ import boto3
 from botocore.config import Config
 
 REQUIRED_ENV = (
-	"CLOUDFLARE_ACCOUNT_ID",
-	"CLOUDFLARE_KEY_ID",
-	"CLOUDFLARE_SECRET_ACCESS_KEY",
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CLOUDFLARE_KEY_ID",
+    "CLOUDFLARE_SECRET_ACCESS_KEY",
 )
 
 for name in REQUIRED_ENV:
-	if not os.environ.get(name):
-		print(f"ERROR: {name} environment variable is not set.", file=sys.stderr)
-		sys.exit(1)
+    if not os.environ.get(name):
+        print(f"ERROR: {name} environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
 
 CLOUDFLARE_ACCOUNT_ID = os.environ["CLOUDFLARE_ACCOUNT_ID"]
 CLOUDFLARE_KEY_ID = os.environ["CLOUDFLARE_KEY_ID"]
 CLOUDFLARE_SECRET_ACCESS_KEY = os.environ["CLOUDFLARE_SECRET_ACCESS_KEY"]
-BUCKET_NAME = os.environ.get("R2_BUCKET") or "apk-repo"
-KEY_PREFIX = os.environ.get("R2_KEY_PREFIX", "")
+BUCKET_NAME = "apk-repo"
 
 R2_ENDPOINT_URL = f"https://{CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
 
 config = Config(
-	read_timeout=300,
-	connect_timeout=60,
-	retries={"max_attempts": 10},
+    read_timeout=300,
+    connect_timeout=60,
+    retries={"max_attempts": 10},
 )
 
 s3 = boto3.client(
-	service_name="s3",
-	endpoint_url=R2_ENDPOINT_URL,
-	aws_access_key_id=CLOUDFLARE_KEY_ID,
-	aws_secret_access_key=CLOUDFLARE_SECRET_ACCESS_KEY,
-	region_name="auto",
-	config=config,
+    service_name="s3",
+    endpoint_url=R2_ENDPOINT_URL,
+    aws_access_key_id=CLOUDFLARE_KEY_ID,
+    aws_secret_access_key=CLOUDFLARE_SECRET_ACCESS_KEY,
+    region_name="auto",
+    config=config,
 )
 
 if len(sys.argv) < 2:
-	print("Usage: cloudflare-r2-upload.py <file_path>", file=sys.stderr)
-	sys.exit(1)
+    print("Usage: cloudflare-r2-upload.py <file_path>", file=sys.stderr)
+    sys.exit(1)
 
 file_path = sys.argv[1]
 file_size = os.path.getsize(file_path)
@@ -49,30 +48,28 @@ file_name = os.path.basename(file_path)
 
 extra_args = {}
 if file_name.lower().endswith(".apk"):
-	extra_args["ContentType"] = "application/vnd.android.package-archive"
+    extra_args["ContentType"] = "application/vnd.android.package-archive"
 
 # Progress callback: print new lines at 10% intervals for CI-friendly logs (bytes_amount is incremental per call)
 _seen_so_far = [0]
 _last_printed_pct = [-1]
 
 def progress_callback(bytes_amount):
-	_seen_so_far[0] += bytes_amount
-	if file_size <= 0:
-		return
-	pct = int(100 * _seen_so_far[0] / file_size)
-	if pct >= _last_printed_pct[0] + 10 or pct == 100:
-		_last_printed_pct[0] = pct
-		mb = _seen_so_far[0] / (1024 * 1024)
-		total_mb = file_size / (1024 * 1024)
-		print(f"Upload progress: {pct}% ({mb:.1f} MB / {total_mb:.1f} MB)", flush=True)
+    _seen_so_far[0] += bytes_amount
+    if file_size <= 0:
+        return
+    pct = int(100 * _seen_so_far[0] / file_size)
+    if pct >= _last_printed_pct[0] + 10 or pct == 100:
+        _last_printed_pct[0] = pct
+        mb = _seen_so_far[0] / (1024 * 1024)
+        total_mb = file_size / (1024 * 1024)
+        print(f"Upload progress: {pct}% ({mb:.1f} MB / {total_mb:.1f} MB)", flush=True)
 
 
 upload_kwargs = {"Callback": progress_callback}
 if extra_args:
-	upload_kwargs["ExtraArgs"] = extra_args
+    upload_kwargs["ExtraArgs"] = extra_args
 
-object_key = f"{KEY_PREFIX}{file_name}"
-
-print(f"Uploading {file_name} ({file_size / (1024*1024):.1f} MB) to R2 {BUCKET_NAME}/{object_key}...", flush=True)
-s3.upload_file(file_path, BUCKET_NAME, object_key, **upload_kwargs)
+print(f"Uploading {file_name} ({file_size / (1024*1024):.1f} MB) to R2...", flush=True)
+s3.upload_file(file_path, BUCKET_NAME, file_name, **upload_kwargs)
 print("Upload complete.", flush=True)

--- a/scripts/cloudflare-r2-upload.py
+++ b/scripts/cloudflare-r2-upload.py
@@ -19,7 +19,8 @@ for name in REQUIRED_ENV:
 CLOUDFLARE_ACCOUNT_ID = os.environ["CLOUDFLARE_ACCOUNT_ID"]
 CLOUDFLARE_KEY_ID = os.environ["CLOUDFLARE_KEY_ID"]
 CLOUDFLARE_SECRET_ACCESS_KEY = os.environ["CLOUDFLARE_SECRET_ACCESS_KEY"]
-BUCKET_NAME = "apk-repo"
+BUCKET_NAME = os.environ.get("R2_BUCKET") or "apk-repo"
+KEY_PREFIX = os.environ.get("R2_KEY_PREFIX", "")
 
 R2_ENDPOINT_URL = f"https://{CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
 
@@ -70,6 +71,8 @@ upload_kwargs = {"Callback": progress_callback}
 if extra_args:
     upload_kwargs["ExtraArgs"] = extra_args
 
-print(f"Uploading {file_name} ({file_size / (1024*1024):.1f} MB) to R2...", flush=True)
-s3.upload_file(file_path, BUCKET_NAME, file_name, **upload_kwargs)
+object_key = f"{KEY_PREFIX}{file_name}"
+
+print(f"Uploading {file_name} ({file_size / (1024*1024):.1f} MB) to R2 {BUCKET_NAME}/{object_key}...", flush=True)
+s3.upload_file(file_path, BUCKET_NAME, object_key, **upload_kwargs)
 print("Upload complete.", flush=True)


### PR DESCRIPTION
Stacks on #1648. Produces the per-ABI debug asset zips for a toolchain the live
server has not published yet, which is what made the upgrade impossible to QA:
`generate_assets.yml` hardcoded `ref: stage` and could only source assets from
`appdevforall.org`, where `assetsDownloadDebug` 404s for 9.6.1.

Storage is unchanged: the zips still go to the two fixed Google Drive file IDs at
their stable `drive.google.com/file/d/<id>/view` links.

## What changes

- **`ref` input** replaces the hardcoded stage checkout, so the workflow can build any branch.
- **`asset_source`**: `site` keeps today's behaviour; `candidate` scps the ingredients from
  the GreenGeeks staging area that the dev-assets asset-set run delivers to; `release`
  reads them from a GitHub release.
- **v7/v8 matrix** so both zips build in parallel. Staging stays in a single `prepare` job
  deliberately: two concurrent legs would both write `~/.ssh/id_rsa` on the same
  self-hosted runner, and one leg's cleanup would pull the key out from under the other.
  Each leg PATCHes its own zip to the Drive file for its ABI, and mints its own Drive
  token, since the one from `prepare` does not carry across jobs.
- **Content gates.** Every ingredient present and non-empty, `documentation.db` carries
  `Content.templateId`, and the built zip contains all nine expected entries — including
  the two whose names carry the Gradle version, so a run cannot quietly publish an 8.14.3
  payload from a branch that reads its version from `org.adfa.constants`. Wrong-variant
  assets pass size and checksum checks, so the gate has to look at content.
- **Stale-asset removal** before staging. `createPluginArtifactsZip` and
  `createPluginMavenRepoZip` write into the source tree, so their output survives between
  runs on a persistent self-hosted workspace.
- **`concurrency: generate-assets`**, `cancel-in-progress: false`. `Cleanup ssh` runs
  `if: always()`, so an overlapping dispatch would tear the key out from under a live run.
- **Slack behind `notify_slack`** (default false), so iterating does not post to the channel.
  The message keeps its original wording and gains one context line naming the Gradle
  version and the ref built.
- Fixes a guard that tested `"DB_FILE_ID"` instead of `"$DB_FILE_ID"` and therefore never
  fired on a missing secret.

## On the Drive links

The two Drive file IDs are fixed, so both links are stable and their contents are replaced
in place on every run. That is deliberate and unchanged, but it means nothing in the URL
distinguishes an 8.14.3 zip from a 9.6.1 one — during this work a zip was downloaded from
that link and taken for the other toolchain. Hence the one added Slack context line, which
names the toolchain without touching the URL. It is the cheapest mitigation that keeps the
behaviour the team has; a version-qualified path would be the alternative and is not what
this PR does.

## A bug worth calling out, because it was mine

An earlier revision of this PR moved the upload to Cloudflare R2. That was not asked for
and was not needed to fix anything here, so it is reverted; `scripts/cloudflare-r2-upload.py`
is byte-identical to `stage` again. Worth recording what it exposed, because the lesson
outlives the revert: a `workflow_dispatch` run takes the *workflow file* from the dispatched
ref but the *repository content* from `inputs.ref`, so building the toolchain branch ran
that branch's copy of the uploader, which predated the change and silently ignored it. The
run reported success while writing to the wrong place. Any repo script a workflow calls has
this hazard. This version calls none — the upload is `curl` — so the `.workflow-tools`
checkout and the `uv` install are both gone.

## Verification

Two full runs exercised both source paths on this workflow's logic: run 34354432483 built
the 8.14.3 set from `site`, and run 34370121582 built from `candidate` with ingredients at
`tmp/assets/candidates/170`. Both had staging and both zip legs green, including both
content gates.

Both of those runs uploaded to R2, since they predate this revert. **The Drive upload step
itself has not been exercised by a run on this branch** — it is the pre-existing step from
`stage`, re-pointed at one ABI per leg. What has been checked locally: the workflow parses,
every step body passes `bash -n`, and the Slack `jq` program renders with a Drive URL. A
dispatch with `notify_slack: false` would confirm the upload end to end before merge.

https://claude.ai/code/session_017HGpMsUzZ5wxCfMtDZ2HGP
