### PR TITLE
ADFA-5739: bind the build service to the application, not the editor

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -504,7 +504,7 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
 		// activity through the framework's own bookkeeping.
 		if (
 			applicationContext.bindService(
-				Intent(this, GradleBuildService::class.java),
+				Intent(applicationContext, GradleBuildService::class.java),
 				buildServiceConnection,
 				BIND_AUTO_CREATE or BIND_IMPORTANT,
 			)

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -391,6 +391,11 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
 	}
 
 	override fun preDestroy() {
+		// First, and on every destroy rather than only a finishing one: onConnected is a bound
+		// reference to this activity, so leaving it set lets a bind that is still pending deliver
+		// into an instance that is already tearing down.
+		buildServiceConnection.onConnected = null
+
 		syncNotificationFlashbar?.dismiss()
 		syncNotificationFlashbar = null
 
@@ -407,10 +412,6 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
 		}
 
 		super.preDestroy()
-
-		// On every destroy, not only a finishing one: onConnected is a bound reference to this
-		// activity, so leaving it set lets a still-pending bind deliver into a dead instance.
-		buildServiceConnection.onConnected = null
 
 		if (didCompleteLiveOnCreate && isDestroying) {
 			try {

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/ProjectHandlerActivity.kt
@@ -408,6 +408,10 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
 
 		super.preDestroy()
 
+		// On every destroy, not only a finishing one: onConnected is a bound reference to this
+		// activity, so leaving it set lets a still-pending bind deliver into a dead instance.
+		buildServiceConnection.onConnected = null
+
 		if (didCompleteLiveOnCreate && isDestroying) {
 			try {
 				stopLanguageServers()
@@ -416,8 +420,7 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
 			}
 
 			try {
-				unbindService(buildServiceConnection)
-				buildServiceConnection.onConnected = {}
+				applicationContext.unbindService(buildServiceConnection)
 			} catch (_: Throwable) {
 				log.error("Unable to unbind service")
 			} finally {
@@ -494,8 +497,12 @@ abstract class ProjectHandlerActivity : BaseEditorActivity() {
 
 		buildServiceConnection.onConnected = this::onGradleBuildServiceConnected
 
+		// Bind through the application context, not the activity. LoadedApk.mServices keys its
+		// ServiceDispatcher on the binding Context, so an activity-scoped bind that outlives the
+		// instance -- a configuration change skips the unbind in preDestroy -- retains the dead
+		// activity through the framework's own bookkeeping.
 		if (
-			bindService(
+			applicationContext.bindService(
 				Intent(this, GradleBuildService::class.java),
 				buildServiceConnection,
 				BIND_AUTO_CREATE or BIND_IMPORTANT,

--- a/app/src/test/java/com/itsaky/androidide/activities/editor/BuildServiceCallbackClearedTest.kt
+++ b/app/src/test/java/com/itsaky/androidide/activities/editor/BuildServiceCallbackClearedTest.kt
@@ -1,0 +1,53 @@
+package com.itsaky.androidide.activities.editor
+
+import com.google.common.truth.Truth.assertThat
+import com.itsaky.androidide.app.BaseApplication
+import com.itsaky.androidide.services.builder.GradleBuildService
+import com.itsaky.androidide.services.builder.GradleBuildServiceConnnection
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * A configuration change destroys the editor without finishing it, so [isDestroying] is false and
+ * the finish-only teardown is skipped. The build service callback must be released anyway: it is a
+ * bound reference to this activity (`this::onGradleBuildServiceConnected`), so a bind still pending
+ * at destroy would otherwise deliver into a dead instance.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = BuildServiceCallbackClearedTest.TestApp::class)
+class BuildServiceCallbackClearedTest {
+	open class TestApp : BaseApplication()
+
+	@Test
+	fun givenANonFinishingDestroy_whenPreDestroyRuns_thenTheBuildServiceCallbackIsCleared() {
+		val activity = Robolectric.buildActivity(EditorHandlerActivity::class.java).get()
+		val connection = connectionField.get(activity) as GradleBuildServiceConnnection
+		onConnected.set(connection, { _: GradleBuildService -> })
+		isDestroying.set(activity, false)
+
+		// preDestroy goes on to tear down members that a bare activity never initialised; the
+		// clearing under test happens first, so what it throws afterwards is not this test's
+		// concern. If the clearing ever moves back below that teardown, the assertion fails.
+		runCatching { preDestroy.invoke(activity) }
+
+		assertThat(onConnected.get(connection)).isNull()
+	}
+
+	private val connectionField =
+		ProjectHandlerActivity::class
+			.java
+			.getDeclaredField("buildServiceConnection")
+			.apply { isAccessible = true }
+	private val onConnected =
+		GradleBuildServiceConnnection::class
+			.java
+			.getDeclaredField("onConnected")
+			.apply { isAccessible = true }
+	private val isDestroying =
+		BaseEditorActivity::class.java.getDeclaredField("isDestroying").apply { isAccessible = true }
+	private val preDestroy =
+		ProjectHandlerActivity::class.java.getDeclaredMethod("preDestroy").apply { isAccessible = true }
+}

--- a/app/src/test/java/com/itsaky/androidide/activities/editor/BuildServiceCallbackClearedTest.kt
+++ b/app/src/test/java/com/itsaky/androidide/activities/editor/BuildServiceCallbackClearedTest.kt
@@ -23,10 +23,24 @@ class BuildServiceCallbackClearedTest {
 
 	@Test
 	fun givenANonFinishingDestroy_whenPreDestroyRuns_thenTheBuildServiceCallbackIsCleared() {
+		assertCallbackClearedWhenDestroying(false)
+	}
+
+	@Test
+	fun givenAFinishingDestroy_whenPreDestroyRuns_thenTheBuildServiceCallbackIsCleared() {
+		assertCallbackClearedWhenDestroying(true)
+	}
+
+	/**
+	 * Both destroy shapes, because the bug was an asymmetry between them: the clearing used to sit
+	 * inside the `isDestroying` guard, so it ran for a finishing destroy and not for a recreation.
+	 * Pinning only one shape would not have caught that.
+	 */
+	private fun assertCallbackClearedWhenDestroying(destroying: Boolean) {
 		val activity = Robolectric.buildActivity(EditorHandlerActivity::class.java).get()
 		val connection = connectionField.get(activity) as GradleBuildServiceConnnection
 		onConnected.set(connection, { _: GradleBuildService -> })
-		isDestroying.set(activity, false)
+		isDestroying.set(activity, destroying)
 
 		// preDestroy goes on to tear down members that a bare activity never initialised; the
 		// clearing under test happens first, so what it throws afterwards is not this test's


### PR DESCRIPTION
[ADFA-5739](https://appdevforall.atlassian.net/browse/ADFA-5739)

> [!CAUTION]
> **Do not merge. This change has a confirmed regression and is a net loss as it stands.**
>
> Measured on a Pixel 6 Pro, identical sequence on both builds (open project, one dark-mode toggle, close project):
>
> | Build | `GradleBuildService` after close |
> | --- | --- |
> | pre-fix (activity-context bind) | `ServiceRecord: 0` — released |
> | this PR (application-context bind) | `ServiceRecord: 1` — leaked |
>
> The activity-context bind was being reclaimed by the framework at context cleanup (`LoadedApk.removeContextRegistrations`), which dropped the service's bind count to zero. Binding to the Application removes that safety net: the Application context is never cleaned up, so the orphaned connection from the pre-recreation instance is never released.
>
> Net effect: this trades a 775 KB retained activity for a retained `GradleBuildService`, its Tooling API server, the Gradle daemon and a stuck foreground notification — hundreds of MB.
>
> The "Known gap" section below previously said this predated the PR. **That was wrong** — the code mechanism predates it, but the observable leak did not, because the framework was masking it. Corrected.
>
> Needs the process-scoped connection owner from [ADFA-5743](https://appdevforall.atlassian.net/browse/ADFA-5743) before any of this is safe to land.


## The leak

A configuration change destroys `EditorActivityKt` without finishing it, so `isDestroying` (`= isFinishing`) is false and `preDestroy` skips `unbindService`. The connection stays in `LoadedApk.mServices`, which keys its `ServiceDispatcher` on the **binding Context** — so the framework's own bookkeeping retained the dead activity.

LeakCanary measured **775,579 bytes in 12,806 objects** held that way, retained ~1.7 h. Heap analysis of the dump confirmed the path:

```
LoadedApk.mServices -> ArrayMap -> Object[] -> EditorActivityKt   (mDestroyed=true, mFinished=false)
  via ServiceDispatcher.mConnection = GradleBuildServiceConnnection
      ServiceDispatcher.mContext    = EditorActivityKt            <- the leaked instance
```

`uiMode` is absent from the editor's `configChanges`, so a system dark/light switch is enough to trigger it.

## Why not "just always unbind"

`GradleBuildService` is bind-only (never `startService`'d) and its `onDestroy` shuts down the Tooling API server. Unbinding on every destroy would therefore tear the Gradle daemon down and restart it on every recreation, so the `isDestroying` guard is protecting something real.

**Correction.** An earlier revision of this description, and the first commit message, said this would happen "on every rotation". That is wrong: `orientation`, `screenSize`, `screenLayout`, `smallestScreenSize` and `fontScale` are all in the editor's `configChanges`, so rotation does **not** recreate it. The real triggers are `uiMode`, locale, density, keyboard and navigation — much rarer, all user-initiated. The always-unbind alternative is therefore cheaper than that sentence implied, though still a daemon restart on each occurrence. Whoever picks up ADFA-5743 should weigh it on the corrected facts.

Binding through `applicationContext` instead keeps the binding alive across recreation exactly as before, while leaving the activity out of `mServices` entirely.

Also clears `buildServiceConnection.onConnected` at the top of `preDestroy`, on every destroy rather than only when finishing: it is a bound reference to the activity, so a bind still pending at destroy would otherwise deliver into an instance that is already tearing down.

## Verification

Pixel 6 Pro, Android 17, six `uiMode` recreations:

| | Destroyed activities | LeakCanary |
| --- | --- | --- |
| Before | 4 | `Found 4 objects retained` -> heap analysis -> leak |
| After | 6 | no retained-object report |

Direct heap assertion on a post-fix `am dumpheap`: **no `ServiceDispatcher` is bound to an Activity context** — all six now hold `IDEApplication`.

`BuildServiceCallbackClearedTest` pins the callback clearing and was proven to fail without the fix: with the clearing back inside the `isDestroying` guard it fails on its assertion, for the reason it is named for.

**It does not run in CI.** No workflow invokes `:app` unit tests — the pipeline runs `:plugin-api:testDebugUnitTest`, `:plugin-api:apiCheck`, `spotlessCheck` and the assembles. So this test guards the fix locally, but a change moving the clearing back inside the guard would go green on every required check. Worth fixing separately; it affects every `:app` unit test in the repo, not just this one.

The application-context bind itself is covered by the device A/B only. Robolectric 4.11.1 keeps a single global list of bound connections keyed by `ServiceConnection` (`ShadowInstrumentation`) and never records the binding `Context`, so no shadow assertion can distinguish an activity bind from an application bind.

## Siblings swept

- `BaseEditorActivity.debuggerServiceConnection` — same `isDestroying` guard, **left alone deliberately**. It is an anonymous inner class capturing the activity, so `applicationContext` would not help it; the fix it needs is to unbind on every destroy, which would end a debug session on rotation. That is a behavioural decision, not a mechanical one. Note the post-fix heap does not clear it: no debug session was active during the run, so the measurement could not have shown this path either way.
- `AppLogsCoordinator` — clean. It tracks bound state and nulls its context.

## Known gap: the service binding is still not released

Filed as [ADFA-5743](https://appdevforall.atlassian.net/browse/ADFA-5743) rather than fixed here, because the fix is a lifetime change rather than a one-line one.

After **any** configuration change the editor can no longer release the build service at all. `buildServiceConnection` is a per-activity `private val`, but the binding is process-scoped: the recreated instance takes the reuse branch in `startServices()` and returns before `bindService`, so its connection object is never registered, and the unbind on close throws `Service not registered` into a swallowed catch.

Reproduced on device: closing the project with no configuration change releases the `ServiceRecord`; closing it after a single dark-mode toggle leaves the `ServiceRecord` and its `ConnectionRecord` in place, so the Tooling API server and Gradle daemon outlive the editor.

**Correction: this does NOT predate the PR.** The reuse branch and the per-instance connection are untouched here, so the *mechanism* predates it — but the observable leak did not. The pre-fix build releases the service on close, because the framework reclaims the orphaned activity-context binding at context cleanup. Moving the bind to the Application removes that reclamation, so this PR is what turns a masked mechanism into a real leak. Verified by building and running both versions on device with the same steps.

## Also filed from review, not fixed here

- [ADFA-5744](https://appdevforall.atlassian.net/browse/ADFA-5744) — `onServiceDisconnected` clears neither `isBoundToBuildSerice` nor the `Lookup` entry, so after an unexpected disconnect the reuse branch in `startServices()` adopts a dead service instead of rebinding. Same ownership problem as ADFA-5743 and best done with it.

## Screens

No UI change; nothing to verify at 2x font scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ADFA-5739]: https://appdevforall.atlassian.net/browse/ADFA-5739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ADFA-5743]: https://appdevforall.atlassian.net/browse/ADFA-5743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ