### PR TITLE
ADFA-5731 | Fix plugin crashes in release builds by keeping shared dependencies

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -210,6 +210,18 @@
 -keep class kotlin.** { *; }
 -keep class kotlinx.coroutines.** { *; }
 
+# Same hazard, libraries the app and plugins both ship: the app's shrunk copy
+# shadows the plugin's complete one. Union of plugin deps that overlap the app;
+# re-audit when a plugin adds one. See docs/research in plugin-examples.
+-keep class androidx.fragment.app.** { *; }
+-keep class androidx.appcompat.** { *; }
+-keep class androidx.core.** { *; }
+-keep class androidx.recyclerview.widget.** { *; }
+-keep class androidx.constraintlayout.** { *; }
+-keep class com.google.android.material.** { *; }
+-keep class io.noties.markwon.** { *; }
+-keep class com.google.gson.** { *; }
+
 -keep class com.google.firebase.** { *; }
 -keep class com.google.android.gms.** { *; }
 


### PR DESCRIPTION
## Description

Added broad `-keep` rules to `app/proguard-rules.pro` for libraries shared between the app and plugins. Because R8 aggressively shrinks unused code in the app and plugin classloading is parent-first, the app's shrunk copy was shadowing the plugin's complete copy. This resulted in `NoSuchMethodError` crashes in release builds when plugins attempted to call stripped methods. Preserving the union of plugin dependencies that overlap the app (such as `androidx.fragment.app.**`, `io.noties.markwon.**`, and `com.google.gson.**`) ensures plugins can safely call any method from those shared libraries.

## Details

Logic-related fix. No UI changes. Release builds will no longer log `NoSuchMethodError` in `/sdcard/idelog.txt` or GlitchTip when navigating plugin surfaces.

### Before

https://github.com/user-attachments/assets/588d5d6d-ed17-4ec4-aada-f1c7b438dfe1


### After

https://github.com/user-attachments/assets/d2566f46-e4ef-4337-a38a-5072f8993a0e


## Ticket

[ADFA-5731](https://appdevforall.atlassian.net/browse/ADFA-5731)

## Observation

These overlapping dependencies should be re-audited whenever a plugin adds a new shared dependency.

[ADFA-5731]: https://appdevforall.atlassian.net/browse/ADFA-5731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ